### PR TITLE
refactor: reuse GitHub repo slug parser

### DIFF
--- a/src/commands/sync-parallel.ts
+++ b/src/commands/sync-parallel.ts
@@ -39,6 +39,7 @@ import { getSharedSkillsDir, semverDiff, SHARED_SKILLS_DIR } from '../core/share
 import { shutdownWorker } from '../retriv/pool.ts'
 import {
   fetchPkgDist,
+  parseGitHubRepoSlug,
   parsePackageSpec,
   readLocalDependencies,
   resolvePackageDocsWithAttempts,
@@ -556,7 +557,7 @@ async function syncBaseSkill(
   const pkgFiles = getPkgKeyFiles(packageName, cwd, version)
 
   // Write base SKILL.md
-  const repoSlug = resolved.repoUrl?.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:[/#]|$)/)?.[1]
+  const repoSlug = parseGitHubRepoSlug(resolved.repoUrl)
 
   // Create named symlink for this package
   linkPkgNamed(skillDir, packageName, cwd, version)

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -45,6 +45,7 @@ import { shutdownWorker } from '../retriv/pool.ts'
 import {
   fetchPkgDist,
   isPrerelease,
+  parseGitHubRepoSlug,
   parsePackageSpec,
   readLocalDependencies,
   resolveCrateDocsWithAttempts,
@@ -460,7 +461,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
     linkPkgNamed(skillDir, storagePackageName, cwd, version)
 
     // Merge into lockfile
-    const repoSlug = resolved.repoUrl?.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:[/#]|$)/)?.[1]
+    const repoSlug = parseGitHubRepoSlug(resolved.repoUrl)
     writeLock(baseDir, skillDirName, {
       packageName: identityPackageName,
       version,
@@ -566,7 +567,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
   const pkgFiles = getPkgKeyFiles(storagePackageName, cwd, version)
 
   // Write base SKILL.md (no LLM needed)
-  const repoSlug = resolved.repoUrl?.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:[/#]|$)/)?.[1]
+  const repoSlug = parseGitHubRepoSlug(resolved.repoUrl)
 
   // Also create named symlink for this package (skip in eject mode)
   if (!config.eject)
@@ -1252,7 +1253,7 @@ export async function exportPortablePrompts(packageSpec: string, opts: {
   writeFileSync(join(skillDir, 'SKILL.md'), skillMd)
 
   // Write lockfile so skilld list/update/assemble can discover this skill
-  const repoSlug = resolved.repoUrl?.match(/github\.com\/([^/]+\/[^/]+?)(?:\.git)?(?:[/#]|$)/)?.[1]
+  const repoSlug = parseGitHubRepoSlug(resolved.repoUrl)
   writeLock(baseDir, skillDirName, {
     packageName,
     version,

--- a/src/sources/index.ts
+++ b/src/sources/index.ts
@@ -113,6 +113,7 @@ export {
   fetchText,
   isGitHubRepoUrl,
   normalizeRepoUrl,
+  parseGitHubRepoSlug,
   parseGitHubUrl,
   parsePackageSpec,
   verifyUrl,

--- a/src/sources/utils.ts
+++ b/src/sources/utils.ts
@@ -162,6 +162,14 @@ export function parseGitHubUrl(url: string): { owner: string, repo: string } | n
   return { owner: match[1]!, repo: match[2]! }
 }
 
+/** Parse owner/repo slug from GitHub URL */
+export function parseGitHubRepoSlug(url: string | undefined): string | undefined {
+  if (!url)
+    return undefined
+  const parsed = parseGitHubUrl(url)
+  return parsed ? `${parsed.owner}/${parsed.repo}` : undefined
+}
+
 /**
  * Normalize git repo URL to https
  */

--- a/test/unit/sources-utils.test.ts
+++ b/test/unit/sources-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isGitHubRepoUrl, normalizeRepoUrl, parseGitHubUrl, parsePackageSpec } from '../../src/sources/utils'
+import { isGitHubRepoUrl, normalizeRepoUrl, parseGitHubRepoSlug, parseGitHubUrl, parsePackageSpec } from '../../src/sources/utils'
 
 describe('sources/utils', () => {
   describe('isGitHubRepoUrl', () => {
@@ -52,6 +52,17 @@ describe('sources/utils', () => {
     it('returns null for invalid URLs', () => {
       expect(parseGitHubUrl('https://gitlab.com/owner/repo')).toBeNull()
       expect(parseGitHubUrl('not-a-url')).toBeNull()
+    })
+  })
+
+  describe('parseGitHubRepoSlug', () => {
+    it('extracts owner/repo slug', () => {
+      expect(parseGitHubRepoSlug('https://github.com/vuejs/vue.git#main')).toBe('vuejs/vue')
+    })
+
+    it('returns undefined for missing or non-GitHub URLs', () => {
+      expect(parseGitHubRepoSlug(undefined)).toBeUndefined()
+      expect(parseGitHubRepoSlug('https://example.com/foo/bar')).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
Small change that extracts a repeated regex into a separate util for better maintenance and readability.