### PR TITLE
fix(cache): parse scoped package names correctly in listCached

### DIFF
--- a/src/cache/storage.ts
+++ b/src/cache/storage.ts
@@ -306,8 +306,8 @@ export function listCached(): CachedPackage[] {
   return readdirSync(REFERENCES_DIR)
     .filter(name => name.includes('@'))
     .map((dir) => {
-      const [name, version] = dir.split('@')
-      return { name: name!, version: version!, dir: join(REFERENCES_DIR, dir) }
+      const atIdx = dir.lastIndexOf('@')
+      return { name: dir.slice(0, atIdx), version: dir.slice(atIdx + 1), dir: join(REFERENCES_DIR, dir) }
     })
 }
 

--- a/test/unit/cache-storage.test.ts
+++ b/test/unit/cache-storage.test.ts
@@ -96,6 +96,19 @@ describe('cache/storage', () => {
       expect(result[1]).toMatchObject({ name: 'nuxt', version: '3.10' })
     })
 
+    it('parses scoped package entries', async () => {
+      const { existsSync, readdirSync } = await import('node:fs')
+      const { listCached } = await import('../../src/cache/storage')
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(readdirSync).mockReturnValue(['@vue/reactivity@3.5.0', '@nuxtjs/tailwindcss@6.12.0'] as any)
+
+      const result = listCached()
+
+      expect(result).toHaveLength(2)
+      expect(result[0]).toMatchObject({ name: '@vue/reactivity', version: '3.5.0' })
+      expect(result[1]).toMatchObject({ name: '@nuxtjs/tailwindcss', version: '6.12.0' })
+    })
+
     it('filters entries without @', async () => {
       const { existsSync, readdirSync } = await import('node:fs')
       const { listCached } = await import('../../src/cache/storage')


### PR DESCRIPTION
`listCached()` splits cache directory names on `@` to extract package name and version. For scoped packages like `@vue/reactivity@3.5.0`, `split('@')` produces `['', 'vue/reactivity', '3.5.0']` - name ends up as empty string, version as `vue/reactivity`.

This means `clearAllCache` silently skips scoped packages (computes wrong cache path), and `skilld cache` shows corrupted entries for them.

Fix: `lastIndexOf('@')` to split on the version separator, not the scope prefix. Added a test covering scoped package parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cache storage parsing to properly extract package names and versions from scoped packages with multiple '@' characters, ensuring accurate handling of all namespaced package entries.

* **Tests**
  * Added test cases to verify correct parsing and extraction of scoped package information from the cache storage system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->