### PR TITLE
feat(codex): add gpt-5.3 model support

### DIFF
--- a/src/agent/clis/codex.ts
+++ b/src/agent/clis/codex.ts
@@ -15,6 +15,8 @@ export const cli = 'codex' as const
 export const agentId = 'codex' as const
 
 export const models: Record<string, CliModelEntry> = {
+  'gpt-5.3-codex': { model: 'gpt-5.3-codex', name: 'GPT-5.3 Codex', hint: 'Latest frontier Codex model' },
+  'gpt-5.3-codex-spark': { model: 'gpt-5.3-codex-spark', name: 'GPT-5.3 Codex Spark', hint: 'Faster GPT-5.3 Codex variant' },
   'gpt-5.2-codex': { model: 'gpt-5.2-codex', name: 'GPT-5.2 Codex', hint: 'Frontier agentic coding model' },
   'gpt-5.1-codex-max': { model: 'gpt-5.1-codex-max', name: 'GPT-5.1 Codex Max', hint: 'Codex-optimized flagship' },
   'gpt-5.2': { model: 'gpt-5.2', name: 'GPT-5.2', hint: 'Latest frontier model' },

--- a/src/agent/clis/types.ts
+++ b/src/agent/clis/types.ts
@@ -29,6 +29,8 @@ export type OptimizeModel
     | 'haiku'
     | 'gemini-3-pro'
     | 'gemini-3-flash'
+    | 'gpt-5.3-codex'
+    | 'gpt-5.3-codex-spark'
     | 'gpt-5.2-codex'
     | 'gpt-5.1-codex-max'
     | 'gpt-5.2'

--- a/test/e2e-agents/generate-pipeline.ts
+++ b/test/e2e-agents/generate-pipeline.ts
@@ -69,6 +69,8 @@ const CLI_MODELS_MAP: Partial<Record<OptimizeModel, string>> = {
   'haiku': 'claude',
   'gemini-3-pro': 'gemini',
   'gemini-3-flash': 'gemini',
+  'gpt-5.3-codex': 'codex',
+  'gpt-5.3-codex-spark': 'codex',
   'gpt-5.2-codex': 'codex',
   'gpt-5.1-codex-max': 'codex',
   'gpt-5.2': 'codex',


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR adds support for two new Codex model IDs in the skill generation flow:
- `gpt-5.3-codex`
- `gpt-5.3-codex-spark`
What this solves:
- these model IDs can now be selected and treated as valid `OptimizeModel` values,
- they are correctly mapped to the Codex CLI provider,
- and the e2e-agents pipeline model→CLI map now recognizes both IDs.
In short, this keeps model support up to date with newer Codex variants and makes them usable end-to-end in the existing model selection/mapping path.

### Linked Issues
N/A

### Additional context
I verified this change with:
- `pnpm typecheck`
- `pnpm lint`
- `pnpm vitest run --project unit`
- `pnpm build`
I did not include full e2e validation in this PR because the current branch/environment has unrelated e2e instability (network/model-cache/timeouts) that reproduces independently of these model-ID additions.
<!-- e.g. is there anything you'd like reviewers to focus on? -->
