### PR TITLE
fix(agent): prefer installed skilld command with fallback

### DIFF
--- a/src/agent/clis/codex.ts
+++ b/src/agent/clis/codex.ts
@@ -30,7 +30,7 @@ export function buildArgs(model: string, _skillDir: string, _symlinkDirs: string
     // Permissions aligned with Claude's scoped model:
     // --full-auto = --sandbox workspace-write + --ask-for-approval on-request
     //   → writes scoped to CWD (.skilld/, set in spawn), reads unrestricted, network blocked
-    // Shell remains enabled for `npx -y skilld search/validate` (no per-command allowlist in Codex)
+    // Shell remains enabled for `skilld` / `npx -y skilld` search/validate (no per-command allowlist in Codex)
     // --ephemeral → no session persistence (equivalent to Claude's --no-session-persistence)
     '--full-auto',
     '-',

--- a/src/agent/clis/gemini.ts
+++ b/src/agent/clis/gemini.ts
@@ -4,6 +4,7 @@
  */
 
 import type { CliModelEntry, ParsedEvent } from './types.ts'
+import { resolveSkilldCommand } from '../../core/shared.ts'
 
 export const cli = 'gemini' as const
 export const agentId = 'gemini-cli' as const
@@ -20,7 +21,7 @@ export function buildArgs(model: string, skillDir: string, symlinkDirs: string[]
     '-m',
     model,
     '--allowed-tools',
-    'read_file,write_file,glob_tool,list_directory,search_file_content,run_shell_command(npx -y skilld),run_shell_command(grep),run_shell_command(head)',
+    `read_file,write_file,glob_tool,list_directory,search_file_content,run_shell_command(${resolveSkilldCommand()}),run_shell_command(grep),run_shell_command(head)`,
     '--include-directories',
     skillDir,
     ...symlinkDirs.flatMap(d => ['--include-directories', d]),

--- a/src/agent/prompts/optional/api-changes.ts
+++ b/src/agent/prompts/optional/api-changes.ts
@@ -1,4 +1,5 @@
 import type { PromptSection, ReferenceWeight, SectionContext, SectionValidationWarning } from './types.ts'
+import { resolveSkilldCommand } from '../../../core/shared.ts'
 import { maxItems, maxLines, releaseBoost } from './budget.ts'
 import { checkAbsolutePaths, checkLineCount, checkSourceCoverage, checkSourcePaths, checkSparseness } from './validate.ts'
 
@@ -6,29 +7,29 @@ export function apiChangesSection({ packageName, version, hasReleases, hasChange
   const [, major, minor] = version?.match(/^(\d+)\.(\d+)/) ?? []
   const boost = releaseBoost(releaseCount, minor ? Number(minor) : undefined)
 
-  // Search hints for the task text (specific queries to run)
+  const cmd = resolveSkilldCommand()
   const searchHints: string[] = []
   if (features?.search !== false) {
     searchHints.push(
-      `\`npx -y skilld search "deprecated" -p ${packageName}\``,
-      `\`npx -y skilld search "breaking" -p ${packageName}\``,
+      `\`${cmd} search "deprecated" -p ${packageName}\``,
+      `\`${cmd} search "breaking" -p ${packageName}\``,
     )
     if (major && minor) {
       const minorNum = Number(minor)
       const majorNum = Number(major)
       if (minorNum <= 2) {
-        searchHints.push(`\`npx -y skilld search "v${majorNum}.${minorNum}" -p ${packageName}\``)
+        searchHints.push(`\`${cmd} search "v${majorNum}.${minorNum}" -p ${packageName}\``)
         if (minorNum > 0)
-          searchHints.push(`\`npx -y skilld search "v${majorNum}.${minorNum - 1}" -p ${packageName}\``)
+          searchHints.push(`\`${cmd} search "v${majorNum}.${minorNum - 1}" -p ${packageName}\``)
         if (majorNum > 0)
-          searchHints.push(`\`npx -y skilld search "v${majorNum - 1}" -p ${packageName}\``)
+          searchHints.push(`\`${cmd} search "v${majorNum - 1}" -p ${packageName}\``)
       }
       else {
-        searchHints.push(`\`npx -y skilld search "v${majorNum}.${minorNum}" -p ${packageName}\``)
-        searchHints.push(`\`npx -y skilld search "v${majorNum}.${minorNum - 1}" -p ${packageName}\``)
-        searchHints.push(`\`npx -y skilld search "v${majorNum}.${minorNum - 2}" -p ${packageName}\``)
+        searchHints.push(`\`${cmd} search "v${majorNum}.${minorNum}" -p ${packageName}\``)
+        searchHints.push(`\`${cmd} search "v${majorNum}.${minorNum - 1}" -p ${packageName}\``)
+        searchHints.push(`\`${cmd} search "v${majorNum}.${minorNum - 2}" -p ${packageName}\``)
       }
-      searchHints.push(`\`npx -y skilld search "Features" -p ${packageName}\``)
+      searchHints.push(`\`${cmd} search "Features" -p ${packageName}\``)
     }
   }
 

--- a/src/agent/prompts/optional/best-practices.ts
+++ b/src/agent/prompts/optional/best-practices.ts
@@ -1,4 +1,5 @@
 import type { PromptSection, ReferenceWeight, SectionContext, SectionValidationWarning } from './types.ts'
+import { resolveSkilldCommand } from '../../../core/shared.ts'
 import { maxItems, maxLines, releaseBoost } from './budget.ts'
 import { checkAbsolutePaths, checkLineCount, checkSourceCoverage, checkSourcePaths, checkSparseness } from './validate.ts'
 
@@ -7,11 +8,12 @@ export function bestPracticesSection({ packageName, hasIssues, hasDiscussions, h
   // Dampened boost — best practices are less directly tied to releases than API changes
   const rawBoost = releaseBoost(releaseCount, minor ? Number(minor) : undefined)
   const boost = 1 + (rawBoost - 1) * 0.5
+  const cmd = resolveSkilldCommand()
   const searchHints: string[] = []
   if (features?.search !== false) {
     searchHints.push(
-      `\`npx -y skilld search "recommended" -p ${packageName}\``,
-      `\`npx -y skilld search "avoid" -p ${packageName}\``,
+      `\`${cmd} search "recommended" -p ${packageName}\``,
+      `\`${cmd} search "avoid" -p ${packageName}\``,
     )
   }
 

--- a/src/agent/prompts/prompt.ts
+++ b/src/agent/prompts/prompt.ts
@@ -5,6 +5,7 @@
 import type { FeaturesConfig } from '../../core/config.ts'
 import type { CustomPrompt, PromptSection, SectionContext, SectionValidationWarning } from './optional/index.ts'
 import { dirname } from 'pathe'
+import { resolveSkilldCommand } from '../../core/shared.ts'
 import { getPackageRules } from '../../sources/package-registry.ts'
 import { apiChangesSection, bestPracticesSection, customSection } from './optional/index.ts'
 
@@ -115,14 +116,16 @@ function generateImportantBlock({ packageName, hasIssues, hasDiscussions, hasRel
     ...rows.map(([desc, cmd]) => `| ${desc} | ${cmd} |`),
   ].join('\n')
 
+  const cmd = resolveSkilldCommand()
+  const fallbackCmd = cmd === 'skilld' ? 'npx -y skilld' : 'skilld'
   const searchBlock = features?.search !== false
     ? `\n\n## Search
 
-Use \`npx -y skilld search\` as your primary research tool — search before manually reading files. Hybrid semantic + keyword search across all indexed docs, issues, and releases.
+Use \`${cmd} search\` as your primary research tool — search before manually reading files. If \`${cmd}\` is unavailable, use \`${fallbackCmd} search\`.
 
 \`\`\`bash
-npx -y skilld search "<query>" -p ${packageName}
-${hasIssues ? `npx -y skilld search "issues:<query>" -p ${packageName}\n` : ''}${hasReleases ? `npx -y skilld search "releases:<query>" -p ${packageName}\n` : ''}\`\`\`
+${cmd} search "<query>" -p ${packageName}
+${hasIssues ? `${cmd} search "issues:<query>" -p ${packageName}\n` : ''}${hasReleases ? `${cmd} search "releases:<query>" -p ${packageName}\n` : ''}\`\`\`
 
 Filters: \`docs:\`, \`issues:\`, \`releases:\` prefix narrows by source type.`
     : ''
@@ -216,6 +219,8 @@ export function buildSectionPrompt(opts: BuildSkillPromptOptions & { section: Sk
   const weightsTable = sectionDef.referenceWeights?.length
     ? `\n\n## Reference Priority\n\n| Reference | Path | Score | Use For |\n|-----------|------|:-----:|--------|\n${sectionDef.referenceWeights.map(w => `| ${w.name} | [\`${w.path.split('/').pop()}\`](${w.path}) | ${w.score}/10 | ${w.useFor} |`).join('\n')}`
     : ''
+  const cmd = resolveSkilldCommand()
+  const fallbackCmd = cmd === 'skilld' ? 'npx -y skilld' : 'skilld'
 
   return `${preamble}${weightsTable}
 
@@ -235,7 +240,7 @@ ${rules.join('\n')}
 
 Write your final output to the file \`${skillDir}/.skilld/${outputFile}\` using the Write tool. Do NOT write to any other file path.
 
-After writing, run \`npx -y skilld validate ${skillDir}/.skilld/${outputFile}\` and fix any warnings before finishing.
+After writing, run \`${cmd} validate ${skillDir}/.skilld/${outputFile}\` and fix any warnings before finishing. If unavailable, use \`${fallbackCmd} validate ${skillDir}/.skilld/${outputFile}\`.
 `
 }
 

--- a/src/agent/prompts/skill.ts
+++ b/src/agent/prompts/skill.ts
@@ -4,6 +4,7 @@
 
 import type { FeaturesConfig } from '../../core/config.ts'
 import { repairMarkdown, sanitizeMarkdown } from '../../core/sanitize.ts'
+import { resolveSkilldCommand } from '../../core/shared.ts'
 import { yamlEscape } from '../../core/yaml.ts'
 import { getFilePatterns } from '../../sources/package-registry.ts'
 import { computeSkillDirName } from '../install.ts'
@@ -245,17 +246,19 @@ function generateFrontmatter({ name, version, description: pkgDescription, globs
 }
 
 function generateSearchBlock(name: string, hasIssues?: boolean, hasReleases?: boolean): string {
+  const cmd = resolveSkilldCommand()
+  const fallbackCmd = cmd === 'skilld' ? 'npx -y skilld' : 'skilld'
   const examples = [
-    `npx -y skilld search "query" -p ${name}`,
+    `${cmd} search "query" -p ${name}`,
   ]
   if (hasIssues)
-    examples.push(`npx -y skilld search "issues:error handling" -p ${name}`)
+    examples.push(`${cmd} search "issues:error handling" -p ${name}`)
   if (hasReleases)
-    examples.push(`npx -y skilld search "releases:deprecated" -p ${name}`)
+    examples.push(`${cmd} search "releases:deprecated" -p ${name}`)
 
   return `## Search
 
-Use \`npx -y skilld search\` instead of grepping \`.skilld/\` directories — hybrid semantic + keyword search across all indexed docs, issues, and releases.
+Use \`${cmd} search\` instead of grepping \`.skilld/\` directories — hybrid semantic + keyword search across all indexed docs, issues, and releases. If \`${cmd}\` is unavailable, use \`${fallbackCmd} search\`.
 
 \`\`\`bash
 ${examples.join('\n')}

--- a/src/core/shared.ts
+++ b/src/core/shared.ts
@@ -1,6 +1,8 @@
+import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { join } from 'pathe'
 import { gt as _semverGt } from 'semver'
+import { isWindows } from 'std-env'
 
 /** Get-or-create for Maps. Polyfill for Map.getOrInsertComputed (not yet in Node.js). */
 export function mapInsert<K, V>(map: Map<K, V>, key: K, create: () => V): V {
@@ -15,6 +17,23 @@ export function mapInsert<K, V>(map: Map<K, V>, key: K, create: () => V): V {
 /** Compare two semver strings: returns true if a > b. Handles prereleases. */
 export function semverGt(a: string, b: string): boolean {
   return _semverGt(a, b, true)
+}
+
+let _skilldCommand: string | undefined
+
+/** Resolve the skilld CLI command — returns `skilld` if the binary is in PATH, otherwise `npx -y skilld` */
+export function resolveSkilldCommand(): string {
+  if (_skilldCommand !== undefined)
+    return _skilldCommand
+  try {
+    const lookup = isWindows ? 'where' : 'which'
+    execSync(`${lookup} skilld`, { stdio: 'ignore' })
+    _skilldCommand = 'skilld'
+  }
+  catch {
+    _skilldCommand = 'npx -y skilld'
+  }
+  return _skilldCommand
 }
 
 export const SHARED_SKILLS_DIR = '.skills'


### PR DESCRIPTION
## Description
This PR updates skilld command usage in generated prompts and agent CLI configuration to prefer a locally installed `skilld` binary when available, while keeping `npx -y skilld` as a fallback.

Previously, prompts and tool allowlists hardcoded `npx -y skilld`, even on systems where `skilld` was already installed and available in `PATH`.  

With this change, command resolution is centralized and reused across relevant prompt builders and tool configuration.

### What this solves:
- avoids unnecessary `npx` invocation when `skilld` is already installed
- keeps behavior safe and portable via explicit fallback
- makes command guidance in prompts consistent with runtime behavior

## Linked Issues
N/A

## Additional context
Key implementation details:
- added `resolveSkilldCommand()` in `src/core/shared.ts`
- replaced hardcoded `npx -y skilld` in prompt generation files and allowed-tools config
- clarified Codex CLI comment to reflect both command variants

### Validation run:
- `pnpm typecheck` ✅
- `pnpm test:run --project unit` ✅
