### PR TITLE
fix(sources): strip multi-char range operators in version fallback

### DIFF
--- a/src/sources/npm.ts
+++ b/src/sources/npm.ts
@@ -424,7 +424,7 @@ export function parseVersionSpecifier(
 
   // Fallback: strip semver prefix if it looks like one
   if (/^[\^~>=<\d]/.test(version))
-    return { name, version: version.replace(/^[\^~>=<]/, '') }
+    return { name, version: version.replace(/^[\^~>=<]+/, '') }
 
   // catalog: and workspace: specifiers - include with wildcard version
   // so the dep isn't silently dropped from state.deps

--- a/test/unit/sources-npm.test.ts
+++ b/test/unit/sources-npm.test.ts
@@ -91,6 +91,8 @@ describe('sources/npm', () => {
           'pkg-caret': '^1.0.0',
           'pkg-tilde': '~2.0.0',
           'pkg-exact': '4.0.0',
+          'pkg-gte': '>=1.5.0',
+          'pkg-lte': '<=3.0.0',
         },
       }))
       vi.mocked(resolvePathSync).mockImplementation(() => {
@@ -102,6 +104,8 @@ describe('sources/npm', () => {
       expect(deps).toContainEqual({ name: 'pkg-caret', version: '1.0.0' })
       expect(deps).toContainEqual({ name: 'pkg-tilde', version: '2.0.0' })
       expect(deps).toContainEqual({ name: 'pkg-exact', version: '4.0.0' })
+      expect(deps).toContainEqual({ name: 'pkg-gte', version: '1.5.0' })
+      expect(deps).toContainEqual({ name: 'pkg-lte', version: '3.0.0' })
     })
 
     it('throws if package.json not found', async () => {


### PR DESCRIPTION
`parseVersionSpecifier` has a fallback for when `resolveInstalledVersion` fails - it strips semver prefix chars and returns the bare version. The regex `/^[\^~>=<]/` only removes one character though, so `>=1.0.0` becomes `=1.0.0` instead of `1.0.0`. That invalid version then flows into `isOutdated` and `semverGt`, breaking version comparison for any dep using range operators.

One-char fix: `/^[\^~>=<]+/`. Added `>=` and `<=` cases to the existing fallback test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of version specifications with multiple leading operators (^, ~, >, =, <) for better handling of local dependency resolution.

* **Tests**
  * Added test coverage for additional version specification formats including >= and <= operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->