### PR TITLE
feat: crate package support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ skilld add npm:vue npm:nuxt npm:pinia
 # Add a pre-authored skill from a GitHub repo
 skilld add gh:vercel-labs/agent-skills
 
+# Add a skill for a Rust crate (crates.io)
+skilld add crate:serde
+
 # Update outdated skills
 skilld update
 skilld update tailwindcss
@@ -183,7 +186,7 @@ skilld config
 | Command | Description |
 |---------|-------------|
 | `skilld` | Interactive wizard (first run) or status menu (existing skills) |
-| `skilld add <source...>` | Add skills. Sources: `npm:<pkg>`, `gh:<owner/repo>`, or bare names (deprecated) |
+| `skilld add <source...>` | Add skills. Sources: `npm:<pkg>`, `crate:<name>`, `gh:<owner/repo>`, or bare names (deprecated) |
 | `skilld update [pkg]`   | Update outdated skills (all or specific) |
 | `skilld search [query]` | Search indexed docs (`-p` package, `--filter` JSON, `--limit`, `--guide`) |
 | `skilld list`           | List installed skills (`--json` for machine-readable output) |

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -40,6 +40,7 @@ import { defaultFeatures, readConfig } from '../core/config.ts'
 import { timedSpinner } from '../core/formatting.ts'
 import { mergeLocks, parsePackages, readLock, syncLockfilesToDirs, writeLock } from '../core/lockfile.ts'
 import { readPackageJsonSafe } from '../core/package-json.ts'
+import { toStoragePackageName } from '../core/prefix.ts'
 import { sanitizeMarkdown } from '../core/sanitize.ts'
 import { getSharedSkillsDir } from '../core/shared.ts'
 import { createIndex, SearchDepsUnavailableError } from '../retriv/index.ts'
@@ -118,7 +119,7 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
     const needsRestore = !existsSync(skillDir)
       || !existsSync(skillMdPath)
       || !existsSync(referencesPath)
