### PR TITLE
fix(sources): terminate version walk-up at filesystem root

### DIFF
--- a/src/sources/npm.ts
+++ b/src/sources/npm.ts
@@ -456,7 +456,10 @@ export function resolveInstalledVersion(name: string, cwd: string): string | nul
           const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
           return pkg.version || null
         }
-        dir = dirname(dir)
+        const parent = dirname(dir)
+        if (parent === dir)
+          break
+        dir = parent
       }
     }
     catch {}

--- a/test/unit/sources-npm.test.ts
+++ b/test/unit/sources-npm.test.ts
@@ -212,6 +212,19 @@ describe('sources/npm', () => {
 
       expect(resolveInstalledVersion('nonexistent', '/project')).toBeNull()
     })
+
+    it('terminates at filesystem root instead of looping forever', async () => {
+      const { resolvePathSync } = await import('mlly')
+      const { existsSync } = await import('node:fs')
+      // First call (package.json path) throws, triggering fallback walk-up
+      vi.mocked(resolvePathSync)
+        .mockImplementationOnce(() => { throw new Error('no exports') })
+        .mockReturnValueOnce('/some/deep/path/entry.js')
+      // No package.json exists anywhere in the tree
+      vi.mocked(existsSync).mockReturnValue(false)
+
+      expect(resolveInstalledVersion('pkg', '/some/deep/path')).toBeNull()
+    })
   })
 
   describe('fetchNpmPackage', () => {


### PR DESCRIPTION
`resolveInstalledVersion` fallback path walks up from a resolved entry point looking for `package.json`, stopping when it finds a `node_modules` directory. When there's no `node_modules` ancestor (symlinked packages, workspaces, pnpm virtual stores), `dirname('/')` keeps returning `'/'` forever and the loop never exits.

Added a root check - if `dirname(dir) === dir`, we've hit the filesystem root and bail out. Test included for the no-ancestor case.

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved npm package version resolution to safely terminate at filesystem root, preventing potential infinite or redundant directory traversal during package lookup.

* **Tests**
  * Added test coverage for npm package resolution behavior, specifically validating proper termination at filesystem root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->