### PR TITLE
chore(deps): migrate semver to verkit

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,13 +70,13 @@
     "p-limit": "catalog:deps",
     "pathe": "catalog:",
     "retriv": "catalog:",
-    "semver": "catalog:",
     "skilld-protocol": "workspace:*",
     "sqlite-vec": "catalog:deps",
     "std-env": "catalog:",
     "typebox": "catalog:",
     "typescript": "catalog:",
-    "unagent": "catalog:"
+    "unagent": "catalog:",
+    "verkit": "catalog:"
   },
   "optionalDependencies": {
     "@napi-rs/keyring": "^1.3.0"
@@ -84,7 +84,6 @@
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev-lint",
     "@types/node": "catalog:dev-build",
-    "@types/semver": "catalog:",
     "@vitest/coverage-v8": "catalog:dev-test",
     "bumpp": "catalog:",
     "eslint": "catalog:dev-lint",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     '@mdream/crawl':
       specifier: ^1.2.2
       version: 1.2.2
-    '@types/semver':
-      specifier: ^7.7.1
-      version: 7.7.1
     bumpp:
       specifier: ^11.1.0
       version: 11.1.0
@@ -45,9 +42,6 @@ catalogs:
     retriv:
       specifier: ^0.14.7
       version: 0.14.7
-    semver:
-      specifier: ^7.8.1
-      version: 7.8.1
     std-env:
       specifier: ^4.1.0
       version: 4.1.0
@@ -63,6 +57,9 @@ catalogs:
     unagent:
       specifier: ^0.0.8
       version: 0.0.8
+    verkit:
+      specifier: ^0.2.0
+      version: 0.2.0
     zod:
       specifier: ^4.4.3
       version: 4.4.3
@@ -168,9 +165,6 @@ importers:
       retriv:
         specifier: 'catalog:'
         version: 0.14.7(@huggingface/transformers@4.2.0)(sqlite-vec@0.1.9)(typescript@6.0.3)
-      semver:
-        specifier: 'catalog:'
-        version: 7.8.1
       skilld-protocol:
         specifier: workspace:*
         version: link:packages/protocol
@@ -189,6 +183,9 @@ importers:
       unagent:
         specifier: 'catalog:'
         version: 0.0.8(@huggingface/transformers@4.2.0)(sqlite-vec@0.1.9)
+      verkit:
+        specifier: 'catalog:'
+        version: 0.2.0
     devDependencies:
       '@antfu/eslint-config':
         specifier: catalog:dev-lint
@@ -196,9 +193,6 @@ importers:
       '@types/node':
         specifier: catalog:dev-build
         version: 25.9.1
-      '@types/semver':
-        specifier: 'catalog:'
-        version: 7.7.1
       '@vitest/coverage-v8':
         specifier: catalog:dev-test
         version: 4.1.7(vitest@4.1.7)
@@ -1861,9 +1855,6 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
-
-  '@types/semver@7.7.1':
-    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3861,6 +3852,10 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  verkit@0.2.0:
+    resolution: {integrity: sha512-6M8R2xSKplkQ+0mAm07IMh548GLLPUnRQZJCCe/W4rfk/SXW2bs8ZJSWa5kjdIdsx3hLG5oLWROJ4+N5hpX08g==}
+    engines: {node: '>=18.12.0'}
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -5354,8 +5349,6 @@ snapshots:
 
   '@types/retry@0.12.0': {}
 
-  '@types/semver@7.7.1': {}
-
   '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3))(eslint@10.4.0(jiti@2.6.1))(typescript@6.0.3)':
@@ -5434,7 +5427,7 @@ snapshots:
       eslint: 10.4.0(jiti@2.6.1)
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      semver: 7.8.0
+      semver: 7.8.1
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -5492,7 +5485,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3
       minimatch: 10.2.5
-      semver: 7.8.0
+      semver: 7.8.1
       tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
@@ -7689,6 +7682,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   validate-npm-package-name@5.0.1: {}
+
+  verkit@0.2.0: {}
 
   vite@7.3.1(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 catalogMode: prefer
+minimumReleaseAgeExclude:
+  - verkit@0.2.0
 shellEmulator: true
 
 trustPolicy: no-downgrade
@@ -11,7 +13,6 @@ catalog:
   '@arethetypeswrong/cli': ^0.18.2
   '@earendil-works/pi-ai': ^0.76.0
   '@mdream/crawl': ^1.2.2
-  '@types/semver': ^7.7.1
   bumpp: ^11.1.0
   giget: ^3.2.0
   hookable: ^6.1.1
@@ -21,12 +22,12 @@ catalog:
   pathe: ^2.0.3
   publint: ^0.3.21
   retriv: ^0.14.7
-  semver: ^7.8.1
   std-env: ^4.1.0
   tsx: ^4.22.3
   typebox: ^1.1.38
   typescript: 6.0.3
   unagent: ^0.0.8
+  verkit: ^0.2.0
   zod: ^4.4.3
 catalogs:
   deps:

--- a/src/core/semver.ts
+++ b/src/core/semver.ts
@@ -3,19 +3,19 @@
  * Centralized so the loose flag stays consistent across the project.
  */
 
-import { diff as _diff, gt as _gt, valid as _valid } from 'semver'
+import { difference, isGreater, normalize } from 'verkit'
 
 /** Returns the cleaned version if valid semver, null otherwise. */
 export function semverValid(v: string): string | null {
-  return _valid(v, true)
+  return normalize(v, { loose: true })
 }
 
 /** Compare two semver strings: returns true if a > b. Handles prereleases. */
 export function semverGt(a: string, b: string): boolean {
-  return _gt(a, b, true)
+  return isGreater(a, b, { loose: true })
 }
 
 /** Returns the semver diff type between two versions, or null if equal/invalid. */
 export function semverDiff(a: string, b: string): string | null {
-  return _diff(a, b)
+  return difference(a, b)
 }


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Replaces the node-semver wrappers in src/core/semver.ts with verkit 0.2.0 named exports. Removes @types/semver and keeps loose parsing for validation and comparison.