-      || hasStaleReferences(referencesPath, info.packageName || name, info.version!, features)
+      || hasStaleReferences(referencesPath, toStoragePackageName(info.packageName || name), info.version!, features)
 
     if (needsRestore) {
       toRestore.push({ name, info })
@@ -138,7 +139,8 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
 
   for (const { name, info } of toRestore) {
     const version = info.version!
-    const pkgName = info.packageName || unsanitizeName(name, info.source)
+    const identityName = info.packageName || unsanitizeName(name, info.source)
+    const pkgName = toStoragePackageName(identityName)
 
     // Shipped skills: re-link from node_modules or cached dist
     if (info.source === 'shipped') {

--- a/src/commands/search-helpers.ts
+++ b/src/commands/search-helpers.ts
@@ -5,6 +5,7 @@ import { join } from 'pathe'
 import { agents, detectTargetAgent } from '../agent/index.ts'
 import { getPackageDbPath, REFERENCES_DIR } from '../cache/index.ts'
 import { readLock } from '../core/index.ts'
+import { toStoragePackageName } from '../core/prefix.ts'
 import { getSharedSkillsDir } from '../core/shared.ts'
 
 /** Collect search.db paths for packages installed in the current project (from skilld-lock.yaml) */
@@ -72,10 +73,11 @@ function filterLockDbs(lock: ReturnType<typeof readLock>, packageFilter?: string
       return filterTokens.every(ft => nameTokens.some(nt => nt.includes(ft) || ft.includes(nt)))
     })
     .map((info) => {
-      const exact = getPackageDbPath(info.packageName!, info.version!)
+      const storageName = toStoragePackageName(info.packageName!)
+      const exact = getPackageDbPath(storageName, info.version!)
       if (existsSync(exact))
         return exact
-      const fallback = findAnyPackageDb(info.packageName!)
+      const fallback = findAnyPackageDb(storageName)
       if (fallback)
         p.log.warn(`Using cached search index for ${info.packageName} (v${info.version} not indexed). Run \`skilld update ${info.packageName}\` to re-index.`)
       return fallback

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -11,6 +11,7 @@ import { sharedArgs } from '../cli-helpers.ts'
 import { defaultFeatures, hasConfig, readConfig } from '../core/config.ts'
 import { formatSource, timeAgo } from '../core/formatting.ts'
 import { parsePackages } from '../core/lockfile.ts'
+import { toStoragePackageName } from '../core/prefix.ts'
 import { getSharedSkillsDir, mapInsert } from '../core/shared.ts'
 
 import { iterateSkills } from '../core/skills.ts'
@@ -211,7 +212,7 @@ export async function statusCommand(opts: StatusOptions = {}): Promise<void> {
       lines.push(parts.join('  '))
 
       const meta: string[] = []
-      const pkgName = info.packageName || pkg.name
+      const pkgName = toStoragePackageName(info.packageName || pkg.name)
       const docs = countDocs(pkgName, info.version) || countRefDocs(join(
         pkg.scope === 'global'
           ? agents[pkg.agents.values().next().value!].globalSkillsDir!

--- a/src/commands/sync-shared.ts
+++ b/src/commands/sync-shared.ts
@@ -1357,6 +1357,8 @@ export async function selectLlmConfig(presetModel?: OptimizeModel, message?: str
 
 export interface EnhanceOptions {
   packageName: string
+  /** Storage/cache key (e.g. namespaced '@skilld-crate/serde'); defaults to packageName */
+  cachePackageName?: string
   version: string
   skillDir: string
   dirName?: string
@@ -1381,7 +1383,8 @@ export interface EnhanceOptions {
 }
 
 export async function enhanceSkillWithLLM(opts: EnhanceOptions): Promise<void> {
-  const { packageName, version, skillDir, dirName, model, resolved, relatedSkills, hasIssues, hasDiscussions, hasReleases, hasChangelog, docsType, hasShippedDocs: shippedDocs, pkgFiles, force, debug, sections, customPrompt, packages, features, eject, overheadLines } = opts
+  const { packageName, cachePackageName, version, skillDir, dirName, model, resolved, relatedSkills, hasIssues, hasDiscussions, hasReleases, hasChangelog, docsType, hasShippedDocs: shippedDocs, pkgFiles, force, debug, sections, customPrompt, packages, features, eject, overheadLines } = opts
+  const cacheKey = cachePackageName || packageName
 
   const effectiveFeatures = features
 
@@ -1389,7 +1392,7 @@ export async function enhanceSkillWithLLM(opts: EnhanceOptions): Promise<void> {
   const docFiles = listReferenceFiles(skillDir)
   const hasGithub = hasIssues || hasDiscussions
   const { optimized, wasOptimized, usage, cost, warnings, error, debugLogsDir } = await optimizeDocs({
-    packageName,
+    packageName: cacheKey,
     skillDir,
     model,
     version,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -38,7 +38,7 @@ import { defaultFeatures, hasCompletedWizard, readConfig, registerProject } from
 import { timedSpinner } from '../core/formatting.ts'
 import { parsePackages, readLock, removeLockEntry, writeLock } from '../core/lockfile.ts'
 import { parseFrontmatter } from '../core/markdown.ts'
-import { parseSkillInput, resolveSkillName } from '../core/prefix.ts'
+import { parseSkillInput, resolveSkillName, toStoragePackageName } from '../core/prefix.ts'
 import { getSharedSkillsDir, SHARED_SKILLS_DIR } from '../core/shared.ts'
 import { getProjectState } from '../core/skills.ts'
 import { shutdownWorker } from '../retriv/pool.ts'
@@ -47,6 +47,7 @@ import {
   isPrerelease,
   parsePackageSpec,
   readLocalDependencies,
+  resolveCrateDocsWithAttempts,
   resolvePackageDocsWithAttempts,
   searchNpmPackages,
 } from '../sources/index.ts'
@@ -102,6 +103,14 @@ function showResolveAttempts(attempts: ResolveAttempt[]): void {
   }
 }
 
+export function isCrateSpec(spec: string): boolean {
+  return spec.startsWith('crate:')
+}
+
+function toCrateIdentity(crateName: string): string {
+  return `crate:${crateName}`
+}
+
 export interface SyncOptions {
   packages?: string[]
   global: boolean
@@ -124,10 +133,13 @@ export interface SyncOptions {
 export async function syncCommand(state: ProjectState, opts: SyncOptions): Promise<void> {
   // If packages specified, sync those
   if (opts.packages && opts.packages.length > 0) {
-    // Use parallel sync for multiple packages
-    if (opts.packages.length > 1) {
-      return syncPackagesParallel({
-        packages: opts.packages,
+    const crateSpecs = opts.packages.filter(isCrateSpec)
+    const npmSpecs = opts.packages.filter(p => !isCrateSpec(p))
+
+    // npm packages: parallel if >1, serial if 1
+    if (npmSpecs.length > 1) {
+      await syncPackagesParallel({
+        packages: npmSpecs,
         global: opts.global,
         agent: opts.agent,
         model: opts.model,
@@ -137,9 +149,14 @@ export async function syncCommand(state: ProjectState, opts: SyncOptions): Promi
         mode: opts.mode,
       })
     }
+    else if (npmSpecs.length === 1) {
+      await syncSinglePackage(npmSpecs[0]!, opts)
+    }
 
-    // Single package - use original flow for cleaner output
-    await syncSinglePackage(opts.packages[0]!, opts)
+    // Crates: serialize (respect crates.io rate limits)
+    for (const spec of crateSpecs)
+      await syncSinglePackage(spec, opts)
+
     return
   }
 
@@ -265,94 +282,112 @@ interface SyncConfig {
 }
 
 async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promise<void> {
-  // Parse dist-tag from spec: "vue@beta" → name="vue", tag="beta"
-  const { name: packageName, tag: requestedTag } = parsePackageSpec(packageSpec)
+  const isCrate = isCrateSpec(packageSpec)
+  const normalizedSpec = isCrate ? packageSpec.slice('crate:'.length).trim() : packageSpec
+  if (isCrate && !normalizedSpec) {
+    p.log.error('Invalid crate spec. Use format: crate:<name>')
+    return
+  }
+
+  // Parse dist-tag/version from spec: "vue@beta" → name="vue", tag="beta"
+  const { name: parsedName, tag: requestedTag } = parsePackageSpec(normalizedSpec)
+  const packageName = isCrate ? parsedName.toLowerCase() : parsedName
+  const identityPackageName = isCrate ? toCrateIdentity(packageName) : packageName
+  const storagePackageName = toStoragePackageName(identityPackageName)
 
   const spin = timedSpinner()
   spin.start(`Resolving ${packageSpec}`)
 
   const cwd = process.cwd()
-  const localDeps = await readLocalDependencies(cwd).catch(() => [])
-  const localVersion = localDeps.find(d => d.name === packageName)?.version
+  const localDeps = isCrate ? [] : await readLocalDependencies(cwd).catch(() => [])
+  const localVersion = isCrate ? undefined : localDeps.find(d => d.name === packageName)?.version
 
-  // Try npm first — use full spec for npm resolution (unpkg supports dist-tags)
-  const resolveResult = await resolvePackageDocsWithAttempts(requestedTag ? packageSpec : packageName, {
-    version: localVersion,
-    cwd,
-    onProgress: step => spin.message(`${packageName}: ${RESOLVE_STEP_LABELS[step]}`),
-  })
+  const resolveResult = isCrate
+    ? await resolveCrateDocsWithAttempts(packageName, {
+        version: requestedTag,
+        onProgress: step => spin.message(`${identityPackageName}: ${step}`),
+      })
+    : await resolvePackageDocsWithAttempts(requestedTag ? normalizedSpec : packageName, {
+        version: localVersion,
+        cwd,
+        onProgress: step => spin.message(`${packageName}: ${RESOLVE_STEP_LABELS[step]}`),
+      })
   let resolved = resolveResult.package
 
-  // If npm fails, check if it's a link: dep and try local resolution
-  if (!resolved) {
+  // If npm fails, check if it's a link: dep and try local resolution (skip for crates)
+  if (!resolved && !isCrate) {
     spin.message(`Resolving local package: ${packageName}`)
     resolved = await resolveLocalDep(packageName, cwd)
   }
 
   if (!resolved) {
-    // Even without docs, the package may ship its own skills (skills-npm convention)
-    const shippedVersion = localVersion || resolveResult.registryVersion || 'latest'
-    const earlyShipped = handleShippedSkills(packageName, shippedVersion, cwd, config.agent, config.global)
-    if (earlyShipped) {
-      const shared = !config.global && getSharedSkillsDir(cwd)
-      for (const shipped of earlyShipped.shipped) {
-        if (shared)
-          linkSkillToAgents(shipped.skillName, shared, cwd, config.agent)
-        p.log.success(`Using published SKILL.md: ${shipped.skillName} → ${relative(cwd, shipped.skillDir)}`)
+    if (!isCrate) {
+      // Even without docs, the package may ship its own skills (skills-npm convention)
+      const shippedVersion = localVersion || resolveResult.registryVersion || 'latest'
+      const earlyShipped = handleShippedSkills(packageName, shippedVersion, cwd, config.agent, config.global)
+      if (earlyShipped) {
+        const shared = !config.global && getSharedSkillsDir(cwd)
+        for (const shipped of earlyShipped.shipped) {
+          if (shared)
+            linkSkillToAgents(shipped.skillName, shared, cwd, config.agent)
+          p.log.success(`Using published SKILL.md: ${shipped.skillName} → ${relative(cwd, shipped.skillDir)}`)
+        }
+        spin.stop(`Using published SKILL.md(s) from ${packageName}`)
+        return
       }
-      spin.stop(`Using published SKILL.md(s) from ${packageName}`)
-      return
+
+      // Search npm for alternatives before giving up
+      spin.message(`Searching npm for "${packageName}"...`)
+      const suggestions = await searchNpmPackages(packageName)
+
+      if (suggestions.length > 0) {
+        spin.stop(`Package "${packageName}" not found on npm`)
+        showResolveAttempts(resolveResult.attempts)
+
+        const selected = await p.select({
+          message: 'Did you mean one of these?',
+          options: [
+            ...suggestions.map(s => ({
+              label: s.name,
+              value: s.name,
+              hint: s.description,
+            })),
+            { label: 'None of these', value: '_none_' as const },
+          ],
+        })
+
+        if (!p.isCancel(selected) && selected !== '_none_')
+          return syncSinglePackage(selected as string, config)
+
+        return
+      }
     }
 
-    // Search npm for alternatives before giving up
-    spin.message(`Searching npm for "${packageName}"...`)
-    const suggestions = await searchNpmPackages(packageName)
-
-    if (suggestions.length > 0) {
-      spin.stop(`Package "${packageName}" not found on npm`)
-      showResolveAttempts(resolveResult.attempts)
-
-      const selected = await p.select({
-        message: 'Did you mean one of these?',
-        options: [
-          ...suggestions.map(s => ({
-            label: s.name,
-            value: s.name,
-            hint: s.description,
-          })),
-          { label: 'None of these', value: '_none_' as const },
-        ],
-      })
-
-      if (!p.isCancel(selected) && selected !== '_none_')
-        return syncSinglePackage(selected as string, config)
-
-      return
-    }
-
-    spin.stop(`Could not find docs for: ${packageName}`)
+    spin.stop(`Could not find docs for: ${identityPackageName}`)
     showResolveAttempts(resolveResult.attempts)
     return
   }
 
-  const version = localVersion || resolved.version || 'latest'
+  const version = isCrate
+    ? (resolved.version || requestedTag || 'latest')
+    : (localVersion || resolved.version || 'latest')
   const versionKey = getVersionKey(version)
 
   // Force: nuke cached references + search index so all existsSync guards re-fetch
   if (config.force) {
-    forceClearCache(packageName, version)
+    forceClearCache(storagePackageName, version)
   }
 
-  const useCache = isCached(packageName, version)
+  const useCache = isCached(storagePackageName, version)
 
-  // Download npm dist if not in node_modules (for standalone/learning use)
-  if (!existsSync(join(cwd, 'node_modules', packageName))) {
+  // Download npm dist if not in node_modules (crates don't have a dist)
+  if (!isCrate && !existsSync(join(cwd, 'node_modules', packageName))) {
     spin.message(`Downloading ${packageName}@${version} dist`)
     await fetchPkgDist(packageName, version)
   }
 
-  // Shipped skills: symlink directly, skip all doc fetching/caching/LLM
-  const shippedResult = handleShippedSkills(packageName, version, cwd, config.agent, config.global)
+  // Shipped skills: symlink directly, skip all doc fetching/caching/LLM (crates don't ship skills)
+  const shippedResult = isCrate ? null : handleShippedSkills(packageName, version, cwd, config.agent, config.global)
   if (shippedResult) {
     const shared = !config.global && getSharedSkillsDir(cwd)
     for (const shipped of shippedResult.shipped) {
@@ -364,10 +399,10 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     return
   }
 
-  spin.stop(`Resolved ${packageName}@${useCache ? versionKey : version}${config.force ? ' (force)' : useCache ? ' (cached)' : ''}`)
+  spin.stop(`Resolved ${identityPackageName}@${useCache ? versionKey : version}${config.force ? ' (force)' : useCache ? ' (cached)' : ''}`)
 
   // Warn when no local dep and resolved to stable latest — prerelease releases won't be fetched
-  if (!localVersion && !requestedTag && !isPrerelease(version)) {
+  if (!isCrate && !localVersion && !requestedTag && !isPrerelease(version)) {
     const nextTag = resolved.distTags?.next ?? resolved.distTags?.beta ?? resolved.distTags?.alpha
     if (nextTag && (!resolved.releasedAt || !nextTag.releasedAt || nextTag.releasedAt > resolved.releasedAt)) {
       p.log.warn(`\x1B[33mNo local dependency found — using latest stable (${version}). Prerelease ${nextTag.version} available: skilld add ${packageName}@beta\x1B[0m`)
@@ -378,12 +413,12 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 
   const baseDir = resolveBaseDir(cwd, config.agent, config.global)
   // In update mode, find the existing skill dir name for this package (may differ from computed name)
-  let skillDirName = config.name ? sanitizeName(config.name) : computeSkillDirName(packageName)
+  let skillDirName = config.name ? sanitizeName(config.name) : computeSkillDirName(storagePackageName)
   if (config.mode === 'update' && !config.name) {
     const lock = readLock(baseDir)
     if (lock) {
       for (const [name, info] of Object.entries(lock.skills)) {
-        if (info.packageName === packageName || parsePackages(info.packages).some(p => p.name === packageName)) {
+        if (info.packageName === identityPackageName || parsePackages(info.packages).some(p => p.name === identityPackageName)) {
           skillDirName = name
           break
         }
@@ -400,7 +435,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 
   // ── Merge mode: skill dir already exists with a different primary package (skip in eject) ──
   const existingLock = config.eject ? undefined : readLock(baseDir)?.skills[skillDirName]
-  const isMerge = existingLock && existingLock.packageName && existingLock.packageName !== packageName
+  const isMerge = existingLock && existingLock.packageName && existingLock.packageName !== identityPackageName
 
   // Capture update context before lockfile gets overwritten
   const updateCtx = config.mode === 'update' && existingLock
@@ -419,15 +454,15 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     : undefined
 
   if (isMerge) {
-    spin.stop(`Merging ${packageName} into ${skillDirName}`)
+    spin.stop(`Merging ${identityPackageName} into ${skillDirName}`)
 
     // Create named symlink for this package
-    linkPkgNamed(skillDir, packageName, cwd, version)
+    linkPkgNamed(skillDir, storagePackageName, cwd, version)
 
     // Merge into lockfile
     const repoSlug = resolved.repoUrl?.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:[/#]|$)/)?.[1]
     writeLock(baseDir, skillDirName, {
-      packageName,
+      packageName: identityPackageName,
       version,
       repo: repoSlug,
       source: existingLock.source,
@@ -438,9 +473,10 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     // Regenerate SKILL.md with all packages listed
     const updatedLock = readLock(baseDir)?.skills[skillDirName]
     const allPackages = parsePackages(updatedLock?.packages).map(p => ({ name: p.name }))
-    const relatedSkills = await findRelatedSkills(packageName, baseDir)
-    const pkgFiles = getPkgKeyFiles(existingLock.packageName!, cwd, existingLock.version)
-    const shippedDocs = hasShippedDocs(existingLock.packageName!, cwd, existingLock.version)
+    const relatedSkills = await findRelatedSkills(storagePackageName, baseDir)
+    const existingStorageName = toStoragePackageName(existingLock.packageName!)
+    const pkgFiles = getPkgKeyFiles(existingStorageName, cwd, existingLock.version)
+    const shippedDocs = hasShippedDocs(existingStorageName, cwd, existingLock.version)
 
     const mergeFeatures = readConfig().features ?? defaultFeatures
     const skillMd = generateSkillMd({
@@ -466,7 +502,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     if (!config.global)
       registerProject(cwd)
 
-    p.outro(`Merged ${packageName} into ${skillDirName}`)
+    p.outro(`Merged ${identityPackageName} into ${skillDirName}`)
     return
   }
 
@@ -478,7 +514,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
   const resSpin = timedSpinner()
   resSpin.start('Finding resources')
   const resources = await fetchAndCacheResources({
-    packageName,
+    packageName: storagePackageName,
     resolved,
     version,
     useCache,
@@ -506,14 +542,14 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     p.log.warn(`\x1B[33m${w}\x1B[0m`)
 
   // Create symlinks (LLM needs .skilld/ to read docs, even in eject mode)
-  linkAllReferences(skillDir, packageName, cwd, version, resources.docsType, undefined, features, resources.repoInfo)
+  linkAllReferences(skillDir, storagePackageName, cwd, version, resources.docsType, undefined, features, resources.repoInfo)
 
   // ── Phase 2: Search index (generated even in eject mode so LLM can use it) ──
   if (features.search) {
     const idxSpin = timedSpinner()
     idxSpin.start('Creating search index')
     await indexResources({
-      packageName,
+      packageName: storagePackageName,
       version,
       cwd,
       docsToIndex: resources.docsToIndex,
@@ -523,23 +559,23 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     idxSpin.stop('Search index ready')
   }
 
-  const pkgDir = resolvePkgDir(packageName, cwd, version)
-  const hasChangelog = detectChangelog(pkgDir, getCacheDir(packageName, version))
-  const relatedSkills = await findRelatedSkills(packageName, baseDir)
-  const shippedDocs = hasShippedDocs(packageName, cwd, version)
-  const pkgFiles = getPkgKeyFiles(packageName, cwd, version)
+  const pkgDir = resolvePkgDir(storagePackageName, cwd, version)
+  const hasChangelog = detectChangelog(pkgDir, getCacheDir(storagePackageName, version))
+  const relatedSkills = await findRelatedSkills(storagePackageName, baseDir)
+  const shippedDocs = hasShippedDocs(storagePackageName, cwd, version)
+  const pkgFiles = getPkgKeyFiles(storagePackageName, cwd, version)
 
   // Write base SKILL.md (no LLM needed)
   const repoSlug = resolved.repoUrl?.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:[/#]|$)/)?.[1]
 
   // Also create named symlink for this package (skip in eject mode)
   if (!config.eject)
-    linkPkgNamed(skillDir, packageName, cwd, version)
+    linkPkgNamed(skillDir, storagePackageName, cwd, version)
 
   // Skip lockfile in eject mode — no agent skills dir to write to
   if (!config.eject) {
     writeLock(baseDir, skillDirName, {
-      packageName,
+      packageName: identityPackageName,
       version,
       repo: repoSlug,
       source: resources.docSource,
@@ -553,7 +589,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
       for (const [name, info] of Object.entries(lock.skills)) {
         if (name === skillDirName)
           continue
-        if (info.packageName === packageName || parsePackages(info.packages).some(p => p.name === packageName)) {
+        if (info.packageName === identityPackageName || parsePackages(info.packages).some(p => p.name === identityPackageName)) {
           removeLockEntry(baseDir, name)
           const staleDir = join(baseDir, name)
           if (existsSync(staleDir))
@@ -569,7 +605,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 
   const isEject = !!config.eject
   const baseSkillMd = generateSkillMd({
-    name: packageName,
+    name: identityPackageName,
     version,
     releasedAt: resolved.releasedAt,
     description: resolved.description,
@@ -597,7 +633,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
   // Check if all default sections are already cached (skip prompt entirely if so)
   const allSectionsCached = !config.force && DEFAULT_SECTIONS.every((s) => {
     const outputFile = SECTION_OUTPUT_FILES[s]
-    return readCachedSection(packageName, version, outputFile) !== null
+    return readCachedSection(storagePackageName, version, outputFile) !== null
   })
 
   if (allSectionsCached) {
@@ -607,14 +643,14 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
       if (!DEFAULT_SECTIONS.includes(s))
         continue
       const outputFile = SECTION_OUTPUT_FILES[s]
-      const content = readCachedSection(packageName, version, outputFile)
+      const content = readCachedSection(storagePackageName, version, outputFile)
       if (content)
         cachedParts.push(wrapSection(s, content))
     }
     const cachedBody = cachedParts.join('\n\n')
 
     const skillMd = generateSkillMd({
-      name: packageName,
+      name: identityPackageName,
       version,
       releasedAt: resolved.releasedAt,
       description: resolved.description,
@@ -655,7 +691,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     const llmConfig = await selectLlmConfig(resolvedModel, undefined, updateCtx)
     if (llmConfig?.promptOnly) {
       writePromptFiles({
-        packageName,
+        packageName: storagePackageName,
         skillDir,
         version,
         hasIssues: resources.hasIssues,
@@ -674,7 +710,8 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     else if (llmConfig) {
       p.log.step(getModelLabel(llmConfig.model))
       await enhanceSkillWithLLM({
-        packageName,
+        packageName: identityPackageName,
+        cachePackageName: storagePackageName,
         version,
         skillDir,
         dirName: skillDirName,
@@ -705,7 +742,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     const skilldDir = join(skillDir, '.skilld')
     if (existsSync(skilldDir) && !config.debug)
       rmSync(skilldDir, { recursive: true, force: true })
-    ejectReferences(skillDir, packageName, cwd, version, resources.docsType, features, resources.repoInfo)
+    ejectReferences(skillDir, storagePackageName, cwd, version, resources.docsType, features, resources.repoInfo)
   }
 
   // Skip agent integration in eject mode (no symlinks, no gitignore, no instructions)
@@ -728,7 +765,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 
   const ejectMsg = isEject ? ' (ejected)' : ''
   const relDir = relative(cwd, skillDir)
-  p.outro(config.mode === 'update' ? `Updated ${packageName}${ejectMsg}` : `Synced ${packageName} → ${relDir}${ejectMsg}`)
+  p.outro(config.mode === 'update' ? `Updated ${identityPackageName}${ejectMsg}` : `Synced ${identityPackageName} → ${relDir}${ejectMsg}`)
 
   try {
     await suggestPrepareHook(cwd)
@@ -741,11 +778,11 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 // ── Citty command definitions (lazy-loaded by cli.ts) ──
 
 export const addCommandDef = defineCommand({
-  meta: { name: 'add', description: 'Install skills (npm:<pkg>, gh:<owner/repo>, @<curator>)' },
+  meta: { name: 'add', description: 'Install skills (npm:<pkg>, crate:<name>, gh:<owner/repo>, @<curator>)' },
   args: {
     package: {
       type: 'positional',
-      description: 'Package(s) to sync (space or comma-separated, e.g., vue nuxt pinia)',
+      description: 'Package(s) to sync (space/comma-separated; npm:<pkg>, crate:<name>, or owner/repo)',
       required: true,
     },
     skill: {
@@ -788,6 +825,7 @@ export const addCommandDef = defineCommand({
     const parsedSources = rawInputs.map(parseSkillInput)
     const gitSources: GitSkillSource[] = []
     const npmEntries: Array<{ name: string, spec: string }> = []
+    const crateSpecs: string[] = []
     const unsupported: string[] = []
 
     for (const source of parsedSources) {
@@ -797,6 +835,9 @@ export const addCommandDef = defineCommand({
           break
         case 'npm':
           npmEntries.push({ name: source.package, spec: source.tag ? `${source.package}@${source.tag}` : source.package })
+          break
+        case 'crate':
+          crateSpecs.push(source.version ? `crate:${source.package}@${source.version}` : `crate:${source.package}`)
           break
         case 'bare':
           p.log.warn(`Bare names are deprecated. Use \x1B[36mnpm:${source.package}\x1B[0m instead.`)
@@ -818,7 +859,7 @@ export const addCommandDef = defineCommand({
     if (unsupported.length > 0) {
       p.log.error(`Curator and collection installs are not yet available:\n  ${unsupported.join('\n  ')}\n\nFollow https://skilld.dev for launch updates.`)
       process.exitCode = 1
-      if (gitSources.length === 0 && npmEntries.length === 0)
+      if (gitSources.length === 0 && npmEntries.length === 0 && crateSpecs.length === 0)
         return
     }
 
@@ -857,8 +898,8 @@ export const addCommandDef = defineCommand({
       if (fallbackPackages.length > 0) {
         const state = await getProjectState(cwd)
         p.intro(introLine({ state, agentId: agent || undefined }))
-        return syncCommand(state, {
-          packages: fallbackPackages,
+        await syncCommand(state, {
+          packages: [...fallbackPackages, ...crateSpecs],
           global: args.global,
           agent,
           model: args.model as OptimizeModel | undefined,
@@ -866,7 +907,23 @@ export const addCommandDef = defineCommand({
           force: args.force,
           debug: args.debug,
         })
+        return
       }
+    }
+
+    // Crates without any npm packages: route straight to syncCommand
+    if (crateSpecs.length > 0) {
+      const state = await getProjectState(cwd)
+      p.intro(introLine({ state, agentId: agent || undefined }))
+      await syncCommand(state, {
+        packages: crateSpecs,
+        global: args.global,
+        agent,
+        model: args.model as OptimizeModel | undefined,
+        yes: args.yes,
+        force: args.force,
+        debug: args.debug,
+      })
     }
   },
 })
@@ -1021,13 +1078,22 @@ export const updateCommandDef = defineCommand({
       })
     }
 
-    // No args: sync all outdated
-    if (state.outdated.length === 0) {
+    // No args: sync all outdated + all crate skills.
+    // Crates have no package.json entry to pin against, so state.outdated never
+    // includes them. Bulk update re-resolves each against crates.io; if the version
+    // hasn't changed the cache short-circuits fetching.
+    const crateSpecs = state.skills
+      .map(s => s.info?.packageName)
+      .filter((name): name is string => !!name && name.startsWith('crate:'))
+    if (state.outdated.length === 0 && crateSpecs.length === 0) {
       p.log.success('All skills up to date')
       return
     }
 
-    const packages = state.outdated.map(s => s.packageName || s.name)
+    const packages = [
+      ...state.outdated.map(s => s.packageName || s.name),
+      ...crateSpecs,
+    ]
     return syncCommand(state, {
       packages,
       global: args.global,

--- a/src/core/prefix.ts
+++ b/src/core/prefix.ts
@@ -3,6 +3,7 @@
  *
  * All sources require an explicit prefix:
  *   npm:vue         → package skill from registry
+ *   crate:serde     → Rust crate from crates.io
  *   gh:owner/repo   → git skill
  *   github:o/r      → git skill (alias)
  *   @handle          → curator's skills
@@ -16,6 +17,7 @@ import { parseGitSkillInput } from '../sources/git-skills.ts'
 
 export type SkillSource
   = | { type: 'npm', package: string, tag?: string }
+    | { type: 'crate', package: string, version?: string }
     | { type: 'git', source: GitSkillSource }
     | { type: 'curator', handle: string }
     | { type: 'collection', handle: string, name: string }
@@ -34,6 +36,15 @@ export function parseSkillInput(input: string): SkillSource {
     const rest = trimmed.slice(4)
     const { name, tag } = splitPackageTag(rest)
     return { type: 'npm', package: name, tag }
+  }
+
+  // crate: prefix → Rust crate from crates.io
+  if (trimmed.startsWith('crate:')) {
+    const rest = trimmed.slice(6).trim()
+    const atIdx = rest.indexOf('@')
+    const name = (atIdx === -1 ? rest : rest.slice(0, atIdx)).toLowerCase()
+    const version = atIdx === -1 ? undefined : rest.slice(atIdx + 1) || undefined
+    return { type: 'crate', package: name, version }
   }
 
   // gh: or github: prefix → git skill
@@ -94,6 +105,8 @@ export function resolveSkillName(input: string): string | null {
     case 'npm':
     case 'bare':
       return source.package
+    case 'crate':
+      return `crate:${source.package}`
     case 'git':
       if (source.source.type === 'github' && source.source.repo)
         return source.source.repo
@@ -106,6 +119,17 @@ export function resolveSkillName(input: string): string | null {
       throw new Error(`Unhandled SkillSource type: ${JSON.stringify(_exhaustive)}`)
     }
   }
+}
+
+/**
+ * Map a lockfile/identity package name to the storage-safe name used for
+ * cache directories and symlinks. `crate:serde` → `@skilld-crate/serde`;
+ * other names pass through unchanged.
+ */
+export function toStoragePackageName(identityName: string): string {
+  if (identityName.startsWith('crate:'))
+    return `@skilld-crate/${identityName.slice('crate:'.length)}`
+  return identityName
 }
 
 /**

--- a/src/core/prepare.ts
+++ b/src/core/prepare.ts
@@ -11,6 +11,13 @@ import { existsSync, lstatSync, mkdirSync, readdirSync, rmSync, symlinkSync, unl
 import { join } from 'pathe'
 import { getCacheDir } from '../cache/version.ts'
 
+/** Map lockfile identity name to storage-safe cache key (crate:X → @skilld-crate/X) */
+function toStorageName(name: string): string {
+  if (name.startsWith('crate:'))
+    return `@skilld-crate/${name.slice('crate:'.length)}`
+  return name
+}
+
 /** Resolve package directory: node_modules first, then global cache */
 export function resolvePkgDir(name: string, cwd: string, version?: string): string | null {
   const nodeModulesPath = join(cwd, 'node_modules', name)
@@ -52,7 +59,7 @@ export function restorePkgSymlink(skillsDir: string, name: string, info: SkillIn
       return // permission/IO error — bail instead of masking
   }
 
-  const pkgName = info.packageName || name
+  const pkgName = toStorageName(info.packageName || name)
   const pkgDir = resolvePkgDir(pkgName, cwd, info.version)
   if (!pkgDir)
     return

--- a/src/sources/crates.ts
+++ b/src/sources/crates.ts
@@ -1,0 +1,200 @@
+import type { ResolveAttempt, ResolvedPackage, ResolveResult } from './types.ts'
+import { resolveGitHubRepo } from './github.ts'
+import { fetchLlmsUrl } from './llms.ts'
+import { $fetch, createRateLimitedRunner, isLikelyCodeHostUrl, isUselessDocsUrl, normalizeRepoUrl, parseGitHubUrl } from './utils.ts'
+
+const VALID_CRATE_NAME = /^[a-z0-9][\w-]*$/
+const runCratesApiRateLimited = createRateLimitedRunner(1000)
+
+interface CratesApiResponse {
+  crate?: {
+    id?: string
+    name?: string
+    description?: string
+    homepage?: string | null
+    documentation?: string | null
+    repository?: string | null
+    max_version?: string
+    newest_version?: string
+    max_stable_version?: string
+    default_version?: string
+    updated_at?: string
+  }
+  versions?: Array<{
+    num?: string
+    yanked?: boolean
+    created_at?: string
+    description?: string | null
+    homepage?: string | null
+    documentation?: string | null
+    repository?: string | null
+  }>
+}
+
+function selectCrateVersion(
+  data: CratesApiResponse,
+  requestedVersion?: string,
+): { version: string, entry?: NonNullable<CratesApiResponse['versions']>[number] } | null {
+  const versions = data.versions || []
+
+  if (requestedVersion) {
+    const exact = versions.find(v => v.num === requestedVersion && !v.yanked)
+    if (exact?.num)
+      return { version: exact.num, entry: exact }
+  }
+
+  const crate = data.crate
+  const preferred = [
+    crate?.max_stable_version,
+    crate?.newest_version,
+    crate?.max_version,
+    crate?.default_version,
+  ].find(Boolean)
+
+  if (preferred) {
+    const match = versions.find(v => v.num === preferred && !v.yanked)
+    if (match?.num)
+      return { version: preferred, entry: match }
+    if (versions.length === 0)
+      return { version: preferred }
+  }
+
+  const firstStable = versions.find(v => !v.yanked && v.num)
+  if (firstStable?.num)
+    return { version: firstStable.num, entry: firstStable }
+
+  return null
+}
+
+function pickPreferredUrl(...urls: Array<string | null | undefined>): string | undefined {
+  return urls.map(v => v?.trim()).find(v => !!v)
+}
+
+async function fetchCratesApi<T>(url: string): Promise<T | null> {
+  return runCratesApiRateLimited(() => $fetch<T>(url).catch(() => null))
+}
+
+export async function resolveCrateDocsWithAttempts(
+  crateName: string,
+  options: { version?: string, onProgress?: (message: string) => void } = {},
+): Promise<ResolveResult> {
+  const attempts: ResolveAttempt[] = []
+  const onProgress = options.onProgress
+  const normalizedName = crateName.trim().toLowerCase()
+
+  if (!normalizedName || !VALID_CRATE_NAME.test(normalizedName)) {
+    attempts.push({
+      source: 'crates',
+      status: 'error',
+      message: `Invalid crate name: ${crateName}`,
+    })
+    return { package: null, attempts }
+  }
+
+  onProgress?.('crates.io metadata')
+  const apiUrl = `https://crates.io/api/v1/crates/${encodeURIComponent(normalizedName)}`
+  const data = await fetchCratesApi<CratesApiResponse>(apiUrl)
+
+  if (!data?.crate) {
+    attempts.push({
+      source: 'crates',
+      url: apiUrl,
+      status: 'not-found',
+      message: 'Crate not found on crates.io',
+    })
+    return { package: null, attempts }
+  }
+
+  attempts.push({
+    source: 'crates',
+    url: apiUrl,
+    status: 'success',
+    message: `Found crate: ${data.crate.name || normalizedName}`,
+  })
+
+  const selected = selectCrateVersion(data, options.version)
+  if (!selected) {
+    attempts.push({
+      source: 'crates',
+      url: apiUrl,
+      status: 'error',
+      message: 'No usable crate versions found',
+    })
+    return { package: null, attempts }
+  }
+
+  const version = selected.version
+  const versionEntry = selected.entry
+  const docsRsUrl = `https://docs.rs/${encodeURIComponent(normalizedName)}/${encodeURIComponent(version)}`
+
+  const repositoryRaw = pickPreferredUrl(versionEntry?.repository, data.crate.repository)
+  const homepage = pickPreferredUrl(versionEntry?.homepage, data.crate.homepage)
+  const documentation = pickPreferredUrl(versionEntry?.documentation, data.crate.documentation)
+  const normalizedRepo = repositoryRaw ? normalizeRepoUrl(repositoryRaw) : undefined
+  const repoUrl = normalizedRepo && isLikelyCodeHostUrl(normalizedRepo)
+    ? normalizedRepo
+    : isLikelyCodeHostUrl(homepage)
+      ? homepage
+      : undefined
+
+  let resolved: ResolvedPackage = {
+    name: normalizedName,
+    version,
+    releasedAt: versionEntry?.created_at || data.crate.updated_at || undefined,
+    description: versionEntry?.description || data.crate.description,
+    docsUrl: (() => {
+      if (documentation && !isUselessDocsUrl(documentation) && !isLikelyCodeHostUrl(documentation))
+        return documentation
+      if (homepage && !isUselessDocsUrl(homepage) && !isLikelyCodeHostUrl(homepage))
+        return homepage
+      return docsRsUrl
+    })(),
+    repoUrl,
+  }
+
+  const gh = repoUrl ? parseGitHubUrl(repoUrl) : null
+  if (gh) {
+    onProgress?.('GitHub enrichment')
+    const ghResolved = await resolveGitHubRepo(gh.owner, gh.repo)
+    if (ghResolved) {
+      attempts.push({
+        source: 'github-meta',
+        url: repoUrl,
+        status: 'success',
+        message: 'Enriched via GitHub repo metadata',
+      })
+      resolved = {
+        ...ghResolved,
+        name: normalizedName,
+        version,
+        releasedAt: resolved.releasedAt || ghResolved.releasedAt,
+        description: resolved.description || ghResolved.description,
+        docsUrl: resolved.docsUrl || ghResolved.docsUrl,
+        repoUrl,
+        readmeUrl: ghResolved.readmeUrl || resolved.readmeUrl,
+      }
+    }
+    else {
+      attempts.push({
+        source: 'github-meta',
+        url: repoUrl,
+        status: 'not-found',
+        message: 'GitHub enrichment failed, using crates.io metadata',
+      })
+    }
+  }
+
+  if (!resolved.llmsUrl && resolved.docsUrl) {
+    onProgress?.('llms.txt discovery')
+    resolved.llmsUrl = await fetchLlmsUrl(resolved.docsUrl).catch(() => null) ?? undefined
+    if (resolved.llmsUrl) {
+      attempts.push({
+        source: 'llms.txt',
+        url: resolved.llmsUrl,
+        status: 'success',
+      })
+    }
+  }
+
+  return { package: resolved, attempts }
+}

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -4,6 +4,9 @@
 
 export { fetchBlogReleases } from './blog-releases.ts'
 
+// Crates (crates.io)
+export { resolveCrateDocsWithAttempts } from './crates.ts'
+
 // Crawl
 export { fetchCrawledDocs, toCrawlPattern } from './crawl.ts'
 

--- a/src/sources/npm.ts
+++ b/src/sources/npm.ts
@@ -14,7 +14,7 @@ import { readPackageJsonSafe } from '../core/package-json.ts'
 import { fetchGitDocs, fetchGitHubRepoMeta, fetchReadme, searchGitHubRepo, validateGitDocsWithLlms } from './github.ts'
 import { fetchLlmsTxt, fetchLlmsUrl } from './llms.ts'
 import { getCrawlUrl } from './package-registry.ts'
-import { $fetch, isGitHubRepoUrl, isUselessDocsUrl, normalizeRepoUrl, parseGitHubUrl, parsePackageSpec } from './utils.ts'
+import { $fetch, isGitHubRepoUrl, isUselessDocsUrl, normalizeRepoUrl, parseGitHubUrl, parsePackageSpec, SKILLD_USER_AGENT } from './utils.ts'
 
 /**
  * Search npm registry for packages matching a query.
@@ -606,7 +606,7 @@ export async function fetchPkgDist(name: string, version: string): Promise<strin
 
   // Download tarball to temp file
   const tarballRes = await fetch(tarballUrl, {
-    headers: { 'User-Agent': 'skilld/1.0' },
+    headers: { 'User-Agent': SKILLD_USER_AGENT },
   }).catch(() => null)
 
   if (!tarballRes?.ok || !tarballRes.body)

--- a/src/sources/types.ts
+++ b/src/sources/types.ts
@@ -65,7 +65,7 @@ export interface FetchedDoc {
 }
 
 export interface ResolveAttempt {
-  source: 'npm' | 'github-docs' | 'github-meta' | 'github-search' | 'llms.txt' | 'readme'
+  source: 'npm' | 'crates' | 'github-docs' | 'github-meta' | 'github-search' | 'llms.txt' | 'readme'
   url?: string
   status: 'success' | 'not-found' | 'error'
   message?: string

--- a/src/sources/utils.ts
+++ b/src/sources/utils.ts
@@ -5,12 +5,40 @@
 import { ofetch } from 'ofetch'
 import { getGitHubToken, isKnownPrivateRepo, markRepoPrivate } from './github-common.ts'
 
+export const SKILLD_USER_AGENT = 'skilld/1.0 (+https://github.com/harlan-zw/skilld)'
+
 export const $fetch = ofetch.create({
   retry: 3,
-  retryDelay: 500,
+  retryDelay: 1000,
+  retryStatusCodes: [408, 429, 500, 502, 503, 504],
   timeout: 15_000,
-  headers: { 'User-Agent': 'skilld/1.0' },
+  headers: { 'User-Agent': SKILLD_USER_AGENT },
 })
+
+/**
+ * Create a rate-limited runner that enforces a minimum gap between task starts.
+ * Queues tasks serially so consumers don't need to coordinate.
+ */
+export function createRateLimitedRunner(intervalMs: number): <T>(task: () => Promise<T>) => Promise<T> {
+  let queue: Promise<void> = Promise.resolve()
+  let lastRunAt = 0
+
+  return async function runRateLimited<T>(task: () => Promise<T>): Promise<T> {
+    const run = async (): Promise<T> => {
+      const elapsed = Date.now() - lastRunAt
+      const waitMs = intervalMs - elapsed
+      if (waitMs > 0)
+        await new Promise(resolve => setTimeout(resolve, waitMs))
+
+      lastRunAt = Date.now()
+      return task()
+    }
+
+    const request = queue.then(run, run)
+    queue = request.then(() => undefined, () => undefined)
+    return request
+  }
+}
 
 /**
  * Fetch text content from URL
@@ -105,6 +133,19 @@ export function isGitHubRepoUrl(url: string): boolean {
   try {
     const parsed = new URL(url)
     return parsed.hostname === 'github.com' || parsed.hostname === 'www.github.com'
+  }
+  catch {
+    return false
+  }
+}
+
+/** Check if URL points to a code hosting provider (GitHub/GitLab) rather than a docs site */
+export function isLikelyCodeHostUrl(url: string | undefined): boolean {
+  if (!url)
+    return false
+  try {
+    const parsed = new URL(url)
+    return ['github.com', 'www.github.com', 'gitlab.com', 'www.gitlab.com'].includes(parsed.hostname)
   }
   catch {
     return false

--- a/test/e2e/crate-smoke.test.ts
+++ b/test/e2e/crate-smoke.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCrateDocsWithAttempts } from '../../src/sources'
+
+describe('e2e crate smoke', () => {
+  it('returns crate resolution result for serde', async () => {
+    const result = await resolveCrateDocsWithAttempts('serde')
+
+    if (result.package) {
+      expect(result.package.name).toBe('serde')
+      expect(result.package.version).toBeTruthy()
+      expect(result.package.docsUrl).toMatch(/^https:\/\/docs\.rs\/serde(?:\/|$)/)
+      expect(result.attempts.some(a => a.source === 'crates' && a.status === 'success')).toBe(true)
+      return
+    }
+
+    expect(result.attempts.some(a => a.source === 'crates')).toBe(true)
+    expect(result.attempts.some(a => a.status === 'not-found' || a.status === 'error')).toBe(true)
+  }, 120_000)
+})

--- a/test/unit/prefix.test.ts
+++ b/test/unit/prefix.test.ts
@@ -56,6 +56,32 @@ describe('prefix parser', () => {
     })
   })
 
+  describe('crate: prefix', () => {
+    it('parses crate name', () => {
+      expect(parseSkillInput('crate:serde')).toEqual({
+        type: 'crate',
+        package: 'serde',
+        version: undefined,
+      })
+    })
+
+    it('parses crate name with version', () => {
+      expect(parseSkillInput('crate:serde@1.0.0')).toEqual({
+        type: 'crate',
+        package: 'serde',
+        version: '1.0.0',
+      })
+    })
+
+    it('lowercases crate name', () => {
+      expect(parseSkillInput('crate:Tokio')).toEqual({
+        type: 'crate',
+        package: 'tokio',
+        version: undefined,
+      })
+    })
+  })
+
   describe('@ prefix (curator and collection)', () => {
     it('parses @handle as curator', () => {
       expect(parseSkillInput('@antfu')).toEqual({
@@ -153,6 +179,10 @@ describe('prefix parser', () => {
 
     it('returns null for collection', () => {
       expect(resolveSkillName('@antfu/utils')).toBeNull()
+    })
+
+    it('returns crate:<name> for crate inputs', () => {
+      expect(resolveSkillName('crate:serde')).toBe('crate:serde')
     })
   })
 })

--- a/test/unit/sources-crates.test.ts
+++ b/test/unit/sources-crates.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFetch = vi.fn<(
+  url: string,
+  opts?: { responseType?: string, method?: string },
+) => Promise<{ ok?: boolean, json?: () => Promise<unknown>, text?: () => Promise<string> }>>()
+
+function createMockFetch() {
+  async function $fetch(url: string, opts?: { responseType?: string, method?: string }): Promise<unknown> {
+    const response = await mockFetch(url, opts)
+    if (!response?.ok)
+      throw new Error('fetch failed')
+    if (opts?.responseType === 'text')
+      return response.text?.() ?? null
+    return response.json?.() ?? null
+  }
+
+  $fetch.raw = async (url: string, opts?: { responseType?: string, method?: string }) => {
+    return mockFetch(url, opts)
+  }
+
+  return $fetch
+}
+
+vi.mock('ofetch', () => ({
+  ofetch: { create: () => createMockFetch() },
+}))
+
+vi.mock('../../src/sources/github', () => ({
+  resolveGitHubRepo: vi.fn(),
+}))
+
+vi.mock('../../src/sources/llms', () => ({
+  fetchLlmsUrl: vi.fn(),
+}))
+
+const { resolveCrateDocsWithAttempts } = await import('../../src/sources/crates')
+
+describe('sources/crates', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('returns error attempt for invalid crate name', async () => {
+    const result = await resolveCrateDocsWithAttempts('serde!')
+
+    expect(result.package).toBeNull()
+    expect(result.attempts).toEqual([
+      {
+        source: 'crates',
+        status: 'error',
+        message: 'Invalid crate name: serde!',
+      },
+    ])
+  })
+
+  it('returns not-found attempt when crates.io metadata cannot be fetched', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network'))
+
+    const result = await resolveCrateDocsWithAttempts('serde')
+
+    expect(result.package).toBeNull()
+    expect(result.attempts).toEqual([
+      {
+        source: 'crates',
+        url: 'https://crates.io/api/v1/crates/serde',
+        status: 'not-found',
+        message: 'Crate not found on crates.io',
+      },
+    ])
+  })
+
+  it('falls back to docs.rs when documentation/homepage are missing or repo-like', async () => {
+    const { fetchLlmsUrl } = await import('../../src/sources/llms')
+    const { resolveGitHubRepo } = await import('../../src/sources/github')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        crate: {
+          name: 'serde',
+          max_version: '1.0.217',
+          repository: 'https://github.com/serde-rs/serde',
+          documentation: 'https://github.com/serde-rs/serde',
+          homepage: 'https://github.com/serde-rs/serde',
+          updated_at: '2025-01-01T00:00:00Z',
+        },
+        versions: [
+          {
+            num: '1.0.217',
+            yanked: false,
+            created_at: '2024-12-20T00:00:00Z',
+          },
+        ],
+      }),
+    })
+
+    vi.mocked(resolveGitHubRepo).mockResolvedValue(null)
+    vi.mocked(fetchLlmsUrl).mockResolvedValue(null)
+
+    const progress: string[] = []
+    const result = await resolveCrateDocsWithAttempts('serde', {
+      onProgress: step => progress.push(step),
+    })
+
+    expect(result.package).toMatchObject({
+      name: 'serde',
+      version: '1.0.217',
+      docsUrl: 'https://docs.rs/serde/1.0.217',
+      repoUrl: 'https://github.com/serde-rs/serde',
+      releasedAt: '2024-12-20T00:00:00Z',
+    })
+    expect(progress).toEqual([
+      'crates.io metadata',
+      'GitHub enrichment',
+      'llms.txt discovery',
+    ])
+  })
+
+  it('selects requested non-yanked version and keeps docs.rs versioned URL', async () => {
+    const { fetchLlmsUrl } = await import('../../src/sources/llms')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        crate: {
+          name: 'serde',
+          max_stable_version: '1.0.220',
+        },
+        versions: [
+          { num: '1.0.220', yanked: false, created_at: '2025-01-10T00:00:00Z' },
+          { num: '1.0.0', yanked: false, created_at: '2020-01-01T00:00:00Z' },
+        ],
+      }),
+    })
+
+    vi.mocked(fetchLlmsUrl).mockResolvedValue(null)
+
+    const result = await resolveCrateDocsWithAttempts('serde', { version: '1.0.0' })
+
+    expect(result.package).toMatchObject({
+      name: 'serde',
+      version: '1.0.0',
+      docsUrl: 'https://docs.rs/serde/1.0.0',
+    })
+  })
+
+  it('falls back from requested yanked version to preferred stable version', async () => {
+    const { fetchLlmsUrl } = await import('../../src/sources/llms')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        crate: {
+          name: 'serde',
+          max_stable_version: '1.0.220',
+          newest_version: '1.0.220',
+        },
+        versions: [
+          { num: '1.0.220', yanked: false, created_at: '2025-01-10T00:00:00Z' },
+          { num: '1.0.200', yanked: true, created_at: '2024-10-01T00:00:00Z' },
+        ],
+      }),
+    })
+
+    vi.mocked(fetchLlmsUrl).mockResolvedValue(null)
+
+    const result = await resolveCrateDocsWithAttempts('serde', { version: '1.0.200' })
+
+    expect(result.package?.version).toBe('1.0.220')
+    expect(result.package?.releasedAt).toBe('2025-01-10T00:00:00Z')
+  })
+
+  it('returns error attempt when crate exists but no usable versions are available', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        crate: {
+          name: 'serde',
+        },
+        versions: [
+          { num: '1.0.220', yanked: true },
+          { num: '1.0.200', yanked: true },
+        ],
+      }),
+    })
+
+    const result = await resolveCrateDocsWithAttempts('serde')
+
+    expect(result.package).toBeNull()
+    expect(result.attempts).toContainEqual({
+      source: 'crates',
+      url: 'https://crates.io/api/v1/crates/serde',
+      status: 'error',
+      message: 'No usable crate versions found',
+    })
+  })
+
+  it('enriches metadata from GitHub when repository points to GitHub', async () => {
+    const { resolveGitHubRepo } = await import('../../src/sources/github')
+    const { fetchLlmsUrl } = await import('../../src/sources/llms')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        crate: {
+          name: 'serde',
+          max_version: '1.0.220',
+          repository: 'git+https://github.com/serde-rs/serde.git',
+          description: 'serde description',
+        },
+        versions: [
+          { num: '1.0.220', yanked: false, created_at: '2025-01-10T00:00:00Z' },
+        ],
+      }),
+    })
+
+    vi.mocked(resolveGitHubRepo).mockResolvedValue({
+      name: 'serde',
+      version: '1.0.220',
+      description: 'github description',
+      docsUrl: 'https://serde.rs',
+      readmeUrl: 'ungh://serde-rs/serde',
+      repoUrl: 'https://github.com/serde-rs/serde',
+      releasedAt: '2025-01-12T00:00:00Z',
+    })
+    vi.mocked(fetchLlmsUrl).mockResolvedValue('https://serde.rs/llms.txt')
+
+    const result = await resolveCrateDocsWithAttempts('serde')
+
+    expect(result.package).toMatchObject({
+      name: 'serde',
+      version: '1.0.220',
+      description: 'serde description',
+      docsUrl: 'https://docs.rs/serde/1.0.220',
+      readmeUrl: 'ungh://serde-rs/serde',
+      repoUrl: 'https://github.com/serde-rs/serde',
+      llmsUrl: 'https://serde.rs/llms.txt',
+    })
+    expect(result.attempts).toContainEqual({
+      source: 'github-meta',
+      url: 'https://github.com/serde-rs/serde',
+      status: 'success',
+      message: 'Enriched via GitHub repo metadata',
+    })
+    expect(result.attempts).toContainEqual({
+      source: 'llms.txt',
+      url: 'https://serde.rs/llms.txt',
+      status: 'success',
+    })
+  })
+
+  it('records github-meta not-found attempt when enrichment fails', async () => {
+    const { resolveGitHubRepo } = await import('../../src/sources/github')
+    const { fetchLlmsUrl } = await import('../../src/sources/llms')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        crate: {
+          name: 'serde',
+          max_version: '1.0.220',
+          repository: 'https://github.com/serde-rs/serde',
+        },
+        versions: [
+          { num: '1.0.220', yanked: false },
+        ],
+      }),
+    })
+
+    vi.mocked(resolveGitHubRepo).mockResolvedValue(null)
+    vi.mocked(fetchLlmsUrl).mockResolvedValue(null)
+
+    const result = await resolveCrateDocsWithAttempts('serde')
+
+    expect(result.attempts).toContainEqual({
+      source: 'github-meta',
+      url: 'https://github.com/serde-rs/serde',
+      status: 'not-found',
+      message: 'GitHub enrichment failed, using crates.io metadata',
+    })
+  })
+})

--- a/test/unit/sync-crate-routing.test.ts
+++ b/test/unit/sync-crate-routing.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/commands/sync-parallel', () => ({
+  syncPackagesParallel: vi.fn(),
+}))
+
+vi.mock('../../src/sources/index.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/sources/index')>()
+  return {
+    ...actual,
+    resolveCrateDocsWithAttempts: vi.fn().mockResolvedValue({
+      package: null,
+      attempts: [
+        {
+          source: 'crates',
+          status: 'not-found',
+          message: 'Crate not found on crates.io',
+        },
+      ],
+    }),
+  }
+})
+
+const { syncCommand, isCrateSpec } = await import('../../src/commands/sync')
+
+describe('commands/sync crate routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('detects crate spec prefix', () => {
+    expect(isCrateSpec('crate:serde')).toBe(true)
+    expect(isCrateSpec('serde')).toBe(false)
+    expect(isCrateSpec('crate')).toBe(false)
+  })
+
+  it('keeps npm batch on parallel path when mixed with crate specs', async () => {
+    const { syncPackagesParallel } = await import('../../src/commands/sync-parallel')
+
+    await syncCommand(
+      {
+        skills: [],
+        deps: new Map(),
+        missing: [],
+        outdated: [],
+        synced: [],
+        unmatched: [],
+        shipped: [],
+      },
+      {
+        packages: ['vue', 'nuxt', 'crate:'],
+        global: false,
+        agent: 'claude-code',
+        yes: true,
+      },
+    )
+
+    expect(vi.mocked(syncPackagesParallel)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(syncPackagesParallel)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packages: ['vue', 'nuxt'],
+      }),
+    )
+  })
+
+  it('routes valid crate spec through single-package path while keeping npm parallel', async () => {
+    const { syncPackagesParallel } = await import('../../src/commands/sync-parallel')
+    const { log } = await import('@clack/prompts')
+    const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => {})
+
+    await syncCommand(
+      {
+        skills: [],
+        deps: new Map(),
+        missing: [],
+        outdated: [],
+        synced: [],
+        unmatched: [],
+        shipped: [],
+      },
+      {
+        packages: ['vue', 'nuxt', 'crate:serde'],
+        global: false,
+        agent: 'claude-code',
+        yes: true,
+      },
+    )
+
+    expect(vi.mocked(syncPackagesParallel)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(syncPackagesParallel)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        packages: ['vue', 'nuxt'],
+      }),
+    )
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  it('does not invoke npm parallel sync when only crate specs are provided', async () => {
+    const { syncPackagesParallel } = await import('../../src/commands/sync-parallel')
+    const { log } = await import('@clack/prompts')
+    const errorSpy = vi.spyOn(log, 'error').mockImplementation(() => {})
+
+    await syncCommand(
+      {
+        skills: [],
+        deps: new Map(),
+        missing: [],
+        outdated: [],
+        synced: [],
+        unmatched: [],
+        shipped: [],
+      },
+      {
+        packages: ['crate:', 'crate:   '],
+        global: false,
+        agent: 'claude-code',
+        yes: true,
+      },
+    )
+
+    expect(vi.mocked(syncPackagesParallel)).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledTimes(2)
+    expect(errorSpy).toHaveBeenNthCalledWith(1, 'Invalid crate spec. Use format: crate:<name>')
+    expect(errorSpy).toHaveBeenNthCalledWith(2, 'Invalid crate spec. Use format: crate:<name>')
+  })
+})

--- a/test/unit/sync-crate-version.test.ts
+++ b/test/unit/sync-crate-version.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const stopAfterVersion = new Error('stop-after-version')
+const isCachedMock = vi.fn((_: string, __: string) => {
+  throw stopAfterVersion
+})
+
+vi.mock('../../src/cache/index.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/cache/index')>()
+  return {
+    ...actual,
+    isCached: isCachedMock,
+  }
+})
+
+vi.mock('../../src/sources/index.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/sources/index')>()
+  return {
+    ...actual,
+    resolvePackageDocsWithAttempts: vi.fn().mockResolvedValue({
+      package: {
+        name: 'tokio',
+        version: '2.0.0',
+        docsUrl: 'https://tokio.dev',
+      },
+      attempts: [
+        {
+          source: 'npm',
+          status: 'success',
+        },
+      ],
+    }),
+    resolveCrateDocsWithAttempts: vi.fn().mockResolvedValue({
+      package: {
+        name: 'serde',
+        version: '1.0.220',
+        docsUrl: 'https://docs.rs/serde/1.0.220',
+      },
+      attempts: [
+        {
+          source: 'crates',
+          status: 'success',
+        },
+      ],
+    }),
+  }
+})
+
+const { syncCommand } = await import('../../src/commands/sync')
+
+describe('commands/sync crate version selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('uses resolved crate version for cache checks when requested version falls back', async () => {
+    await expect(syncCommand(
+      {
+        skills: [],
+        deps: new Map(),
+        missing: [],
+        outdated: [],
+        synced: [],
+        unmatched: [],
+        shipped: [],
+      },
+      {
+        packages: ['crate:serde@1.0.200'],
+        global: false,
+        agent: 'claude-code',
+        yes: true,
+      },
+    )).rejects.toThrow(stopAfterVersion)
+
+    expect(isCachedMock).toHaveBeenCalledWith('@skilld-crate/serde', '1.0.220')
+  })
+
+  it('keeps npm package cache key unnamespaced for same-name package', async () => {
+    await expect(syncCommand(
+      {
+        skills: [],
+        deps: new Map(),
+        missing: [],
+        outdated: [],
+        synced: [],
+        unmatched: [],
+        shipped: [],
+      },
+      {
+        packages: ['tokio'],
+        global: false,
+        agent: 'claude-code',
+        yes: true,
+      },
+    )).rejects.toThrow(stopAfterVersion)
+
+    expect(isCachedMock).toHaveBeenCalledWith('tokio', '2.0.0')
+  })
+})


### PR DESCRIPTION
## Description
This PR adds Rust crate support to `skilld` with `crate:<name>` (e.g. `skilld add crate:serde`), while preserving existing npm/git behavior.

### What’s included:
- crates.io resolver implementation (`src/sources/crates.ts`)
- crate-aware sync routing (`src/commands/sync.ts`)
- mixed-batch support without degrading npm parallel sync
- npm/crate collision prevention via crate storage namespace (`@skilld-crate/<name>`) and crate identity (`crate:<name>`) in lock metadata
- shared fetch/rate-limit helper improvements in `src/sources/utils.ts`
- README updates for new usage examples

### Tests:
- `test/unit/sources-crates.test.ts`
- `test/unit/sync-crate-routing.test.ts`
- `test/unit/sync-crate-version.test.ts`
- `test/e2e/crate-smoke.test.ts`

### Validation:
- unit tests for crate paths pass
- crate e2e smoke test passes
- `pnpm typecheck` passes
- `pnpm build` passes

## Linked Issues
N/A

## Additional context
Please focus review on namespace separation and cache/identity consistency in `src/commands/sync.ts`.