### PR TITLE
refactor(sources): deduplicate content utilities between issues and discussions

### DIFF
--- a/src/sources/discussions.ts
+++ b/src/sources/discussions.ts
@@ -6,7 +6,7 @@
 
 import { spawnSync } from 'node:child_process'
 import { mapInsert } from '../core/shared.ts'
-import { BOT_USERS, buildFrontmatter, isoDate } from './github-common.ts'
+import { BOT_USERS, buildFrontmatter, COMMENT_NOISE_RE, hasCodeBlock, isoDate, truncateBody } from './github-common.ts'
 import { isGhAvailable } from './issues.ts'
 
 /** Categories most useful for skill generation (in priority order) */
@@ -42,52 +42,6 @@ export interface GitHubDiscussion {
   isMaintainer?: boolean
   answer?: string
   topComments: DiscussionComment[]
-}
-
-/** Noise patterns in comments — filter these out */
-const COMMENT_NOISE_RE = /^(?:\+1|👍|same here|any update|bump|following|is there any progress|when will this|me too|i have the same|same issue|thanks|thank you)[\s!?.]*$/i
-
-/** Check if body contains a code block */
-function hasCodeBlock(text: string): boolean {
-  return /```[\s\S]*?```/.test(text) || /`[^`]+`/.test(text)
-}
-
-/**
- * Smart body truncation — preserves code blocks and error messages.
- * Instead of slicing at a char limit, finds a safe break point.
- */
-function truncateBody(body: string, limit: number): string {
-  if (body.length <= limit)
-    return body
-
-  // Find code block boundaries so we don't cut mid-block
-  const codeBlockRe = /```[\s\S]*?```/g
-  let lastSafeEnd = limit
-  let match: RegExpExecArray | null
-
-  // eslint-disable-next-line no-cond-assign
-  while ((match = codeBlockRe.exec(body)) !== null) {
-    const blockStart = match.index
-    const blockEnd = blockStart + match[0].length
-
-    if (blockStart < limit && blockEnd > limit) {
-      if (blockEnd <= limit + 500) {
-        lastSafeEnd = blockEnd
-      }
-      else {
-        lastSafeEnd = blockStart
-      }
-      break
-    }
-  }
-
-  // Try to break at a paragraph boundary
-  const slice = body.slice(0, lastSafeEnd)
-  const lastParagraph = slice.lastIndexOf('\n\n')
-  if (lastParagraph > lastSafeEnd * 0.6)
-    return `${slice.slice(0, lastParagraph)}\n\n...`
-
-  return `${slice}...`
 }
 
 /** Off-topic or spam title patterns — instant reject */

--- a/src/sources/github-common.ts
+++ b/src/sources/github-common.ts
@@ -27,6 +27,58 @@ export function buildFrontmatter(fields: Record<string, string | number | boolea
   return lines.join('\n')
 }
 
+// ── Content Processing ──
+
+/** Check if body contains a code block */
+export function hasCodeBlock(text: string): boolean {
+  return /```[\s\S]*?```/.test(text) || /`[^`]+`/.test(text)
+}
+
+/** Noise patterns in comments — filter these out */
+export const COMMENT_NOISE_RE = /^(?:\+1|👍|same here|any update|bump|following|is there any progress|when will this|me too|i have the same|same issue|thanks|thank you)[\s!?.]*$/i
+
+/**
+ * Smart body truncation — preserves code blocks and error messages.
+ * Instead of slicing at a char limit, finds a safe break point.
+ */
+export function truncateBody(body: string, limit: number): string {
+  if (body.length <= limit)
+    return body
+
+  // Find code block boundaries so we don't cut mid-block
+  const codeBlockRe = /```[\s\S]*?```/g
+  let lastSafeEnd = limit
+  let match: RegExpExecArray | null
+
+  // eslint-disable-next-line no-cond-assign
+  while ((match = codeBlockRe.exec(body)) !== null) {
+    const blockStart = match.index
+    const blockEnd = blockStart + match[0].length
+
+    // If the limit falls inside a code block, move limit to after the block
+    // (if not too far) or before the block
+    if (blockStart < limit && blockEnd > limit) {
+      if (blockEnd <= limit + 500) {
+        // Block ends reasonably close — include it
+        lastSafeEnd = blockEnd
+      }
+      else {
+        // Block is too long — cut before it
+        lastSafeEnd = blockStart
+      }
+      break
+    }
+  }
+
+  // Try to break at a paragraph boundary
+  const slice = body.slice(0, lastSafeEnd)
+  const lastParagraph = slice.lastIndexOf('\n\n')
+  if (lastParagraph > lastSafeEnd * 0.6)
+    return `${slice.slice(0, lastParagraph)}\n\n...`
+
+  return `${slice}...`
+}
+
 // ── GitHub Auth ──
 
 let _ghToken: string | null | undefined

