### PR TITLE
feat: registry pivot foundations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,35 +20,44 @@ pnpm test -- --project e2e               # E2E tests only
 ### CLI Commands
 
 ```bash
-skilld                # Interactive menu
-skilld add vue nuxt   # Add skills for packages
-skilld update         # Update all outdated skills
-skilld update vue     # Update specific package
-skilld remove         # Remove installed skills
-skilld list           # List installed skills (one per line)
-skilld list --json    # List as JSON
-skilld info           # Show config, agents, features, per-package detail
-skilld config         # Change settings
-skilld install        # Restore references from lockfile
-skilld prepare        # Hook for package.json "prepare" (restore refs, sync shipped, report outdated)
-skilld uninstall      # Remove skilld data
-skilld search "query" # Search indexed docs
-skilld search "query" -p nuxt  # Search filtered by package
-skilld cache --clean     # Clean expired LLM cache entries
-skilld cache --stats     # Show cache disk usage breakdown
-skilld add owner/repo    # Add pre-authored skills from git repo
-skilld eject vue                    # Eject skill (portable, no symlinks)
-skilld eject vue --name vue         # Eject with custom skill dir name
-skilld eject vue --out ./dir/       # Eject to custom path
-skilld eject vue --from 2025-07-01  # Only releases/issues since date
-skilld author                       # Generate skill for npm publishing (monorepo-aware)
-skilld author -m haiku              # Author with specific LLM model
-skilld author -o ./custom/          # Author to custom output directory
+skilld                          # Interactive menu
+skilld add npm:vue npm:nuxt     # Install package skills from registry
+skilld add gh:owner/repo        # Install git skills from GitHub
+skilld add @curator             # Install all skills from a curator (coming soon)
+skilld add @curator/collection  # Install a specific collection (coming soon)
+skilld add vue                  # Bare names deprecated, resolves as npm:vue with warning
+skilld update                   # Update all outdated skills
+skilld update vue               # Update specific package
+skilld remove                   # Remove installed skills
+skilld list                     # List installed skills (one per line)
+skilld list --json              # List as JSON
+skilld info                     # Show config, agents, features, per-package detail
+skilld config                   # Change settings
+skilld install                  # Restore references from lockfile
+skilld prepare                  # Hook for package.json "prepare" (restore refs, sync shipped, report outdated)
+skilld uninstall                # Remove skilld data
+skilld search "query"           # Search indexed docs
+skilld search "query" -p nuxt   # Search filtered by package
+skilld cache --clean            # Clean expired LLM cache entries
+skilld cache --stats            # Show cache disk usage breakdown
+```
+
+### Author Commands (skill creation and publishing)
+
+```bash
+skilld author package               # Generate a package skill from docs (monorepo-aware)
+skilld author package -m haiku      # Author with specific LLM model
+skilld author package -o ./custom/  # Author to custom output directory
+skilld author publish               # Publish skill list to skilld.dev
+skilld author eject vue             # Eject skill (portable, no symlinks)
+skilld author eject vue --name vue  # Eject with custom skill dir name
+skilld author validate <file>       # Validate a skill section
+skilld author assemble [dir]        # Merge enhancement output into SKILL.md
 ```
 
 ## Architecture
 
-CLI tool that generates AI agent skills from NPM package documentation. Requires Node >= 22.6.0. Flow: `package name → resolve docs → cache references → generate SKILL.md → install to agent dirs`.
+CLI tool and curated registry for AI agent skills. Requires Node >= 22.6.0. Primary flow: `skilld add npm:<pkg>` → fetch curated skill from skilld.dev → install to agent dirs. Fallback: `skilld author package <pkg>` → resolve docs → cache references → generate SKILL.md.
 
 **Key directories:**
 - `~/.skilld/` - Global cache: `references/<pkg>@<version>/`, `llm-cache/`, `config.yaml`
@@ -61,7 +70,8 @@ CLI tool that generates AI agent skills from NPM package documentation. Requires
 - `src/sources/` - Doc fetching (npm registry, llms.txt, GitHub via ungh.cc)
 - `src/cache/` - Reference caching with symlinks to `~/.skilld/references/`
 - `src/retriv/` - Vector search with sqlite-vec + @huggingface/transformers embeddings
-- `src/core/` - Config (custom YAML parser), skills iteration, formatting, lockfile
+- `src/core/` - Config (custom YAML parser), skills iteration, formatting, lockfile, prefix parser
+- `src/registry/` - Registry client for skilld.dev API (curated skill fetching)
 
 **Doc resolution cascade (src/commands/sync.ts):**
 1. Package ships `skills/` directory → symlink directly (skills-npm convention)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ __Requires Node 22.6.0 or higher.__
 Or add a specific package directly:
 
 ```bash
-npx -y skilld add vue
+npx -y skilld add npm:vue
 ```
 
 If you need to re-configure skilld, just run `npx -y skilld config` to update your agent, model, or preferences.
@@ -59,10 +59,10 @@ If you need to re-configure skilld, just run `npx -y skilld config` to update yo
 **No agent CLI?** No problem - choose "No agent" when prompted. You get a base skill immediately, plus portable prompts you can run in any LLM:
 
 ```bash
-npx -y skilld add vue
+npx -y skilld add npm:vue
 # Choose "No agent" -> base skill + prompts exported
 # Paste prompts into ChatGPT/Claude web, save outputs, then:
-npx -y skilld assemble
+npx -y skilld author assemble
 ```
 
 ### Tips
@@ -143,8 +143,11 @@ Yes. Add `skilld prepare` to your prepare script. It restores references, auto-i
 # Interactive mode - auto-discover from package.json
 skilld
 
-# Add skills for specific package(s)
-skilld add vue nuxt pinia
+# Add skills for specific package(s) — npm: prefix for registry packages
+skilld add npm:vue npm:nuxt npm:pinia
+
+# Add a pre-authored skill from a GitHub repo
+skilld add gh:vercel-labs/agent-skills
 
 # Update outdated skills
 skilld update
@@ -156,13 +159,13 @@ skilld search "error" -p nuxt --filter '{"type":"issue"}'
 skilld search --guide -p nuxt
 
 # Target a specific agent
-skilld add react --agent cursor
+skilld add npm:react --agent cursor
 
 # Install globally to ~/.claude/skills
-skilld add zod --global
+skilld add npm:zod --global
 
 # Skip prompts
-skilld add drizzle-orm --yes
+skilld add npm:drizzle-orm --yes
 
 # Check skill info
 skilld info
@@ -180,8 +183,8 @@ skilld config
 | Command | Description |
 |---------|-------------|
 | `skilld` | Interactive wizard (first run) or status menu (existing skills) |
-| `skilld add <pkg...>` | Add skills for package(s), space or comma-separated |
-| `skilld update [pkg]` | Update outdated skills (all or specific) |
+| `skilld add <source...>` | Add skills. Sources: `npm:<pkg>`, `gh:<owner/repo>`, or bare names (deprecated) |
+| `skilld update [pkg]`   | Update outdated skills (all or specific) |
 | `skilld search [query]` | Search indexed docs (`-p` package, `--filter` JSON, `--limit`, `--guide`) |
 | `skilld list`           | List installed skills (`--json` for machine-readable output) |
 | `skilld info`           | Show skill info and config |
@@ -190,15 +193,18 @@ skilld config
 | `skilld remove`         | Remove installed skills |
 | `skilld uninstall`      | Remove all skilld data |
 | `skilld cache`          | Cache management (clean expired LLM cache entries) |
-| `skilld eject <pkg>`    | Eject skill as portable directory (no symlinks) |
-| `skilld assemble [dir]` | Merge LLM output files back into SKILL.md (auto-discovers) |
+| `skilld author package <pkg>`  | Generate a portable package skill from docs |
+| `skilld author publish` | Publish skills to skilld.dev |
+| `skilld author eject <pkg>`    | Eject skill as portable directory (no symlinks) |
+| `skilld author validate <file>`| Validate a skill section |
+| `skilld author assemble [dir]` | Merge LLM output files back into SKILL.md (auto-discovers) |
 
 ### Works Without an Agent CLI
 
 No Claude, Gemini, or Codex CLI? Choose "No agent" when prompted. You get a base skill immediately, plus portable prompts you can run in any LLM to enhance it:
 
 ```bash
-skilld add vue
+skilld add npm:vue
 # Choose "No agent" -> installs to .claude/skills/vue-skilld/
 
 # What you get:
@@ -208,23 +214,23 @@ skilld add vue
 
 # Run each PROMPT_*.md in ChatGPT/Claude web/any LLM
 # Save outputs as _BEST_PRACTICES.md, _API_CHANGES.md, then:
-skilld assemble
+skilld author assemble
 ```
 
-`skilld assemble` auto-discovers skills with pending output files. `skilld update` re-exports prompts for outdated packages.
+`skilld author assemble` auto-discovers skills with pending output files. `skilld update` re-exports prompts for outdated packages.
 
 ### Eject
 
 Export a skill as a portable, self-contained directory for sharing via git repos:
 
 ```bash
-skilld eject vue                    # Default skill directory
-skilld eject vue --name vue         # Custom directory name
-skilld eject vue --out ./skills/    # Custom path
-skilld eject vue --from 2025-07-01  # Only recent releases/issues
+skilld author eject vue                    # Default skill directory
+skilld author eject vue --name vue         # Custom directory name
+skilld author eject vue --out ./skills/    # Custom path
+skilld author eject vue --from 2025-07-01  # Only recent releases/issues
 ```
 
