### PR TITLE
fix(cli): accept source prefixes in the wizard package prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ skilld
 # Add skills for specific package(s) — npm: prefix for registry packages
 skilld add npm:vue npm:nuxt npm:pinia
 
+# The same prefixes work in the interactive wizard's package prompt
+
 # Add a pre-authored skill from a GitHub repo
 skilld add gh:vercel-labs/agent-skills
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,6 +14,7 @@ import { isInteractive, isRunningInsideAgent } from './cli/env.ts'
 import { formatStatus, getRepoHint, relativeTime } from './cli/intro.ts'
 import { guard, menuLoop } from './cli/menu.ts'
 import { hasPrepareHook, suggestPrepareHook } from './cli/prepare-hook.ts'
+import { parseSkillInput } from './core/prefix.ts'
 import { configCommand, configCommandDef } from './commands/config.ts'
 import { removeCommand, removeCommandDef } from './commands/remove.ts'
 import { infoCommandDef, statusCommand } from './commands/status.ts'
@@ -58,6 +59,23 @@ function deprecatedForwarder(
 }
 
 // ── Subcommands (lazy-loaded) ──
+
+/**
+ * Normalize manually-entered packages. Accepts `npm:` prefixed and bare names;
+ * other sources are only installable through `skilld add`.
+ */
+function toPackageNames(tokens: string[]): string[] | null {
+  const names: string[] = []
+  for (const token of tokens) {
+    const source = parseSkillInput(token)
+    if (source.type !== 'npm' && source.type !== 'bare') {
+      p.log.error(`${token} is not an npm package. Install it with \`skilld add ${token}\`.`)
+      return null
+    }
+    names.push(source.package)
+  }
+  return names
+}
 
 const SUBCOMMAND_NAMES = ['add', 'eject', 'update', 'info', 'list', 'config', 'remove', 'install', 'uninstall', 'search', 'cache', 'validate', 'assemble', 'setup', 'prepare', 'author', 'publish', 'upload', 'login', 'logout', 'whoami', 'pull']
 
