### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     "type": "git",
     "url": "https://github.com/skilld-dev/skilld"
   },
+  "homepage": "https://github.com/skilld-dev/skilld#readme",
+  "bugs": {
+    "url": "https://github.com/skilld-dev/skilld/issues"
+  },
   "keywords": [
     "ai",
     "agent",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -14,6 +14,10 @@
     "url": "git+https://github.com/skilld-dev/skilld.git",
     "directory": "packages/protocol"
   },
+  "homepage": "https://github.com/skilld-dev/skilld/tree/main/packages/protocol#readme",
+  "bugs": {
+    "url": "https://github.com/skilld-dev/skilld/issues"
+  },
   "keywords": [
     "skilld",
     "protocol",


### PR DESCRIPTION
## Summary

- add npm `homepage` and `bugs.url` metadata for the root `skilld` package
- add npm `homepage` and `bugs.url` metadata for `skilld-protocol`

This is metadata-only. Runtime code, dependencies, exports, package versions, and build output are unchanged.

## Validation

```sh
node manifest assertion for package.json and packages/protocol/package.json
git diff --check
(cd packages/protocol && npm pack --dry-run --ignore-scripts --json)
```

The dry-run package includes `package.json`.