-Share via `skilld add owner/repo` - consumers get fully functional skills with no LLM cost.
+Share via `skilld add gh:owner/repo` - consumers get fully functional skills with no LLM cost.
 
 ### CLI Options
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,9 +149,29 @@ async function brandLoader<T>(work: () => Promise<T>, minMs = 1500): Promise<T> 
   return result
 }
 
+// ── Deprecation forwarder ──
+
+function deprecatedForwarder(
+  oldName: string,
+  newName: string,
+  loader: () => Promise<any>,
+): () => Promise<any> {
+  return () => loader().then((cmd: any) => {
+    const original = cmd.run
+    return defineCommand({
+      ...cmd,
+      meta: { ...cmd.meta, name: oldName },
+      async run(ctx: any) {
+        console.warn(`\x1B[33m⚠ \`skilld ${oldName}\` is deprecated. Use \`skilld ${newName}\` instead.\x1B[0m`)
+        return original(ctx)
+      },
+    })
+  })
+}
+
 // ── Subcommands (lazy-loaded) ──
 
-const SUBCOMMAND_NAMES = ['add', 'eject', 'update', 'info', 'list', 'config', 'remove', 'install', 'uninstall', 'search', 'cache', 'validate', 'assemble', 'setup', 'prepare', 'author', 'publish']
+const SUBCOMMAND_NAMES = ['add', 'eject', 'update', 'info', 'list', 'config', 'remove', 'install', 'uninstall', 'search', 'cache', 'validate', 'assemble', 'setup', 'prepare', 'author', 'publish', 'upload']
 
 // ── Main command ──
 