@@ -277,7 +295,7 @@ const main = defineCommand({
         if (source === 'manual') {
           const input = await p.text({
             message: 'Enter package names (space or comma-separated)',
-            placeholder: 'vue nuxt pinia',
+            placeholder: 'vue npm:nuxt pinia',
           })
           if (p.isCancel(input)) {
             if (!hasPkgJson) {
@@ -290,7 +308,10 @@ const main = defineCommand({
             p.log.warn('No packages entered')
             continue
           }
-          selected = input.split(COMMA_OR_WHITESPACE_RE).map(s => s.trim()).filter(Boolean)
+          const names = toPackageNames(input.split(COMMA_OR_WHITESPACE_RE).map(s => s.trim()).filter(Boolean))
+          if (!names)
+            continue
+          selected = names
           if (selected.length === 0) {
             p.log.warn('No valid packages entered')
             continue
@@ -534,11 +555,14 @@ const main = defineCommand({
             if (source === 'manual') {
               const input = guard(await p.text({
                 message: 'Enter package names (space or comma-separated)',
-                placeholder: 'vue nuxt pinia',
+                placeholder: 'vue npm:nuxt pinia',
               }))
               if (!input)
                 return
-              selected = input.split(COMMA_OR_WHITESPACE_RE).map(s => s.trim()).filter(Boolean)
+              const names = toPackageNames(input.split(COMMA_OR_WHITESPACE_RE).map(s => s.trim()).filter(Boolean))
+              if (!names)
+                return
+              selected = names
               if (selected.length === 0)
                 return
             }

--- a/src/core/prepare.ts
+++ b/src/core/prepare.ts
@@ -29,7 +29,14 @@ export function resolvePkgDir(name: string, cwd: string, version?: string): stri
     return nodeModulesPath
 
   if (version) {
-    const cachedPkgDir = join(getCacheDir(name, version), 'pkg')
+    // getCacheDir rejects malformed names; this path probes, so treat that as a miss.
+    let cachedPkgDir: string
+    try {
+      cachedPkgDir = join(getCacheDir(name, version), 'pkg')
+    }
+    catch {
+      return null
+    }
     if (existsSync(join(cachedPkgDir, 'package.json')))
       return cachedPkgDir
   }

--- a/test/unit/pkg-dir-probe.test.ts
+++ b/test/unit/pkg-dir-probe.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { getShippedSkills, resolvePkgDir } from '../../src/core/prepare.ts'
+
+// `getCacheDir` rejects malformed names to block path traversal. These callers
+// probe for an optional cache hit, so a rejection is a miss, not a crash: an
+// unparsed spec used to abort the whole sync with an uncaught error.
+describe('package dir probing', () => {
+  it.each(['npm:vue', 'gh:owner/repo', '../escape'])('returns null for %j', (name) => {
+    expect(resolvePkgDir(name, process.cwd(), '1.0.0')).toBeNull()
+  })
+
+  it.each(['npm:vue', '../escape'])('reports no shipped skills for %j', (name) => {
+    expect(getShippedSkills(name, process.cwd(), '1.0.0')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

The interactive wizard rejects the source prefixes documented for `skilld add`, with a stack trace rather than a message:

```
◇  Enter package names (space or comma-separated)
│  npm:unlighthouse
│
◑  npm:unlighthouse: npm registryError: Invalid package name: npm:unlighthouse
    at getCacheDir (dist/_chunks/prepare.mjs:15:40)
    at resolvePkgDir (dist/_chunks/prepare.mjs:30:29)
    at getShippedSkills (dist/_chunks/prepare.mjs:53:18)
    at handleShippedSkills (dist/_chunks/skill-installer2.mjs:14:24)
    at npmResolver (dist/_chunks/sync.mjs:34:20)

■  Canceled
```

`add` normalizes its inputs:

```ts
// src/commands/sync/add.ts
const items = rawInputs.map(parseSkillInput)
```

The wizard does not:

```ts
// src/cli.ts
selected = input.split(COMMA_OR_WHITESPACE_RE).map(s => s.trim()).filter(Boolean)
```

So `npm:unlighthouse` travels as a literal package name until `getCacheDir` rejects it, and the throw takes down the whole run.

## Change

Normalize the same way `add` does, at both manual-entry prompts. `npm:` prefixed and bare names resolve; other sources report where they belong instead of failing later:

```
gh:owner/repo is not an npm package. Install it with `skilld add gh:owner/repo`.
```

Second, `resolvePkgDir` no longer lets the validation error escape. It probes for an optional cache hit, so a malformed name is a miss. Traversal is still rejected, it just no longer aborts a sync from a read path. `getShippedSkills` is the only caller that could reach it with unvalidated input, and it already treats "not found" as empty.

## Testing

`test/unit/pkg-dir-probe.test.ts` covers the probe returning null for `npm:vue`, `gh:owner/repo`, and `../escape` rather than throwing, and `getShippedSkills` reporting none.

Normalization verified against the wizard's own splitting:

```
npm:unlighthouse           -> ["unlighthouse"]
unlighthouse               -> ["unlighthouse"]
vue npm:nuxt pinia         -> ["vue","nuxt","pinia"]
gh:harlan-zw/unlighthouse  -> rejected with guidance
crate:serde                -> rejected with guidance
```

```
Test Files  57 passed (57)
     Tests  908 passed (908)
```

`pnpm typecheck` clean.

## Docs

README notes that the same prefixes work in the wizard prompt, and the placeholder now shows one (`vue npm:nuxt pinia`).

## Out of scope

`resolvePkgDir('', cwd, v)` returns `<cwd>/node_modules`, because `join(cwd, 'node_modules', '')` exists. No caller passes an empty name, so I left it alone rather than widen this PR.