--- a/src/sources/issues.ts
+++ b/src/sources/issues.ts
@@ -7,7 +7,7 @@
 import { spawnSync } from 'node:child_process'
 
 import { mapInsert } from '../core/shared.ts'
-import { BOT_USERS, buildFrontmatter, isoDate } from './github-common.ts'
+import { BOT_USERS, buildFrontmatter, COMMENT_NOISE_RE, hasCodeBlock, isoDate, truncateBody } from './github-common.ts'
 
 export type IssueType = 'bug' | 'question' | 'docs' | 'feature' | 'other'
 
@@ -142,11 +142,6 @@ function isNoiseIssue(issue: { labels: string[], title: string, body: string }):
   return false
 }
 
-/** Check if body contains a code block */
-function hasCodeBlock(text: string): boolean {
-  return /```[\s\S]*?```/.test(text) || /`[^`]+`/.test(text)
-}
-
 /**
  * Detect non-technical issues: fan mail, showcases, sentiment.
  * Short body + no code + high reactions = likely non-technical.
@@ -240,48 +235,6 @@ function bodyLimit(reactions: number): number {
 }
 
 /**
- * Smart body truncation — preserves code blocks and error messages.
- * Instead of slicing at a char limit, finds a safe break point.
- */
-function truncateBody(body: string, limit: number): string {
-  if (body.length <= limit)
-    return body
-
-  // Find code block boundaries so we don't cut mid-block
-  const codeBlockRe = /```[\s\S]*?```/g
-  let lastSafeEnd = limit
-  let match: RegExpExecArray | null
-
-  // eslint-disable-next-line no-cond-assign
-  while ((match = codeBlockRe.exec(body)) !== null) {
-    const blockStart = match.index
-    const blockEnd = blockStart + match[0].length
-
-    // If the limit falls inside a code block, move limit to after the block
-    // (if not too far) or before the block
-    if (blockStart < limit && blockEnd > limit) {
-      if (blockEnd <= limit + 500) {
-        // Block ends reasonably close — include it
-        lastSafeEnd = blockEnd
-      }
-      else {
-        // Block is too long — cut before it
-        lastSafeEnd = blockStart
-      }
-      break
-    }
-  }
-
-  // Try to break at a paragraph boundary
-  const slice = body.slice(0, lastSafeEnd)
-  const lastParagraph = slice.lastIndexOf('\n\n')
-  if (lastParagraph > lastSafeEnd * 0.6)
-    return `${slice.slice(0, lastParagraph)}\n\n...`
-
-  return `${slice}...`
-}
-
-/**
  * Fetch issues for a state using GitHub Search API sorted by reactions
  */
 function fetchIssuesByState(
@@ -357,9 +310,6 @@ function oneYearAgo(): string {
   d.setFullYear(d.getFullYear() - 1)
   return isoDate(d.toISOString())!
 }
-
-/** Noise patterns in comments — filter these out */
-const COMMENT_NOISE_RE = /^(?:\+1|👍|same here|any update|bump|following|is there any progress|when will this|me too|i have the same|same issue)[\s!?.]*$/i
 
 /**
  * Batch-fetch top comments for issues via GraphQL.


### PR DESCRIPTION
## Summary
- Extract `hasCodeBlock`, `COMMENT_NOISE_RE`, and `truncateBody` from both `issues.ts` and `discussions.ts` into the shared `github-common.ts` module
- These were identical implementations (~44 lines each) duplicated across both files
- The shared `COMMENT_NOISE_RE` uses the discussions variant which also filters `thanks`/`thank you` noise comments (minor improvement for issues)