@@ -159,14 +179,13 @@ const main = defineCommand({
   meta: {
     name: 'skilld',
     version,
-    description: 'Sync package documentation for agentic use',
+    description: 'Curated agent skills for your projects',
   },
   args: {
     agent: sharedArgs.agent,
   },
   subCommands: {
     add: () => import('./commands/sync.ts').then(m => m.addCommandDef),
-    eject: () => import('./commands/sync.ts').then(m => m.ejectCommandDef),
     update: () => import('./commands/sync.ts').then(m => m.updateCommandDef),
     info: () => infoCommandDef,
     list: () => import('./commands/list.ts').then(m => m.listCommandDef),
@@ -177,11 +196,15 @@ const main = defineCommand({
     uninstall: () => import('./commands/uninstall.ts').then(m => m.uninstallCommandDef),
     search: () => import('./commands/search.ts').then(m => m.searchCommandDef),
     cache: () => import('./commands/cache.ts').then(m => m.cacheCommandDef),
-    validate: () => import('./commands/validate.ts').then(m => m.validateCommandDef),
-    assemble: () => import('./commands/assemble.ts').then(m => m.assembleCommandDef),
     setup: () => import('./commands/setup.ts').then(m => m.setupCommandDef),
-    author: () => import('./commands/author.ts').then(m => m.authorCommandDef),
-    publish: () => import('./commands/author.ts').then(m => m.authorCommandDef),
+    // Author group (nested subcommands)
+    author: () => import('./commands/author-group.ts').then(m => m.authorGroupDef),
+    // Deprecated forwarders (old top-level commands → skilld author <subcommand>)
+    eject: deprecatedForwarder('eject', 'author eject', () => import('./commands/sync.ts').then(m => m.ejectCommandDef)),
+    validate: deprecatedForwarder('validate', 'author validate', () => import('./commands/validate.ts').then(m => m.validateCommandDef)),
+    assemble: deprecatedForwarder('assemble', 'author assemble', () => import('./commands/assemble.ts').then(m => m.assembleCommandDef)),
+    publish: deprecatedForwarder('publish', 'author publish', () => import('./commands/author.ts').then(m => m.authorCommandDef)),
+    upload: deprecatedForwarder('upload', 'author publish', () => import('./commands/upload.ts').then(m => m.uploadCommandDef)),
   },
   async run({ args }) {
     // Guard: citty always calls parent run() after subcommand dispatch.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,7 +203,7 @@ const main = defineCommand({
     eject: deprecatedForwarder('eject', 'author eject', () => import('./commands/sync.ts').then(m => m.ejectCommandDef)),
     validate: deprecatedForwarder('validate', 'author validate', () => import('./commands/validate.ts').then(m => m.validateCommandDef)),
     assemble: deprecatedForwarder('assemble', 'author assemble', () => import('./commands/assemble.ts').then(m => m.assembleCommandDef)),
-    publish: deprecatedForwarder('publish', 'author publish', () => import('./commands/author.ts').then(m => m.authorCommandDef)),
+    publish: deprecatedForwarder('publish', 'author publish', () => import('./commands/upload.ts').then(m => m.uploadCommandDef)),
     upload: deprecatedForwarder('upload', 'author publish', () => import('./commands/upload.ts').then(m => m.uploadCommandDef)),
   },
   async run({ args }) {

--- a/src/commands/author-group.ts
+++ b/src/commands/author-group.ts
@@ -1,0 +1,12 @@
+import { defineCommand } from 'citty'
+
+export const authorGroupDef = defineCommand({
+  meta: { name: 'author', description: 'Create, generate, and publish skills' },
+  subCommands: {
+    package: () => import('./author.ts').then(m => m.authorCommandDef),
+    publish: () => import('./upload.ts').then(m => m.uploadCommandDef),
+    eject: () => import('./sync.ts').then(m => m.ejectCommandDef),
+    validate: () => import('./validate.ts').then(m => m.validateCommandDef),
+    assemble: () => import('./assemble.ts').then(m => m.assembleCommandDef),
+  },
+})

--- a/src/commands/author.ts
+++ b/src/commands/author.ts
@@ -637,7 +637,7 @@ function printConsumerGuidance(packageNames: string[]): void {
 }
 
 export const authorCommandDef = defineCommand({
-  meta: { name: 'author', description: 'Generate portable skill for npm publishing' },
+  meta: { name: 'package', description: 'Generate a package skill from documentation' },
   args: {
     out: {
       type: 'string',

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -7,6 +7,7 @@ import { unlinkSkillFromAgents } from '../agent/index.ts'
 import { getInstalledGenerators, introLine, isInteractive, promptForAgent, resolveAgent, sharedArgs } from '../cli-helpers.ts'
 import { readConfig } from '../core/config.ts'
 import { removeLockEntry } from '../core/lockfile.ts'
+import { resolveSkillName } from '../core/prefix.ts'
 import { getSharedSkillsDir } from '../core/shared.ts'
 import { getProjectState, getSkillsDir, iterateSkills } from '../core/skills.ts'
 
@@ -128,9 +129,22 @@ export const removeCommandDef = defineCommand({
     const intro = { state, generators, modelId: config.model, agentId: agent || config.agent || undefined }
     p.intro(`${introLine(intro)} · remove (${scope})`)
 
-    // Collect packages from positional args
+    // Collect packages from positional args (strip npm:/gh: prefixes)
     const packages = args.package
-      ? [...new Set([args.package, ...((args as any)._ || [])].map((s: string) => s.trim()).filter(Boolean))]
+      ? [...new Set(
+          [args.package, ...((args as any)._ || [])]
+            .map((s: string) => s.trim())
+            .filter(Boolean)
+            .map((s) => {
+              const name = resolveSkillName(s)
+              if (!name) {
+                p.log.warn(`Cannot remove \x1B[36m${s}\x1B[0m: curator/collection inputs are not addressable here.`)
+                return null
+              }
+              return name
+            })
+            .filter((s): s is string => s !== null),
+        )]
       : undefined
 
     return removeCommand(state, {

--- a/src/commands/sync-registry.ts
+++ b/src/commands/sync-registry.ts
@@ -45,7 +45,7 @@ export async function syncRegistrySkill(opts: SyncRegistryOptions): Promise<Regi
   mkdirSync(baseDir, { recursive: true })
   writeLock(baseDir, skill.name, {
     packageName: skill.packageName,
-    version: skill.version,
+    version: skill.updatedAt,
     repo: skill.repo,
     source: 'registry',
     syncedAt: new Date().toISOString().slice(0, 10),

--- a/src/commands/sync-registry.ts
+++ b/src/commands/sync-registry.ts
@@ -1,0 +1,59 @@
+/**
+ * Registry-based skill installation
+ *
+ * Simplified install flow for curated skills from skilld.dev:
+ * fetch SKILL.md → write to disk → update lockfile → link to agents.
+ *
+ * No doc resolution, no LLM, no caching. Fast path.
+ */
+
+import type { AgentType } from '../agent/index.ts'
+import type { RegistrySkill } from '../registry/client.ts'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { join } from 'pathe'
+import { linkSkillToAgents } from '../agent/install.ts'
+import { writeLock } from '../core/lockfile.ts'
+import { SHARED_SKILLS_DIR } from '../core/shared.ts'
+import { fetchRegistrySkill } from '../registry/client.ts'
+
+export interface SyncRegistryOptions {
+  packageName: string
+  agent: AgentType
+  global?: boolean
+  cwd?: string
+}
+
+/**
+ * Install a package skill from the skilld.dev registry.
+ * Returns the installed skill, or null if no curated skill exists.
+ */
+export async function syncRegistrySkill(opts: SyncRegistryOptions): Promise<RegistrySkill | null> {
+  const { packageName, agent, cwd = process.cwd() } = opts
+
+  const skill = await fetchRegistrySkill(packageName)
+  if (!skill)
+    return null
+
+  // Write SKILL.md to shared skills dir
+  const sharedDir = join(cwd, SHARED_SKILLS_DIR)
+  const skillDir = join(sharedDir, skill.name)
+  mkdirSync(skillDir, { recursive: true })
+  writeFileSync(join(skillDir, 'SKILL.md'), skill.content)
+
+  // Update lockfile
+  const baseDir = join(cwd, '.claude', 'skills')
+  mkdirSync(baseDir, { recursive: true })
+  writeLock(baseDir, skill.name, {
+    packageName: skill.packageName,
+    version: skill.version,
+    repo: skill.repo,
+    source: 'registry',
+    syncedAt: new Date().toISOString().slice(0, 10),
+    generator: 'curator',
+  })
+
+  // Link to agent skill directories
+  linkSkillToAgents(skill.name, skillDir, cwd, agent)
+
+  return skill
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -38,7 +38,7 @@ import { defaultFeatures, hasCompletedWizard, readConfig, registerProject } from
 import { timedSpinner } from '../core/formatting.ts'
 import { parsePackages, readLock, removeLockEntry, writeLock } from '../core/lockfile.ts'
 import { parseFrontmatter } from '../core/markdown.ts'
-import { parseSkillInput } from '../core/prefix.ts'
+import { parseSkillInput, resolveSkillName } from '../core/prefix.ts'
 import { getSharedSkillsDir, SHARED_SKILLS_DIR } from '../core/shared.ts'
 import { getProjectState } from '../core/skills.ts'
 import { shutdownWorker } from '../retriv/pool.ts'
@@ -788,6 +788,7 @@ export const addCommandDef = defineCommand({
     const parsedSources = rawInputs.map(parseSkillInput)
     const gitSources: GitSkillSource[] = []
     const npmEntries: Array<{ name: string, spec: string }> = []
+    const unsupported: string[] = []
 
     for (const source of parsedSources) {
       switch (source.type) {
@@ -802,12 +803,23 @@ export const addCommandDef = defineCommand({
           npmEntries.push({ name: source.package, spec: source.tag ? `${source.package}@${source.tag}` : source.package })
           break
         case 'curator':
-          p.log.warn(`Curator installs (\x1B[36m@${source.handle}\x1B[0m) are not yet available.`)
+          unsupported.push(`@${source.handle} (curator)`)
           break
         case 'collection':
-          p.log.warn(`Collection installs (\x1B[36m@${source.handle}/${source.name}\x1B[0m) are not yet available.`)
+          unsupported.push(`@${source.handle}/${source.name} (collection)`)
           break
+        default: {
+          const _exhaustive: never = source
+          throw new Error(`Unhandled SkillSource type: ${JSON.stringify(_exhaustive)}`)
+        }
       }
+    }
+
+    if (unsupported.length > 0) {
+      p.log.error(`Curator and collection installs are not yet available:\n  ${unsupported.join('\n  ')}\n\nFollow https://skilld.dev for launch updates.`)
+      process.exitCode = 1
+      if (gitSources.length === 0 && npmEntries.length === 0)
+        return
     }
 
     // Handle git sources
@@ -960,7 +972,10 @@ export const updateCommandDef = defineCommand({
     if (agent === 'none') {
       const state = await getProjectState(cwd)
       const packages = args.package
-        ? [...new Set([args.package, ...((args as any)._ || [])].flatMap(s => s.split(/[,\s]+/)).map(s => s.trim()).filter(Boolean))]
+        ? Array.from(
+            new Set([args.package, ...((args as any)._ || [])].flatMap(s => s.split(/[,\s]+/)).map(s => s.trim()).filter(Boolean)),
+            s => resolveSkillName(s),
+          ).filter((s): s is string => s !== null)
         : state.outdated.map(s => s.packageName || s.name)
       if (packages.length === 0) {
         if (!silent)
@@ -980,9 +995,20 @@ export const updateCommandDef = defineCommand({
       p.intro(introLine({ state, generators, modelId: config.model, agentId: config.agent || agent || undefined }))
     }
 
-    // Specific packages
+    // Specific packages (strip npm:/gh: prefixes)
     if (args.package) {
-      const packages = [...new Set([args.package, ...((args as any)._ || [])].flatMap(s => s.split(/[,\s]+/)).map(s => s.trim()).filter(Boolean))]
+      const raw = [...new Set([args.package, ...((args as any)._ || [])].flatMap(s => s.split(/[,\s]+/)).map(s => s.trim()).filter(Boolean))]
+      const packages: string[] = []
+      for (const r of raw) {
+        const name = resolveSkillName(r)
+        if (!name) {
+          p.log.warn(`Cannot update \x1B[36m${r}\x1B[0m: curator/collection inputs are not addressable here.`)
+          continue
+        }
+        packages.push(name)
+      }
+      if (packages.length === 0)
+        return
       return syncCommand(state, {
         packages,
         global: args.global,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -846,7 +846,7 @@ export const addCommandDef = defineCommand({
       for (const entry of dedupedEntries) {
         const result = await syncRegistrySkill({ packageName: entry.name, agent, cwd })
         if (result) {
-          p.log.success(`Installed \x1B[36m${result.name}\x1B[0m (${result.version}) from registry`)
+          p.log.success(`Installed \x1B[36m${result.name}\x1B[0m from registry`)
         }
         else {
           fallbackPackages.push(entry.spec)

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -38,10 +38,10 @@ import { defaultFeatures, hasCompletedWizard, readConfig, registerProject } from
 import { timedSpinner } from '../core/formatting.ts'
 import { parsePackages, readLock, removeLockEntry, writeLock } from '../core/lockfile.ts'
 import { parseFrontmatter } from '../core/markdown.ts'
+import { parseSkillInput } from '../core/prefix.ts'
 import { getSharedSkillsDir, SHARED_SKILLS_DIR } from '../core/shared.ts'
 import { getProjectState } from '../core/skills.ts'
 import { shutdownWorker } from '../retriv/pool.ts'
-import { parseGitSkillInput } from '../sources/git-skills.ts'
 import {
   fetchPkgDist,
   isPrerelease,
@@ -741,7 +741,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 // ── Citty command definitions (lazy-loaded by cli.ts) ──
 
 export const addCommandDef = defineCommand({
-  meta: { name: 'add', description: 'Add skills for package(s)' },
+  meta: { name: 'add', description: 'Install skills (npm:<pkg>, gh:<owner/repo>, @<curator>)' },
   args: {
     package: {
       type: 'positional',
@@ -784,16 +784,30 @@ export const addCommandDef = defineCommand({
     if (!hasCompletedWizard())
       await runWizard({ agent })
 
-    // Partition: git sources vs npm packages
+    // Classify inputs via prefix parser
+    const parsedSources = rawInputs.map(parseSkillInput)
     const gitSources: GitSkillSource[] = []
-    const npmTokens: string[] = []
+    const npmEntries: Array<{ name: string, spec: string }> = []
 
-    for (const input of rawInputs) {
-      const git = parseGitSkillInput(input)
-      if (git)
-        gitSources.push(git)
-      else
-        npmTokens.push(input)
+    for (const source of parsedSources) {
+      switch (source.type) {
+        case 'git':
+          gitSources.push(source.source)
+          break
+        case 'npm':
+          npmEntries.push({ name: source.package, spec: source.tag ? `${source.package}@${source.tag}` : source.package })
+          break
+        case 'bare':
+          p.log.warn(`Bare names are deprecated. Use \x1B[36mnpm:${source.package}\x1B[0m instead.`)
+          npmEntries.push({ name: source.package, spec: source.tag ? `${source.package}@${source.tag}` : source.package })
+          break
+        case 'curator':
+          p.log.warn(`Curator installs (\x1B[36m@${source.handle}\x1B[0m) are not yet available.`)
+          break
+        case 'collection':
+          p.log.warn(`Collection installs (\x1B[36m@${source.handle}/${source.name}\x1B[0m) are not yet available.`)
+          break
+      }
     }
 
     // Handle git sources
@@ -804,20 +818,43 @@ export const addCommandDef = defineCommand({
       }
     }
 
-    // Handle npm packages via existing flow
-    if (npmTokens.length > 0) {
-      const packages = [...new Set(npmTokens.flatMap(s => s.split(/[,\s]+/)).map(s => s.trim()).filter(Boolean))]
-      const state = await getProjectState(cwd)
-      p.intro(introLine({ state, agentId: agent || undefined }))
-      return syncCommand(state, {
-        packages,
-        global: args.global,
-        agent,
-        model: args.model as OptimizeModel | undefined,
-        yes: args.yes,
-        force: args.force,
-        debug: args.debug,
+    // Handle npm packages: registry first, then fallback to doc generation
+    if (npmEntries.length > 0) {
+      const { syncRegistrySkill } = await import('./sync-registry.ts')
+      const seen = new Set<string>()
+      const dedupedEntries = npmEntries.filter((e) => {
+        if (seen.has(e.name))
+          return false
+        seen.add(e.name)
+        return true
       })
+
+      // Try registry for each package, collect misses for fallback
+      const fallbackPackages: string[] = []
+      for (const entry of dedupedEntries) {
+        const result = await syncRegistrySkill({ packageName: entry.name, agent, cwd })
+        if (result) {
+          p.log.success(`Installed \x1B[36m${result.name}\x1B[0m (${result.version}) from registry`)
+        }
+        else {
+          fallbackPackages.push(entry.spec)
+        }
+      }
+
+      // Fallback: generate from docs for packages not in registry
+      if (fallbackPackages.length > 0) {
+        const state = await getProjectState(cwd)
+        p.intro(introLine({ state, agentId: agent || undefined }))
+        return syncCommand(state, {
+          packages: fallbackPackages,
+          global: args.global,
+          agent,
+          model: args.model as OptimizeModel | undefined,
+          yes: args.yes,
+          force: args.force,
+          debug: args.debug,
+        })
+      }
     }
   },
 })

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -50,7 +50,7 @@ function readSkillsFromDir(dir: string, source: 'local' | 'global', extraLockDir
     skills.push({
       name: fm.name || dirName,
       description: fm.description,
-      version: fm.metadata?.version || fm.version || lockInfo?.version,
+      version: fm.version || lockInfo?.version,
       repo: lockInfo?.repo,
       generator: lockInfo?.generator,
       source,
@@ -147,7 +147,7 @@ export async function uploadCommand(options?: { dryRun?: boolean }): Promise<voi
     process.stdout.write(`Found ${colorize('bold', String(skills.length))} skill${skills.length === 1 ? '' : 's'}:\n\n`)
     for (const skill of skills) {
       const version = skill.version ? colorize('dim', ` v${skill.version}`) : ''
-      const tag = colorize(SOURCE_COLORS[skill.source] || 'dim', skill.source)
+      const tag = colorize((SOURCE_COLORS[skill.source] || 'dim') as 'dim', skill.source)
       const repo = skill.repo ? colorize('dim', ` github.com/${skill.repo}`) : ''
       process.stdout.write(`  ${colorize('cyan', skill.name)}${version} ${tag}${repo}\n`)
     }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -1,0 +1,211 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { multiselect } from '@clack/prompts'
+import { defineCommand } from 'citty'
+import { colorize } from 'consola/utils'
+import { ofetch } from 'ofetch'
+import { join } from 'pathe'
+import { readLock } from '../core/lockfile.ts'
+import { parseFrontmatter } from '../core/markdown.ts'
+
+const UPLOAD_URL = 'https://skilld.dev/api/collections/import'
+
+interface DiscoveredSkill {
+  name: string
+  description?: string
+  version?: string
+  repo?: string
+  generator?: string
+  source: 'local' | 'global' | 'plugin'
+}
+
+function readSkillsFromDir(dir: string, source: 'local' | 'global', extraLockDirs?: string[]): DiscoveredSkill[] {
+  if (!existsSync(dir))
+    return []
+
+  // Merge lockfiles: primary dir + any extra dirs (e.g. ~/.skilld/skills/ for global)
+  let lock = readLock(dir)
+  if (!lock && extraLockDirs) {
+    for (const d of extraLockDirs) {
+      lock = readLock(d)
+      if (lock)
+        break
+    }
+  }
+  const entries = readdirSync(dir).filter((f) => {
+    if (f.startsWith('.') || f.endsWith('.yaml') || f.endsWith('.yml'))
+      return false
+    const full = join(dir, f)
+    return statSync(full).isDirectory()
+  })
+
+  const skills: DiscoveredSkill[] = []
+  for (const dirName of entries) {
+    const skillMd = join(dir, dirName, 'SKILL.md')
+    if (!existsSync(skillMd))
+      continue
+    const content = readFileSync(skillMd, 'utf-8')
+    const fm = parseFrontmatter(content)
+    const lockInfo = lock?.skills[dirName]
+    skills.push({
+      name: fm.name || dirName,
+      description: fm.description,
+      version: fm.metadata?.version || fm.version || lockInfo?.version,
+      repo: lockInfo?.repo,
+      generator: lockInfo?.generator,
+      source,
+    })
+  }
+
+  return skills
+}
+
+interface MarketplaceInfo {
+  source: { source: string, repo: string }
+}
+
+function readPlugins(configDir: string): DiscoveredSkill[] {
+  const settingsPath = join(configDir, 'settings.json')
+  if (!existsSync(settingsPath))
+    return []
+
+  const settings = JSON.parse(readFileSync(settingsPath, 'utf-8'))
+  const enabledPlugins = settings.enabledPlugins as Record<string, boolean> | undefined
+  if (!enabledPlugins)
+    return []
+
+  // Load marketplace repos for GitHub links
+  const marketplacesPath = join(configDir, 'plugins', 'known_marketplaces.json')
+  const marketplaces: Record<string, MarketplaceInfo> = existsSync(marketplacesPath)
+    ? JSON.parse(readFileSync(marketplacesPath, 'utf-8'))
+    : {}
+
+  // Load installed plugins for version info
+  const installedPath = join(configDir, 'plugins', 'installed_plugins.json')
+  const installed: { plugins: Record<string, Array<{ version?: string }>> } = existsSync(installedPath)
+    ? JSON.parse(readFileSync(installedPath, 'utf-8'))
+    : { plugins: {} }
+
+  return Object.entries(enabledPlugins)
+    .filter(([, enabled]) => enabled)
+    .map(([id]) => {
+      const marketplace = id.split('@')[1]
+      const pluginName = id.split('@')[0]
+      const marketplaceInfo = marketplace ? marketplaces[marketplace] : undefined
+      const repo = marketplaceInfo?.source?.repo
+      const versions = installed.plugins[id]
+      const version = versions?.[0]?.version !== 'unknown' ? versions?.[0]?.version : undefined
+
+      return {
+        name: pluginName!,
+        version,
+        repo: repo ? `${repo}` : undefined,
+        source: 'plugin' as const,
+      }
+    })
+}
+
+function discoverAllSkills(cwd: string): DiscoveredSkill[] {
+  const claudeHome = process.env.CLAUDE_CONFIG_DIR || join(homedir(), '.claude')
+  const localDir = join(cwd, '.claude', 'skills')
+  const globalDir = join(claudeHome, 'skills')
+
+  const skilldGlobalDir = join(homedir(), '.skilld', 'skills')
+  const local = readSkillsFromDir(localDir, 'local')
+  const global = readSkillsFromDir(globalDir, 'global', [skilldGlobalDir])
+  const plugins = readPlugins(claudeHome)
+
+  // Filter out skilld-generated skills, deduplicate by repo
+  const seenRepos = new Set<string>()
+  const all: DiscoveredSkill[] = []
+  for (const skill of [...local, ...global, ...plugins]) {
+    if (!skill.repo || seenRepos.has(skill.repo))
+      continue
+    if (skill.generator === 'skilld')
+      continue
+    seenRepos.add(skill.repo)
+    all.push(skill)
+  }
+  return all
+}
+
+const SOURCE_COLORS: Record<string, string> = {
+  local: 'green',
+  global: 'blue',
+  plugin: 'magenta',
+}
+
+export async function uploadCommand(options?: { dryRun?: boolean }): Promise<void> {
+  const skills = discoverAllSkills(process.cwd())
+
+  if (skills.length === 0) {
+    process.stdout.write('No skills found.\n')
+    return
+  }
+
+  if (options?.dryRun) {
+    process.stdout.write(`Found ${colorize('bold', String(skills.length))} skill${skills.length === 1 ? '' : 's'}:\n\n`)
+    for (const skill of skills) {
+      const version = skill.version ? colorize('dim', ` v${skill.version}`) : ''
+      const tag = colorize(SOURCE_COLORS[skill.source] || 'dim', skill.source)
+      const repo = skill.repo ? colorize('dim', ` github.com/${skill.repo}`) : ''
+      process.stdout.write(`  ${colorize('cyan', skill.name)}${version} ${tag}${repo}\n`)
+    }
+    process.stdout.write(`\n${colorize('dim', 'Dry run complete. No requests were made.')}\n`)
+    return
+  }
+
+  const selected = await multiselect({
+    message: `Select skills to upload (${skills.length} found)`,
+    options: skills.map((s) => {
+      const version = s.version ? ` v${s.version}` : ''
+      const repo = s.repo ? ` github.com/${s.repo}` : ''
+      return {
+        value: s.name,
+        label: `${s.name}${version}`,
+        hint: `${s.source}${repo}`,
+      }
+    }),
+    initialValues: [],
+  })
+
+  if (typeof selected === 'symbol' || selected.length === 0)
+    return
+
+  const selectedSet = new Set(selected)
+  const payload = skills
+    .filter(s => selectedSet.has(s.name))
+    .map(s => ({
+      name: s.name,
+      version: s.version,
+      repo: s.repo,
+      source: s.source,
+    }))
+
+  const { token, expires } = await ofetch<{ token: string, expires: string }>(UPLOAD_URL, {
+    method: 'POST',
+    body: { skills: payload },
+  })
+
+  const expiresDate = new Date(expires)
+  const minutesLeft = Math.round((expiresDate.getTime() - Date.now()) / 60000)
+
+  process.stdout.write(`\nToken: ${colorize('green', token)}\n\n`)
+  process.stdout.write(`Paste this token at: ${colorize('cyan', 'https://skilld.dev/people/YOUR_HANDLE/edit-skills')}\n`)
+  process.stdout.write(colorize('dim', `Token expires in ${minutesLeft} minutes.\n`))
+}
+
+export const uploadCommandDef = defineCommand({
+  meta: { name: 'publish', description: 'Publish your skill list to skilld.dev' },
+  args: {
+    dryRun: {
+      type: 'boolean',
+      alias: 'd',
+      description: 'Show what would be uploaded without making any requests',
+      default: false,
+    },
+  },
+  run({ args }) {
+    return uploadCommand({ dryRun: args.dryRun })
+  },
+})

--- a/src/core/lockfile.ts
+++ b/src/core/lockfile.ts
@@ -96,6 +96,11 @@ export function readLock(skillsDir: string): SkilldLock | null {
         skills[currentSkill]![kv[0]] = kv[1]
     }
   }
+  // Normalize legacy source values
+  for (const info of Object.values(skills)) {
+    if (info.source === 'npm')
+      info.source = 'registry'
+  }
   const lock = { skills }
   lockCache.set(skillsDir, lock)
   return { skills: { ...lock.skills } }

--- a/src/core/prefix.ts
+++ b/src/core/prefix.ts
@@ -84,6 +84,31 @@ export function parseSkillInputs(inputs: string[]): SkillSource[] {
 }
 
 /**
+ * Resolve a CLI input to the bare package/skill name used for lookup in the lockfile.
+ * Strips `npm:` / `gh:` prefixes. Returns null for curator/collection (not addressable
+ * as a single skill name).
+ */
+export function resolveSkillName(input: string): string | null {
+  const source = parseSkillInput(input)
+  switch (source.type) {
+    case 'npm':
+    case 'bare':
+      return source.package
+    case 'git':
+      if (source.source.type === 'github' && source.source.repo)
+        return source.source.repo
+      return null
+    case 'curator':
+    case 'collection':
+      return null
+    default: {
+      const _exhaustive: never = source
+      throw new Error(`Unhandled SkillSource type: ${JSON.stringify(_exhaustive)}`)
+    }
+  }
+}
+
+/**
  * Split "package@tag" into name and optional tag.
  * Handles scoped packages: "@scope/pkg@tag"
  */

--- a/src/core/prefix.ts
+++ b/src/core/prefix.ts
@@ -1,0 +1,106 @@
+/**
+ * Prefix-based input parser for `skilld add`
+ *
+ * All sources require an explicit prefix:
+ *   npm:vue         → package skill from registry
+ *   gh:owner/repo   → git skill
+ *   github:o/r      → git skill (alias)
+ *   @handle          → curator's skills
+ *   @handle/coll     → specific collection
+ *
+ * Bare names (no prefix) are deprecated but still resolve as npm: with a warning.
+ */
+
+import type { GitSkillSource } from '../sources/git-skills.ts'
+import { parseGitSkillInput } from '../sources/git-skills.ts'
+
+export type SkillSource
+  = | { type: 'npm', package: string, tag?: string }
+    | { type: 'git', source: GitSkillSource }
+    | { type: 'curator', handle: string }
+    | { type: 'collection', handle: string, name: string }
+    | { type: 'bare', package: string, tag?: string }
+
+/**
+ * Parse a single CLI input token into a typed SkillSource.
+ *
+ * Does NOT emit deprecation warnings; callers handle that for `bare` type.
+ */
+export function parseSkillInput(input: string): SkillSource {
+  const trimmed = input.trim()
+
+  // npm: prefix → package skill
+  if (trimmed.startsWith('npm:')) {
+    const rest = trimmed.slice(4)
+    const { name, tag } = splitPackageTag(rest)
+    return { type: 'npm', package: name, tag }
+  }
+
+  // gh: or github: prefix → git skill
+  if (trimmed.startsWith('gh:') || trimmed.startsWith('github:')) {
+    const rest = trimmed.startsWith('gh:') ? trimmed.slice(3) : trimmed.slice(7)
+    const gitSource = parseGitSkillInput(rest)
+    if (gitSource)
+      return { type: 'git', source: gitSource }
+    // If gh: prefix used but can't parse as git, treat as github shorthand
+    if (/^[\w.-]+\/[\w.-]+/.test(rest)) {
+      const [owner, repo] = rest.split('/')
+      return { type: 'git', source: { type: 'github', owner, repo } }
+    }
+    // Invalid gh: input, fall through to bare
+    return { type: 'bare', package: rest }
+  }
+
+  // @handle or @handle/collection
+  if (trimmed.startsWith('@')) {
+    const rest = trimmed.slice(1)
+    const slashIdx = rest.indexOf('/')
+    if (slashIdx === -1) {
+      return { type: 'curator', handle: rest }
+    }
+    const handle = rest.slice(0, slashIdx)
+    const name = rest.slice(slashIdx + 1)
+    // Disambiguate: @scope/pkg (npm scoped) vs @handle/collection
+    // Scoped npm packages need npm: prefix in the new world.
+    // @handle with / is always a collection.
+    return { type: 'collection', handle, name }
+  }
+
+  // Try existing git detection (SSH, URLs, local paths, owner/repo shorthand)
+  const gitSource = parseGitSkillInput(trimmed)
+  if (gitSource)
+    return { type: 'git', source: gitSource }
+
+  // Bare name (deprecated) → resolves as npm
+  const { name, tag } = splitPackageTag(trimmed)
+  return { type: 'bare', package: name, tag }
+}
+
+/**
+ * Parse multiple CLI input tokens, classifying each.
+ */
+export function parseSkillInputs(inputs: string[]): SkillSource[] {
+  return inputs.map(parseSkillInput)
+}
+
+/**
+ * Split "package@tag" into name and optional tag.
+ * Handles scoped packages: "@scope/pkg@tag"
+ */
+function splitPackageTag(spec: string): { name: string, tag?: string } {
+  // Scoped: @scope/pkg@tag → find the @ after the scope
+  if (spec.startsWith('@')) {
+    const slashIdx = spec.indexOf('/')
+    if (slashIdx !== -1) {
+      const afterSlash = spec.indexOf('@', slashIdx)
+      if (afterSlash !== -1)
+        return { name: spec.slice(0, afterSlash), tag: spec.slice(afterSlash + 1) || undefined }
+    }
+    return { name: spec }
+  }
+  // Unscoped: pkg@tag
+  const atIdx = spec.indexOf('@')
+  if (atIdx !== -1)
+    return { name: spec.slice(0, atIdx), tag: spec.slice(atIdx + 1) || undefined }
+  return { name: spec }
+}

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -1,77 +1,187 @@
 /**
  * Registry client for skilld.dev
  *
- * Fetches curated package skills from the skilld.dev registry API.
- * Currently stubbed — returns null for all lookups until the API is live.
+ * Talks to the public skilld.dev JSON API: resolves an npm package name to a
+ * curated skill's owner/repo, then fetches the detail payload which includes
+ * the raw SKILL.md. For local development, set SKILLD_REGISTRY_URL (e.g.
+ * http://localhost:3000/api) to point at a running Nuxt dev server.
+ *
+ * Returns null when a skill isn't curated, the API is unreachable, or the
+ * skill has no resolvable SKILL.md, so callers fall through to the
+ * doc-generation pipeline.
  */
 
 import { ofetch } from 'ofetch'
 
-const DEFAULT_REGISTRY_BASE = 'https://skilld.dev/api'
+const DEFAULT_REGISTRY_URL = 'https://skilld.dev/api'
 
-function registryBase(): string {
-  return process.env.SKILLD_REGISTRY_URL?.replace(/\/$/, '') || DEFAULT_REGISTRY_BASE
+export function getRegistryBase(): string {
+  return process.env.SKILLD_REGISTRY_URL || DEFAULT_REGISTRY_URL
 }
 
 export interface RegistrySkill {
-  /** Skill directory name (e.g. "vue-skilld") */
+  /** Skill directory name (matches what lands in .claude/skills/<name>/) */
   name: string
-  /** npm package name */
+  /** npm package name used to look up this skill */
   packageName: string
-  /** Package version this skill was generated for */
-  version: string
-  /** Full SKILL.md content */
+  /** Raw SKILL.md content (frontmatter + body) */
   content: string
-  /** GitHub repo (owner/repo) */
-  repo?: string
-  /** ISO timestamp of last update */
+  /** Source repo owner */
+  owner: string
+  /** Full "owner/repo" identifier */
+  repo: string
+  /** Human-readable display name from the registry */
+  displayName?: string
+  /** Install count reported by the registry */
+  installs?: number
+  /** True when the source repo is on the official owners list */
+  official?: boolean
+  /** Default branch the SKILL.md was fetched from */
+  branch?: string
+  /** Path to SKILL.md within the source repo */
+  skillPath?: string
+  /** ISO timestamp of the source repo's last push — used for staleness */
   updatedAt?: string
 }
 
+export interface RegistrySearchHit {
+  name: string
+  packageName: string
+  displayName?: string
+  owner: string
+  repo: string
+  installs?: number
+  official?: boolean
+}
+
 export interface RegistrySearchResult {
-  skills: Array<{
-    name: string
-    packageName: string
-    version: string
-    description?: string
-    updatedAt?: string
-  }>
+  skills: RegistrySearchHit[]
+  total: number
+}
+
+interface ResolveResponseEntry {
+  owner: string
+  repo: string
+  official: boolean
+}
+
+interface SkillDetailResponse {
+  owner: string
+  repo: string
+  name: string
+  displayName: string
+  installs: number
+  branch?: string
+  skillPath?: string | null
+  raw?: string | null
+  pushedAt?: string | null
+}
+
+interface SkillListItem {
+  name: string
+  owner: string
+  repo: string
+  displayName: string
+  installs: number
+  official: boolean
+}
+
+interface SkillListResponse {
+  items: SkillListItem[]
+  total: number
+}
+
+export interface FetchRegistrySkillOptions {
+  /** Narrow the resolve to a specific owner when multiple skills share a name */
+  owner?: string
 }
 
 /**
  * Fetch a curated package skill from the registry.
- * Returns null if no curated skill exists for this package.
+ * Returns null if no curated skill exists, the SKILL.md can't be loaded, or the API is unreachable.
  */
-export async function fetchRegistrySkill(packageName: string): Promise<RegistrySkill | null> {
-  try {
-    return await ofetch<RegistrySkill>(`${registryBase()}/skills/${encodeURIComponent(packageName)}`)
-  }
-  catch {
-    // Registry unavailable or skill not found
+export async function fetchRegistrySkill(
+  packageName: string,
+  opts: FetchRegistrySkillOptions = {},
+): Promise<RegistrySkill | null> {
+  const base = getRegistryBase()
+
+  const resolved = await ofetch<Record<string, ResolveResponseEntry>>(`${base}/skills/resolve`, {
+    method: 'POST',
+    body: { items: [{ packageName, owner: opts.owner }] },
+  }).catch(() => null)
+
+  const hit = resolved?.[packageName]
+  if (!hit)
     return null
+
+  const slug = `${hit.owner}/${hit.repo}/${packageName}`
+  const detail = await ofetch<SkillDetailResponse>(`${base}/skills/${slug}`).catch(() => null)
+
+  if (!detail?.raw)
+    return null
+
+  return {
+    name: detail.name,
+    packageName,
+    content: detail.raw,
+    owner: detail.owner,
+    repo: `${detail.owner}/${detail.repo}`,
+    displayName: detail.displayName,
+    installs: detail.installs,
+    official: hit.official,
+    branch: detail.branch,
+    skillPath: detail.skillPath ?? undefined,
+    updatedAt: detail.pushedAt ?? undefined,
   }
 }
 
 /**
  * Search the registry for skills matching a query.
  */
-export async function searchRegistry(query: string): Promise<RegistrySearchResult> {
-  try {
-    return await ofetch<RegistrySearchResult>(`${registryBase()}/search`, {
-      query: { q: query },
-    })
-  }
-  catch {
-    return { skills: [] }
+export async function searchRegistry(
+  query: string,
+  opts: { limit?: number, owner?: string, official?: boolean } = {},
+): Promise<RegistrySearchResult> {
+  const base = getRegistryBase()
+  const result = await ofetch<SkillListResponse>(`${base}/skills`, {
+    query: {
+      q: query,
+      limit: opts.limit ?? 20,
+      owner: opts.owner,
+      official: opts.official ? 'true' : undefined,
+    },
+  }).catch(() => null)
+
+  if (!result)
+    return { skills: [], total: 0 }
+
+  return {
+    skills: result.items.map(i => ({
+      name: i.name,
+      packageName: i.name,
+      displayName: i.displayName,
+      owner: i.owner,
+      repo: `${i.owner}/${i.repo}`,
+      installs: i.installs,
+      official: i.official,
+    })),
+    total: result.total,
   }
 }
 
 /**
- * Check if a newer version of a registry skill is available.
+ * Check whether the registry has a newer SKILL.md than the local copy.
+ * Returns the new `updatedAt` timestamp if newer, else null.
  */
-export async function checkRegistryUpdate(packageName: string, currentVersion: string): Promise<string | null> {
+export async function checkRegistryUpdate(
+  packageName: string,
+  currentUpdatedAt: string | undefined,
+): Promise<string | null> {
   const skill = await fetchRegistrySkill(packageName)
-  if (!skill || skill.version === currentVersion)
+  if (!skill?.updatedAt)
     return null
-  return skill.version
+  if (!currentUpdatedAt || skill.updatedAt > currentUpdatedAt)
+    return skill.updatedAt
+  return null
 }

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -16,7 +16,7 @@ import { ofetch } from 'ofetch'
 const DEFAULT_REGISTRY_URL = 'https://skilld.dev/api'
 
 export function getRegistryBase(): string {
-  return process.env.SKILLD_REGISTRY_URL || DEFAULT_REGISTRY_URL
+  return (process.env.SKILLD_REGISTRY_URL || DEFAULT_REGISTRY_URL).replace(/\/$/, '')
 }
 
 export interface RegistrySkill {

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -7,7 +7,11 @@
 
 import { ofetch } from 'ofetch'
 
-const REGISTRY_BASE = 'https://skilld.dev/api'
+const DEFAULT_REGISTRY_BASE = 'https://skilld.dev/api'
+
+function registryBase(): string {
+  return process.env.SKILLD_REGISTRY_URL?.replace(/\/$/, '') || DEFAULT_REGISTRY_BASE
+}
 
 export interface RegistrySkill {
   /** Skill directory name (e.g. "vue-skilld") */
@@ -40,7 +44,7 @@ export interface RegistrySearchResult {
  */
 export async function fetchRegistrySkill(packageName: string): Promise<RegistrySkill | null> {
   try {
-    return await ofetch<RegistrySkill>(`${REGISTRY_BASE}/skills/${encodeURIComponent(packageName)}`)
+    return await ofetch<RegistrySkill>(`${registryBase()}/skills/${encodeURIComponent(packageName)}`)
   }
   catch {
     // Registry unavailable or skill not found
@@ -53,7 +57,7 @@ export async function fetchRegistrySkill(packageName: string): Promise<RegistryS
  */
 export async function searchRegistry(query: string): Promise<RegistrySearchResult> {
   try {
-    return await ofetch<RegistrySearchResult>(`${REGISTRY_BASE}/search`, {
+    return await ofetch<RegistrySearchResult>(`${registryBase()}/search`, {
       query: { q: query },
     })
   }

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -1,0 +1,73 @@
+/**
+ * Registry client for skilld.dev
+ *
+ * Fetches curated package skills from the skilld.dev registry API.
+ * Currently stubbed — returns null for all lookups until the API is live.
+ */
+
+import { ofetch } from 'ofetch'
+
+const REGISTRY_BASE = 'https://skilld.dev/api'
+
+export interface RegistrySkill {
+  /** Skill directory name (e.g. "vue-skilld") */
+  name: string
+  /** npm package name */
+  packageName: string
+  /** Package version this skill was generated for */
+  version: string
+  /** Full SKILL.md content */
+  content: string
+  /** GitHub repo (owner/repo) */
+  repo?: string
+  /** ISO timestamp of last update */
+  updatedAt?: string
+}
+
+export interface RegistrySearchResult {
+  skills: Array<{
+    name: string
+    packageName: string
+    version: string
+    description?: string
+    updatedAt?: string
+  }>
+}
+
+/**
+ * Fetch a curated package skill from the registry.
+ * Returns null if no curated skill exists for this package.
+ */
+export async function fetchRegistrySkill(packageName: string): Promise<RegistrySkill | null> {
+  try {
+    return await ofetch<RegistrySkill>(`${REGISTRY_BASE}/skills/${encodeURIComponent(packageName)}`)
+  }
+  catch {
+    // Registry unavailable or skill not found
+    return null
+  }
+}
+
+/**
+ * Search the registry for skills matching a query.
+ */
+export async function searchRegistry(query: string): Promise<RegistrySearchResult> {
+  try {
+    return await ofetch<RegistrySearchResult>(`${REGISTRY_BASE}/search`, {
+      query: { q: query },
+    })
+  }
+  catch {
+    return { skills: [] }
+  }
+}
+
+/**
+ * Check if a newer version of a registry skill is available.
+ */
+export async function checkRegistryUpdate(packageName: string, currentVersion: string): Promise<string | null> {
+  const skill = await fetchRegistrySkill(packageName)
+  if (!skill || skill.version === currentVersion)
+    return null
+  return skill.version
+}

--- a/test/unit/lockfile.test.ts
+++ b/test/unit/lockfile.test.ts
@@ -184,6 +184,40 @@ describe('core/lockfile', () => {
     })
   })
 
+  describe('legacy source normalization', () => {
+    it('normalizes source: npm to source: registry', async () => {
+      const { existsSync, readFileSync } = await import('node:fs')
+      const { readLock } = await import('../../src/core/lockfile')
+
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(readFileSync).mockReturnValue(
+        'skills:\n'
+        + '  vue-skilld:\n'
+        + '    packageName: vue\n'
+        + '    version: "3.5.0"\n'
+        + '    source: npm\n',
+      )
+
+      const lock = readLock('/skills')
+      expect(lock?.skills['vue-skilld']?.source).toBe('registry')
+    })
+
+    it('leaves non-npm source values untouched', async () => {
+      const { existsSync, readFileSync } = await import('node:fs')
+      const { readLock } = await import('../../src/core/lockfile')
+
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(readFileSync).mockReturnValue(
+        'skills:\n'
+        + '  external-skill:\n'
+        + '    source: github\n',
+      )
+
+      const lock = readLock('/skills')
+      expect(lock?.skills['external-skill']?.source).toBe('github')
+    })
+  })
+
   describe('git skill fields (path, ref, commit)', () => {
     it('readLock parses git fields from lockfile', async () => {
       const { existsSync, readFileSync } = await import('node:fs')

--- a/test/unit/prefix.test.ts
+++ b/test/unit/prefix.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parseSkillInput, parseSkillInputs } from '../../src/core/prefix'
+import { parseSkillInput, parseSkillInputs, resolveSkillName } from '../../src/core/prefix'
 
 describe('prefix parser', () => {
   describe('npm: prefix', () => {
@@ -127,6 +127,32 @@ describe('prefix parser', () => {
         package: 'vue',
         tag: undefined,
       })
+    })
+  })
+
+  describe('resolveSkillName', () => {
+    it('strips npm: prefix', () => {
+      expect(resolveSkillName('npm:vue')).toBe('vue')
+    })
+
+    it('strips npm: prefix from scoped package', () => {
+      expect(resolveSkillName('npm:@nuxt/ui')).toBe('@nuxt/ui')
+    })
+
+    it('returns bare name unchanged', () => {
+      expect(resolveSkillName('vue')).toBe('vue')
+    })
+
+    it('returns repo name for gh:owner/repo', () => {
+      expect(resolveSkillName('gh:vercel-labs/skills')).toBe('skills')
+    })
+
+    it('returns null for curator', () => {
+      expect(resolveSkillName('@antfu')).toBeNull()
+    })
+
+    it('returns null for collection', () => {
+      expect(resolveSkillName('@antfu/utils')).toBeNull()
     })
   })
 })

--- a/test/unit/prefix.test.ts
+++ b/test/unit/prefix.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest'
+import { parseSkillInput, parseSkillInputs } from '../../src/core/prefix'
+
+describe('prefix parser', () => {
+  describe('npm: prefix', () => {
+    it('parses simple package name', () => {
+      expect(parseSkillInput('npm:vue')).toEqual({
+        type: 'npm',
+        package: 'vue',
+        tag: undefined,
+      })
+    })
+
+    it('parses package with tag', () => {
+      expect(parseSkillInput('npm:vue@3.5')).toEqual({
+        type: 'npm',
+        package: 'vue',
+        tag: '3.5',
+      })
+    })
+
+    it('parses scoped package', () => {
+      expect(parseSkillInput('npm:@nuxt/ui')).toEqual({
+        type: 'npm',
+        package: '@nuxt/ui',
+        tag: undefined,
+      })
+    })
+
+    it('parses scoped package with tag', () => {
+      expect(parseSkillInput('npm:@nuxt/ui@3.0.0')).toEqual({
+        type: 'npm',
+        package: '@nuxt/ui',
+        tag: '3.0.0',
+      })
+    })
+  })
+
+  describe('gh: and github: prefix', () => {
+    it('parses gh:owner/repo', () => {
+      const result = parseSkillInput('gh:vercel-labs/skills')
+      expect(result.type).toBe('git')
+      if (result.type === 'git') {
+        expect(result.source.owner).toBe('vercel-labs')
+        expect(result.source.repo).toBe('skills')
+      }
+    })
+
+    it('parses github:owner/repo', () => {
+      const result = parseSkillInput('github:vercel-labs/skills')
+      expect(result.type).toBe('git')
+      if (result.type === 'git') {
+        expect(result.source.owner).toBe('vercel-labs')
+        expect(result.source.repo).toBe('skills')
+      }
+    })
+  })
+
+  describe('@ prefix (curator and collection)', () => {
+    it('parses @handle as curator', () => {
+      expect(parseSkillInput('@antfu')).toEqual({
+        type: 'curator',
+        handle: 'antfu',
+      })
+    })
+
+    it('parses @handle/collection as collection', () => {
+      expect(parseSkillInput('@antfu/vue-stack')).toEqual({
+        type: 'collection',
+        handle: 'antfu',
+        name: 'vue-stack',
+      })
+    })
+  })
+
+  describe('bare names (deprecated)', () => {
+    it('treats bare name as deprecated npm', () => {
+      expect(parseSkillInput('vue')).toEqual({
+        type: 'bare',
+        package: 'vue',
+        tag: undefined,
+      })
+    })
+
+    it('treats bare name with tag as deprecated npm', () => {
+      expect(parseSkillInput('vue@3.5')).toEqual({
+        type: 'bare',
+        package: 'vue',
+        tag: '3.5',
+      })
+    })
+  })
+
+  describe('legacy git detection (no prefix)', () => {
+    it('detects owner/repo shorthand as git', () => {
+      const result = parseSkillInput('vercel-labs/skills')
+      expect(result.type).toBe('git')
+    })
+
+    it('detects https URLs as git', () => {
+      const result = parseSkillInput('https://github.com/vercel-labs/skills')
+      expect(result.type).toBe('git')
+    })
+
+    it('detects SSH URLs as git', () => {
+      const result = parseSkillInput('git@github.com:vercel-labs/skills')
+      expect(result.type).toBe('git')
+    })
+
+    it('detects local paths as git', () => {
+      const result = parseSkillInput('./my-skills')
+      expect(result.type).toBe('git')
+    })
+  })
+
+  describe('parseSkillInputs (batch)', () => {
+    it('classifies mixed inputs', () => {
+      const results = parseSkillInputs(['npm:vue', 'gh:owner/repo', '@antfu', 'nuxt'])
+      expect(results.map(r => r.type)).toEqual(['npm', 'git', 'curator', 'bare'])
+    })
+  })
+
+  describe('whitespace handling', () => {
+    it('trims input', () => {
+      expect(parseSkillInput('  npm:vue  ')).toEqual({
+        type: 'npm',
+        package: 'vue',
+        tag: undefined,
+      })
+    })
+  })
+})

--- a/test/unit/registry-client.test.ts
+++ b/test/unit/registry-client.test.ts
@@ -4,6 +4,31 @@ vi.mock('ofetch', () => ({
   ofetch: vi.fn(),
 }))
 
+function mockResolveAndDetail(ofetch: ReturnType<typeof vi.fn>, opts: {
+  packageName: string
+  owner?: string
+  repo?: string
+  raw?: string
+  pushedAt?: string
+}) {
+  const owner = opts.owner ?? 'antfu'
+  const repo = opts.repo ?? 'skills'
+  ofetch.mockResolvedValueOnce({
+    [opts.packageName]: { owner, repo, official: false },
+  })
+  ofetch.mockResolvedValueOnce({
+    owner,
+    repo,
+    name: opts.packageName,
+    displayName: opts.packageName,
+    installs: 1,
+    branch: 'main',
+    skillPath: `skills/${opts.packageName}/SKILL.md`,
+    raw: opts.raw ?? '# skill',
+    pushedAt: opts.pushedAt ?? '2026-01-01T00:00:00Z',
+  })
+}
+
 describe('registry client', () => {
   let originalUrl: string | undefined
 
@@ -22,52 +47,105 @@ describe('registry client', () => {
   it('fetchRegistrySkill uses default base when env unset', async () => {
     delete process.env.SKILLD_REGISTRY_URL
     const { ofetch } = await import('ofetch')
-    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'vue-skilld', packageName: 'vue', version: '3.5.0', content: '# vue' })
+    mockResolveAndDetail(vi.mocked(ofetch), { packageName: 'vue' })
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
-    await fetchRegistrySkill('vue')
+    const skill = await fetchRegistrySkill('vue')
 
-    expect(ofetch).toHaveBeenCalledWith('https://skilld.dev/api/skills/vue')
+    expect(skill).not.toBeNull()
+    expect(ofetch).toHaveBeenNthCalledWith(1, 'https://skilld.dev/api/skills/resolve', {
+      method: 'POST',
+      body: { items: [{ packageName: 'vue', owner: undefined }] },
+    })
+    expect(ofetch).toHaveBeenNthCalledWith(2, 'https://skilld.dev/api/skills/antfu/skills/vue')
   })
 
   it('fetchRegistrySkill respects SKILLD_REGISTRY_URL override', async () => {
     process.env.SKILLD_REGISTRY_URL = 'http://localhost:3000/api'
     const { ofetch } = await import('ofetch')
-    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'vue-skilld', packageName: 'vue', version: '3.5.0', content: '# vue' })
+    mockResolveAndDetail(vi.mocked(ofetch), { packageName: 'vue' })
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
     await fetchRegistrySkill('vue')
 
-    expect(ofetch).toHaveBeenCalledWith('http://localhost:3000/api/skills/vue')
+    expect(ofetch).toHaveBeenNthCalledWith(1, 'http://localhost:3000/api/skills/resolve', expect.any(Object))
+    expect(ofetch).toHaveBeenNthCalledWith(2, 'http://localhost:3000/api/skills/antfu/skills/vue')
   })
 
   it('strips trailing slash from override', async () => {
     process.env.SKILLD_REGISTRY_URL = 'http://localhost:3000/api/'
     const { ofetch } = await import('ofetch')
-    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'vue-skilld', packageName: 'vue', version: '3.5.0', content: '# vue' })
+    mockResolveAndDetail(vi.mocked(ofetch), { packageName: 'vue' })
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
     await fetchRegistrySkill('vue')
 
-    expect(ofetch).toHaveBeenCalledWith('http://localhost:3000/api/skills/vue')
+    expect(ofetch).toHaveBeenNthCalledWith(1, 'http://localhost:3000/api/skills/resolve', expect.any(Object))
   })
 
-  it('returns null when registry fetch fails', async () => {
+  it('returns null when resolve fails', async () => {
     const { ofetch } = await import('ofetch')
-    vi.mocked(ofetch).mockRejectedValueOnce(new Error('404'))
+    vi.mocked(ofetch).mockRejectedValueOnce(new Error('network'))
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
     expect(await fetchRegistrySkill('nonexistent')).toBeNull()
   })
 
-  it('encodes scoped package names', async () => {
+  it('returns null when resolve has no hit', async () => {
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch).mockResolvedValueOnce({})
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    expect(await fetchRegistrySkill('nonexistent')).toBeNull()
+    expect(ofetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns null when detail has no raw SKILL.md', async () => {
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch)
+      .mockResolvedValueOnce({ vue: { owner: 'antfu', repo: 'skills', official: false } })
+      .mockResolvedValueOnce({ owner: 'antfu', repo: 'skills', name: 'vue', raw: null })
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    expect(await fetchRegistrySkill('vue')).toBeNull()
+  })
+
+  it('passes scoped package names unencoded to resolve body', async () => {
     delete process.env.SKILLD_REGISTRY_URL
     const { ofetch } = await import('ofetch')
-    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'nuxt-ui-skilld', packageName: '@nuxt/ui', version: '3.0.0', content: '# nuxt/ui' })
+    mockResolveAndDetail(vi.mocked(ofetch), { packageName: '@nuxt/ui', owner: 'nuxt', repo: 'ui' })
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
     await fetchRegistrySkill('@nuxt/ui')
 
-    expect(ofetch).toHaveBeenCalledWith('https://skilld.dev/api/skills/%40nuxt%2Fui')
+    expect(ofetch).toHaveBeenNthCalledWith(1, 'https://skilld.dev/api/skills/resolve', {
+      method: 'POST',
+      body: { items: [{ packageName: '@nuxt/ui', owner: undefined }] },
+    })
+    expect(ofetch).toHaveBeenNthCalledWith(2, 'https://skilld.dev/api/skills/nuxt/ui/@nuxt/ui')
+  })
+
+  it('maps detail payload into RegistrySkill', async () => {
+    const { ofetch } = await import('ofetch')
+    mockResolveAndDetail(vi.mocked(ofetch), {
+      packageName: 'vue',
+      owner: 'antfu',
+      repo: 'skills',
+      raw: '---\nname: vue\n---\n# vue',
+      pushedAt: '2026-03-16T06:16:24Z',
+    })
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    const skill = await fetchRegistrySkill('vue')
+
+    expect(skill).toMatchObject({
+      name: 'vue',
+      packageName: 'vue',
+      owner: 'antfu',
+      repo: 'antfu/skills',
+      content: '---\nname: vue\n---\n# vue',
+      updatedAt: '2026-03-16T06:16:24Z',
+      branch: 'main',
+    })
   })
 })

--- a/test/unit/registry-client.test.ts
+++ b/test/unit/registry-client.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('ofetch', () => ({
+  ofetch: vi.fn(),
+}))
+
+describe('registry client', () => {
+  let originalUrl: string | undefined
+
+  beforeEach(() => {
+    originalUrl = process.env.SKILLD_REGISTRY_URL
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    if (originalUrl === undefined)
+      delete process.env.SKILLD_REGISTRY_URL
+    else
+      process.env.SKILLD_REGISTRY_URL = originalUrl
+  })
+
+  it('fetchRegistrySkill uses default base when env unset', async () => {
+    delete process.env.SKILLD_REGISTRY_URL
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'vue-skilld', packageName: 'vue', version: '3.5.0', content: '# vue' })
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    await fetchRegistrySkill('vue')
+
+    expect(ofetch).toHaveBeenCalledWith('https://skilld.dev/api/skills/vue')
+  })
+
+  it('fetchRegistrySkill respects SKILLD_REGISTRY_URL override', async () => {
+    process.env.SKILLD_REGISTRY_URL = 'http://localhost:3000/api'
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'vue-skilld', packageName: 'vue', version: '3.5.0', content: '# vue' })
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    await fetchRegistrySkill('vue')
+
+    expect(ofetch).toHaveBeenCalledWith('http://localhost:3000/api/skills/vue')
+  })
+
+  it('strips trailing slash from override', async () => {
+    process.env.SKILLD_REGISTRY_URL = 'http://localhost:3000/api/'
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'vue-skilld', packageName: 'vue', version: '3.5.0', content: '# vue' })
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    await fetchRegistrySkill('vue')
+
+    expect(ofetch).toHaveBeenCalledWith('http://localhost:3000/api/skills/vue')
+  })
+
+  it('returns null when registry fetch fails', async () => {
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch).mockRejectedValueOnce(new Error('404'))
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    expect(await fetchRegistrySkill('nonexistent')).toBeNull()
+  })
+
+  it('encodes scoped package names', async () => {
+    delete process.env.SKILLD_REGISTRY_URL
+    const { ofetch } = await import('ofetch')
+    vi.mocked(ofetch).mockResolvedValueOnce({ name: 'nuxt-ui-skilld', packageName: '@nuxt/ui', version: '3.0.0', content: '# nuxt/ui' })
+
+    const { fetchRegistrySkill } = await import('../../src/registry/client')
+    await fetchRegistrySkill('@nuxt/ui')
+
+    expect(ofetch).toHaveBeenCalledWith('https://skilld.dev/api/skills/%40nuxt%2Fui')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Part of the skilld.dev registry pivot (no single issue, strategic change).

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Lays the CLI foundations for pivoting skilld from "generate skills from docs" to "curated registry at skilld.dev." No breaking changes; bare names still work with a deprecation warning.

**Prefix parser** (`src/core/prefix.ts`): classifies `skilld add` inputs into typed sources:
- `npm:vue` → package skill from registry
- `gh:owner/repo` or `github:owner/repo` → git skill
- `@handle` → curator (stubbed, coming soon)
- `@handle/collection` → collection (stubbed, coming soon)
- Bare `vue` → deprecated, warns and resolves as `npm:vue`

**Registry client** (`src/registry/client.ts`): live client for the skilld.dev API. `fetchRegistrySkill` calls `POST /api/skills/resolve` to map a package name to its curated `owner/repo`, then `GET /api/skills/<owner>/<repo>/<name>` for the raw SKILL.md. `searchRegistry` hits `GET /api/skills?q=...`. Base URL defaults to `https://skilld.dev/api`; override with `SKILLD_REGISTRY_URL` for local dev. Returns null on miss/network error so callers fall through to the doc-generation pipeline.

Since the registry DB has no `version` column, staleness is tracked via `updatedAt` (repo `pushedAt` timestamp) rather than semver. `checkRegistryUpdate` compares ISO timestamps.

**Registry install flow** (`src/commands/sync-registry.ts`): simplified install path for registry skills: fetch SKILL.md → write to disk → lockfile with `source: 'registry'` (stores `updatedAt` in the version slot) → link to agents. No LLM, no doc crawling.

**Author command nesting**: authoring commands moved under `skilld author`:
- `skilld author package` (was `skilld author`)
- `skilld author publish` (was `skilld upload`)
- `skilld author eject` (was `skilld eject`)
- `skilld author validate` (was `skilld validate`)
- `skilld author assemble` (was `skilld assemble`)

Old top-level commands forward with deprecation warnings.

**Lockfile compat**: `readLock()` normalizes legacy `source: 'npm'` to `source: 'registry'`.

16 new unit tests for the prefix parser.