### PR TITLE
refactor: reuse parsed package names

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -38,7 +38,7 @@ import {
 import { promptForAgent, resolveAgent, sharedArgs } from '../cli-helpers.ts'
 import { defaultFeatures, readConfig } from '../core/config.ts'
 import { timedSpinner } from '../core/formatting.ts'
-import { mergeLocks, parsePackages, readLock, syncLockfilesToDirs, writeLock } from '../core/lockfile.ts'
+import { mergeLocks, parsePackageNames, parsePackages, readLock, syncLockfilesToDirs, writeLock } from '../core/lockfile.ts'
 import { readPackageJsonSafe } from '../core/package-json.ts'
 import { toStoragePackageName } from '../core/prefix.ts'
 import { sanitizeMarkdown } from '../core/sanitize.ts'
@@ -596,7 +596,7 @@ async function enhanceRegenerated(
     // Derive dirName from the skill directory name
     const dirName = skillDir.split('/').pop()
 
-    const allPackages = parsePackages(packages).map(p => ({ name: p.name }))
+    const allPackages = parsePackageNames(packages)
     const skillMd = generateSkillMd({
       name: pkgName,
       version,
@@ -687,7 +687,7 @@ function regenerateBaseSkillMd(
   const dirName = skillDir.split('/').pop()
 
   // Build multi-package list from lockfile packages field
-  const allPackages = parsePackages(packages).map(p => ({ name: p.name }))
+  const allPackages = parsePackageNames(packages)
 
   const content = generateSkillMd({
     name: pkgName,

--- a/src/commands/sync-parallel.ts
+++ b/src/commands/sync-parallel.ts
@@ -33,7 +33,7 @@ import {
 } from '../cache/index.ts'
 import { defaultFeatures, readConfig, registerProject } from '../core/config.ts'
 import { formatDuration } from '../core/formatting.ts'
-import { parsePackages, readLock, writeLock } from '../core/lockfile.ts'
+import { parsePackageNames, parsePackages, readLock, writeLock } from '../core/lockfile.ts'
 import { parseFrontmatter } from '../core/markdown.ts'
 import { getSharedSkillsDir, semverDiff, SHARED_SKILLS_DIR } from '../core/shared.ts'
 import { shutdownWorker } from '../retriv/pool.ts'
@@ -572,7 +572,7 @@ async function syncBaseSkill(
 
   // Read back merged packages from lockfile
   const updatedLock = readLock(baseDir)?.skills[skillDirName]
-  const allPackages = parsePackages(updatedLock?.packages).map(p => ({ name: p.name }))
+  const allPackages = parsePackageNames(updatedLock?.packages)
 
   const skillMd = generateSkillMd({
     name: packageName,

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -36,7 +36,7 @@ import {
 import { getInstalledGenerators, introLine, isInteractive, promptForAgent, resolveAgent, sharedArgs, suggestPrepareHook } from '../cli-helpers.ts'
 import { defaultFeatures, hasCompletedWizard, readConfig, registerProject } from '../core/config.ts'
 import { timedSpinner } from '../core/formatting.ts'
-import { parsePackages, readLock, removeLockEntry, writeLock } from '../core/lockfile.ts'
+import { parsePackageNames, parsePackages, readLock, removeLockEntry, writeLock } from '../core/lockfile.ts'
 import { parseFrontmatter } from '../core/markdown.ts'
 import { parseSkillInput, resolveSkillName, toStoragePackageName } from '../core/prefix.ts'
 import { getSharedSkillsDir, SHARED_SKILLS_DIR } from '../core/shared.ts'
@@ -472,7 +472,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 
     // Regenerate SKILL.md with all packages listed
     const updatedLock = readLock(baseDir)?.skills[skillDirName]
-    const allPackages = parsePackages(updatedLock?.packages).map(p => ({ name: p.name }))
+    const allPackages = parsePackageNames(updatedLock?.packages)
     const relatedSkills = await findRelatedSkills(storagePackageName, baseDir)
     const existingStorageName = toStoragePackageName(existingLock.packageName!)
     const pkgFiles = getPkgKeyFiles(existingStorageName, cwd, existingLock.version)
@@ -601,7 +601,7 @@ async function syncSinglePackage(packageSpec: string, config: SyncConfig): Promi
 
   // Read back merged packages from lockfile for SKILL.md generation
   const updatedLock = config.eject ? undefined : readLock(baseDir)?.skills[skillDirName]
-  const allPackages = parsePackages(updatedLock?.packages).map(p => ({ name: p.name }))
+  const allPackages = parsePackageNames(updatedLock?.packages)
 
   const isEject = !!config.eject
   const baseSkillMd = generateSkillMd({

--- a/src/core/lockfile.ts
+++ b/src/core/lockfile.ts
@@ -32,6 +32,10 @@ export function parsePackages(packages?: string): Array<{ name: string, version:
   }).filter(p => p.name)
 }
 
+export function parsePackageNames(packages?: string): Array<{ name: string }> {
+  return parsePackages(packages).map(({ name }) => ({ name }))
+}
+
 export function serializePackages(pkgs: Array<{ name: string, version: string }>): string {
   return pkgs.map(p => `${p.name}@${p.version}`).join(', ')
 }

--- a/test/unit/lockfile.test.ts
+++ b/test/unit/lockfile.test.ts
@@ -55,6 +55,16 @@ describe('core/lockfile', () => {
     })
   })
 
+  describe('parsePackageNames', () => {
+    it('drops version fields for SKILL.md package metadata', async () => {
+      const { parsePackageNames } = await import('../../src/core/lockfile')
+      expect(parsePackageNames('vue@3.5.0, @vue/reactivity@3.5.0')).toEqual([
+        { name: 'vue' },
+        { name: '@vue/reactivity' },
+      ])
+    })
+  })
+
   describe('serializePackages', () => {
     it('serializes single package', async () => {
       const { serializePackages } = await import('../../src/core/lockfile')


### PR DESCRIPTION
Small cleanup: reuse one helper for converting lockfile package entries into SKILL.md package metadata. Less repeated mapping, easier to keep consistent.