### PR TITLE
feat: connect installs and change watches to skilld.dev

### DIFF
--- a/packages/protocol/src/test-fixtures.ts
+++ b/packages/protocol/src/test-fixtures.ts
@@ -29,8 +29,6 @@ export const fixtures = {
   audit: {
     skillLivePass: {
       id: 'antfu/skills/vue',
-      installs: 1234,
-      formatted: '1.2k',
       audits: [
         { provider: 'skills.sh', slug: 'static', status: 'pass' },
         { provider: 'skills.sh', slug: 'license', status: 'pass' },
@@ -40,8 +38,6 @@ export const fixtures = {
     },
     skillLiveWarn: {
       id: 'antfu/skills/motion-v',
-      installs: 42,
-      formatted: '42',
       audits: [
         { provider: 'skills.sh', slug: 'static', status: 'pass' },
         { provider: 'skills.sh', slug: 'deps', status: 'warn', summary: 'wildcard import', riskLevel: 'medium', categories: ['imports'] },
@@ -177,7 +173,7 @@ export const fixtures = {
       repo: 'skills',
       name: 'vue',
       displayName: 'Vue',
-      installs: 1234,
+      stars: 1234,
       branch: 'main',
       skillPath: 'vue/SKILL.md',
       raw: '# Vue\n\nUse <script setup>.',

--- a/packages/protocol/src/wire/audit.ts
+++ b/packages/protocol/src/wire/audit.ts
@@ -26,12 +26,10 @@ export const AuditEntrySchema = z.object({
 
 export const SkillLiveResponseSchema = z.object({
   id: z.string(),
-  installs: z.number().nullable(),
-  formatted: z.string().nullable(),
   audits: z.array(AuditEntrySchema),
   source: z.literal('skills.sh'),
   fetchedAt: z.string(),
-})
+}).strict()
 
 export type AuditEntry = z.infer<typeof AuditEntrySchema>
 export type SkillLiveResponse = z.infer<typeof SkillLiveResponseSchema>

--- a/packages/protocol/src/wire/skills.ts
+++ b/packages/protocol/src/wire/skills.ts
@@ -31,12 +31,12 @@ export const SkillDetailResponseSchema = z.object({
   repo: z.string(),
   name: z.string(),
   displayName: z.string(),
-  installs: z.number(),
-  branch: z.string().optional(),
-  skillPath: z.string().nullable().optional(),
-  raw: z.string().nullable().optional(),
-  pushedAt: z.string().nullable().optional(),
-})
+  stars: z.number(),
+  branch: z.string(),
+  skillPath: z.string().nullable(),
+  raw: z.string().nullable(),
+  pushedAt: z.string().nullable(),
+}).passthrough()
 
 export type SkillsResolveInput = z.infer<typeof SkillsResolveInputSchema>
 export type SkillsResolveEntry = z.infer<typeof SkillsResolveEntrySchema>

--- a/src/auth/client.ts
+++ b/src/auth/client.ts
@@ -1,5 +1,5 @@
 /**
- * `withAuth(fetcher)` — wraps an ofetch-like call with the current session.
+ * `withAuth(baseUrl)` wraps an ofetch-like call with the current session.
  * Adds `Authorization: Bearer …`, refreshes on 401, re-reads the marker file
  * before refreshing so concurrent CLI invocations can share a rotated token.
  *
@@ -7,62 +7,84 @@
  * expiry: a 401 propagates instead of triggering refresh.
  */
 
+import type { StorageScheme, StoredSession } from './store.ts'
 import type { TokenResponse } from './types.ts'
 import { ofetch } from 'ofetch'
-import { getRegistryBase } from '../registry/client.ts'
 import { loadSession, saveSession } from './store.ts'
 
 export interface AuthedFetcher {
   <T>(url: string, init?: Parameters<typeof ofetch<T>>[1]): Promise<T>
 }
 
-async function refreshSession(refreshToken: string): Promise<TokenResponse | null> {
-  const base = getRegistryBase()
-  return ofetch<TokenResponse>(`${base}/cli/oauth/refresh`, {
-    method: 'POST',
-    body: { refresh_token: refreshToken },
-  }).catch(() => null)
+interface AuthenticatedFetchDependencies {
+  baseUrl: string
+  fetch: AuthedFetcher
+  loadSession: () => Promise<StoredSession | null>
+  saveSession: (session: Parameters<typeof saveSession>[0]) => Promise<StorageScheme>
 }
 
-export function withAuth(): AuthedFetcher {
+type FetchAttempt<T>
+  = | { _tag: 'Ok', value: T }
+    | { _tag: 'Err', error: unknown }
+
+function isAuthFailure(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('statusCode' in error))
+    return false
+  const statusCode = (error as { statusCode?: unknown }).statusCode
+  return statusCode === 401 || statusCode === 403
+}
+
+export function createAuthenticatedFetch(deps: AuthenticatedFetchDependencies): AuthedFetcher {
   return async <T>(url: string, init?: Parameters<typeof ofetch<T>>[1]): Promise<T> => {
-    const session = await loadSession()
+    const session = await deps.loadSession()
     if (!session)
       throw new Error('auth required')
 
-    const send = (token: string): Promise<T> => ofetch<T>(url, {
+    const send = (token: string): Promise<T> => deps.fetch<T>(url, {
       ...init,
       headers: { ...(init?.headers as any), Authorization: `Bearer ${token}` },
     })
 
-    const fail401Codes = new Set([401, 403])
-
-    const firstAttempt = await send(session.accessToken).catch((err: { statusCode?: number } & Error) => err)
-    if (!(firstAttempt instanceof Error) || !fail401Codes.has((firstAttempt as { statusCode?: number }).statusCode ?? 0))
-      return firstAttempt as T
+    const firstAttempt: FetchAttempt<T> = await send(session.accessToken)
+      .then(value => ({ _tag: 'Ok' as const, value }))
+      .catch(error => ({ _tag: 'Err' as const, error }))
+    if (firstAttempt._tag === 'Ok')
+      return firstAttempt.value
+    if (!isAuthFailure(firstAttempt.error))
+      throw firstAttempt.error
 
     if (session.scheme === 'env' || !session.refreshToken)
-      throw firstAttempt
+      throw firstAttempt.error
 
     // Re-read marker; another process may have already rotated.
-    const fresh = await loadSession()
+    const fresh = await deps.loadSession()
     const candidateRefresh = fresh?.refreshToken ?? session.refreshToken
-    if (fresh && fresh.accessToken !== session.accessToken) {
+    if (fresh && fresh.accessToken !== session.accessToken)
       return send(fresh.accessToken)
-    }
 
-    const rotated = await refreshSession(candidateRefresh)
-    if (!rotated)
-      throw firstAttempt
+    const rotated = await deps.fetch<TokenResponse>(`${deps.baseUrl}/cli/oauth/refresh`, {
+      method: 'POST',
+      body: { refresh_token: candidateRefresh },
+    })
 
-    await saveSession({
+    await deps.saveSession({
       login: rotated.login,
       accessToken: rotated.accessToken,
       refreshToken: rotated.refreshToken,
       expiresAt: rotated.expiresAt,
+      host: session.host,
       tokens: { accessToken: rotated.accessToken, refreshToken: rotated.refreshToken },
     })
 
     return send(rotated.accessToken)
   }
+}
+
+export function withAuth(baseUrl: string): AuthedFetcher {
+  return createAuthenticatedFetch({
+    baseUrl,
+    fetch: ofetch,
+    loadSession,
+    saveSession,
+  })
 }

--- a/src/auth/store.ts
+++ b/src/auth/store.ts
@@ -6,7 +6,7 @@
  * file. Use it in CI when keychain access isn't available.
  */
 
-import type { AuthSession } from '../registry/client.ts'
+import type { AuthSession } from 'skilld-protocol/wire'
 import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { dirname } from 'pathe'
 import { AUTH_PATH, CACHE_DIR } from '../core/paths.ts'

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,7 +59,7 @@ function deprecatedForwarder(
 
 // ── Subcommands (lazy-loaded) ──
 
-const SUBCOMMAND_NAMES = ['add', 'eject', 'update', 'info', 'list', 'config', 'remove', 'install', 'uninstall', 'search', 'cache', 'validate', 'assemble', 'setup', 'prepare', 'author', 'publish', 'upload', 'login', 'logout', 'whoami', 'pull']
+const SUBCOMMAND_NAMES = ['add', 'eject', 'update', 'changes', 'watch', 'unwatch', 'info', 'list', 'config', 'remove', 'install', 'uninstall', 'search', 'cache', 'validate', 'assemble', 'setup', 'prepare', 'author', 'publish', 'upload', 'login', 'logout', 'whoami', 'pull']
 
 // ── Main command ──
 
@@ -75,6 +75,9 @@ const main = defineCommand({
   subCommands: {
     add: () => import('./commands/sync/add.ts').then(m => m.addCommandDef),
     update: () => import('./commands/sync/update.ts').then(m => m.updateCommandDef),
+    changes: () => import('./commands/changes.ts').then(m => m.changesCommandDef),
+    watch: () => import('./commands/watch.ts').then(m => m.watchCommandDef),
+    unwatch: () => import('./commands/watch.ts').then(m => m.unwatchCommandDef),
     info: () => infoCommandDef,
     list: () => import('./commands/list.ts').then(m => m.listCommandDef),
     config: () => configCommandDef,

--- a/src/cli/digest-render.ts
+++ b/src/cli/digest-render.ts
@@ -23,12 +23,7 @@ function relative(iso: string, now = Date.now()): string {
   return RELATIVE_FORMATTER.format(Math.round(hours / 24), 'day')
 }
 
-export function renderDigest(entries: ChangeEntry[]): void {
-  if (entries.length === 0) {
-    p.log.success('No new updates since last digest.')
-    return
-  }
-
+export function formatDigestLines(entries: ChangeEntry[], now = Date.now()): string[] {
   const byRepo = new Map<string, ChangeEntry[]>()
   for (const entry of entries) {
     const list = byRepo.get(entry.repo) ?? []
@@ -40,14 +35,21 @@ export function renderDigest(entries: ChangeEntry[]): void {
   for (const [repo, items] of byRepo) {
     lines.push(styleText('cyan', repo))
     for (const item of items) {
-      const when = styleText('gray', relative(item.at))
+      const when = styleText('gray', relative(item.at, now))
       lines.push(`  ${styleText('green', '•')} ${item.skill} ${when}`)
       if (item.summary)
         lines.push(`    ${styleText('gray', item.summary)}`)
+      lines.push(`    ${styleText('gray', `https://skilld.dev/gh/${item.repo}/${encodeURIComponent(item.skill)}`)}`)
     }
   }
-  lines.push('')
-  lines.push(styleText('gray', 'See full activity at https://skilld.dev/me/activity'))
+  return lines
+}
 
-  p.log.message(lines.join('\n'))
+export function renderDigest(entries: ChangeEntry[]): void {
+  if (entries.length === 0) {
+    p.log.success('No new updates since last digest.')
+    return
+  }
+
+  p.log.message(formatDigestLines(entries).join('\n'))
 }

--- a/src/commands/changes.ts
+++ b/src/commands/changes.ts
@@ -1,0 +1,19 @@
+import * as p from '@clack/prompts'
+import { defineCommand } from 'citty'
+import { renderChangesDigest } from './sync/changes-digest.ts'
+
+export const changesCommandDef = defineCommand({
+  meta: { name: 'changes', description: 'Show watched skill changes' },
+  async run() {
+    p.intro('skilld changes')
+    const result = await renderChangesDigest(true).catch((error) => {
+      p.log.error(`Failed to load changes: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+      return null
+    })
+    if (result === 'auth-required') {
+      p.log.error('Not logged in. Run `skilld login` first.')
+      process.exitCode = 1
+    }
+  },
+})

--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -16,6 +16,7 @@ import { loadSession } from '../auth/store.ts'
 import { autoResolveAgent } from '../cli/agent-prompt.ts'
 import { sharedArgs } from '../cli/args.ts'
 import { createRegistryClient } from '../registry/client.ts'
+import { manifestToSources } from '../registry/collections.ts'
 import { track } from '../telemetry.ts'
 import { installSkills } from './sync/install-many.ts'
 
@@ -23,46 +24,6 @@ function manifestItemKey(item: CollectionManifestItem): string {
   if (item.kind === 'gh')
     return item.name ? `${item.owner}/${item.repo}/${item.name}` : `${item.owner}/${item.repo}`
   return item.package ?? `${item.kind}:unknown`
-}
-
-/**
- * Convert selected manifest items into `installSkills` inputs. Multiple gh
- * items in the same repo collapse to one `git` source carrying the union of
- * picked skill names as `skillFilter`, so a repo with N skills installs in
- * one `syncGitSkills` call instead of N redundant ones.
- */
-function manifestToSources(items: CollectionManifestItem[]): Array<{ source: SkillSource, skillFilter?: string }> {
-  const npm: Array<{ source: SkillSource, skillFilter?: string }> = []
-  const crate: Array<{ source: SkillSource, skillFilter?: string }> = []
-  const ghByRepo = new Map<string, { owner: string, repo: string, names: string[] }>()
-
-  for (const item of items) {
-    if (item.kind === 'npm' && item.package) {
-      npm.push({ source: { type: 'npm', package: item.package } })
-      continue
-    }
-    if (item.kind === 'crate' && item.package) {
-      crate.push({ source: { type: 'crate', package: item.package } })
-      continue
-    }
-    if (item.kind === 'gh' && item.owner && item.repo) {
-      const key = `${item.owner}/${item.repo}`
-      const group = ghByRepo.get(key) ?? { owner: item.owner, repo: item.repo, names: [] }
-      if (item.name && !group.names.includes(item.name))
-        group.names.push(item.name)
-      ghByRepo.set(key, group)
-    }
-  }
-
-  const gh: Array<{ source: SkillSource, skillFilter?: string }> = []
-  for (const group of ghByRepo.values()) {
-    gh.push({
-      source: { type: 'git', source: { type: 'github', owner: group.owner, repo: group.repo } },
-      skillFilter: group.names.length ? group.names.join(',') : undefined,
-    })
-  }
-
-  return [...gh, ...npm, ...crate]
 }
 
 function badgeFor(status: AuditStatus, result: AuditResult): string {
@@ -126,15 +87,28 @@ export const pullCommandDef = defineCommand({
       return
     }
 
-    const client = createRegistryClient({ session })
-    const collections = await client.my.collections()
+    const client = createRegistryClient()
+    const collections = await client.my.collections().catch((error) => {
+      p.log.error(`Failed to load collections: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+      return null
+    })
+    if (!collections)
+      return
     const picked = await pickCollection(collections, args.collection)
     if (!picked)
       return
 
-    const manifest = await client.fetchCollection(session.login, picked.slug) as CollectionManifest | null
+    let manifestFailed = false
+    const manifest = await client.fetchCollection(session.login, picked.slug).catch((error) => {
+      manifestFailed = true
+      p.log.error(`Failed to load @${session.login}/${picked.slug}: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+      return null
+    }) as CollectionManifest | null
     if (!manifest) {
-      p.log.error(`Failed to load collection manifest for @${session.login}/${picked.slug}.`)
+      if (!manifestFailed)
+        p.log.error(`Collection @${session.login}/${picked.slug} was not found.`)
       process.exitCode = 1
       return
     }
@@ -156,7 +130,10 @@ export const pullCommandDef = defineCommand({
         auditByKey.set(manifestItemKey(item), { status: 'unaudited', audits: [] })
         return
       }
-      const result = await client.audit({ owner: item.owner, repo: item.repo, name: item.name })
+      const result = await client.audit({ owner: item.owner, repo: item.repo, name: item.name }).catch((error) => {
+        p.log.warn(`Audit unavailable for ${item.owner}/${item.repo}/${item.name}: ${error instanceof Error ? error.message : String(error)}`)
+        return { status: 'unaudited' as const, audits: [] }
+      })
       auditCache.set(`${item.owner}/${item.repo}/${item.name}`, result)
       auditByKey.set(manifestItemKey(item), result)
     }))

--- a/src/commands/sync/add.ts
+++ b/src/commands/sync/add.ts
@@ -45,8 +45,8 @@ export const addCommandDef = defineCommand({
 
     // --agent none → portable export (no installed-agent target needed).
     if (args.agent === 'none') {
-      if (items.some(item => item.type === 'curator' || item.type === 'collection')) {
-        p.log.error('Curator and collection installs require a target agent.')
+      if (items.some(item => item.type === 'curator')) {
+        p.log.error('Curator installs require a target agent.')
         process.exitCode = 1
         return
       }

--- a/src/commands/sync/add.ts
+++ b/src/commands/sync/add.ts
@@ -6,12 +6,13 @@ import { sharedArgs } from '../../cli/args.ts'
 import { hasCompletedWizard } from '../../core/config.ts'
 import { parseSkillInput } from '../../core/prefix.ts'
 import { COMMA_OR_WHITESPACE_RE } from '../../core/regex.ts'
+import { watchRepositories } from '../watch.ts'
 import { runWizard } from '../wizard.ts'
 import { installSkills } from './install-many.ts'
 import { exportPortablePrompts } from './portable.ts'
 
 export const addCommandDef = defineCommand({
-  meta: { name: 'add', description: 'Install skills (npm:<pkg>, crate:<name>, gh:<owner/repo>, @<curator>)' },
+  meta: { name: 'add', description: 'Install skills from packages, repositories, curators, or collections' },
   args: {
     'package': {
       type: 'positional',
@@ -28,6 +29,10 @@ export const addCommandDef = defineCommand({
       type: 'boolean',
       description: 'Install skills that fail the upstream audit gate',
     },
+    'watch': {
+      type: 'boolean',
+      description: 'Watch installed repositories for changes',
+    },
     ...sharedArgs,
   },
   async run({ args }) {
@@ -36,9 +41,15 @@ export const addCommandDef = defineCommand({
         .map((s: string) => s.trim())
         .filter(Boolean),
     )]
+    const items = rawInputs.map(parseSkillInput)
 
     // --agent none → portable export (no installed-agent target needed).
     if (args.agent === 'none') {
+      if (items.some(item => item.type === 'curator' || item.type === 'collection')) {
+        p.log.error('Curator and collection installs require a target agent.')
+        process.exitCode = 1
+        return
+      }
       const packages = [...new Set(rawInputs.flatMap(s => s.split(COMMA_OR_WHITESPACE_RE)).map(s => s.trim()).filter(Boolean))]
       for (const pkg of packages)
         await exportPortablePrompts(pkg, { force: args.force, agent: 'none' })
@@ -55,8 +66,7 @@ export const addCommandDef = defineCommand({
     if (!hasCompletedWizard())
       await runWizard({ agent })
 
-    const items = rawInputs.map(parseSkillInput)
-    await installSkills(items, {
+    const summary = await installSkills(items, {
       agent,
       surface: 'cli:add',
       global: args.global,
@@ -67,5 +77,22 @@ export const addCommandDef = defineCommand({
       skillFilter: args.skill,
       allowUnsafe: args['allow-unsafe'],
     })
+    if (args.watch) {
+      if (summary.repositories.length === 0) {
+        p.log.warn('No GitHub repositories were resolved to watch.')
+        return
+      }
+      await watchRepositories(summary.repositories).then((result) => {
+        if (result._tag === 'AuthRequired') {
+          p.log.error('Skills installed. Run `skilld login`, then `skilld watch`.')
+          process.exitCode = 1
+          return
+        }
+        p.log.success(`Watching ${summary.repositories.length} repositories. ${result.inserted} added.`)
+      }).catch((error) => {
+        p.log.error(`Skills installed, but watch failed: ${error instanceof Error ? error.message : String(error)}`)
+        process.exitCode = 1
+      })
+    }
   },
 })

--- a/src/commands/sync/changes-digest.ts
+++ b/src/commands/sync/changes-digest.ts
@@ -1,0 +1,16 @@
+import { loadSession, peekMarker, updateMarker } from '../../auth/store.ts'
+import { renderDigest } from '../../cli/digest-render.ts'
+import { createRegistryClient } from '../../registry/client.ts'
+
+export async function renderChangesDigest(showEmpty = false): Promise<'auth-required' | 'shown' | 'empty'> {
+  const session = await loadSession()
+  if (!session)
+    return 'auth-required'
+  const marker = peekMarker()
+  const client = createRegistryClient()
+  const digest = await client.my.changes({ since: marker?.lastDigestAt })
+  if (digest.entries.length > 0 || showEmpty)
+    renderDigest(digest.entries)
+  updateMarker({ lastDigestAt: digest.windowEnd })
+  return digest.entries.length > 0 ? 'shown' : 'empty'
+}

--- a/src/commands/sync/install-many.ts
+++ b/src/commands/sync/install-many.ts
@@ -6,7 +6,7 @@
 
 import type { AgentType, OptimizeModel } from '../../agent/index.ts'
 import type { SkillSource } from '../../core/prefix.ts'
-import type { AuditResult, RegistryClient } from '../../registry/client.ts'
+import type { AuditResult, RegistryClient, RepositoryRef } from '../../registry/client.ts'
 import type { GitSkillSource } from '../../sources/git-skills.ts'
 import { styleText } from 'node:util'
 import * as p from '@clack/prompts'
@@ -14,6 +14,7 @@ import { introLine } from '../../cli/intro.ts'
 import { COMMA_OR_WHITESPACE_RE } from '../../core/regex.ts'
 import { getProjectState } from '../../core/skills.ts'
 import { createRegistryClient, gateInstall } from '../../registry/client.ts'
+import { manifestToSources } from '../../registry/collections.ts'
 import { track } from '../../telemetry.ts'
 import { syncGitSkills } from '../sync-git.ts'
 import { syncCommand } from '../sync.ts'
@@ -40,9 +41,120 @@ export interface InstallSummary {
   installed: number
   skipped: number
   failed: number
+  repositories: RepositoryRef[]
 }
 
 const RECEIPTS_URL = 'https://skilld.dev/gh'
+
+function repositoryKey(repo: RepositoryRef): string {
+  return `${repo.owner}/${repo.repo}`
+}
+
+function addRepository(repositories: RepositoryRef[], repository: RepositoryRef): void {
+  if (!repositories.some(repo => repositoryKey(repo) === repositoryKey(repository)))
+    repositories.push(repository)
+}
+
+function manifestItemsToSources(items: Parameters<typeof manifestToSources>[0]): SkillSource[] {
+  return manifestToSources(items).map(({ source, skillFilter }) =>
+    source.type === 'git' ? { ...source, skillFilter } : source,
+  )
+}
+
+export async function expandPublicSources(
+  items: SkillSource[],
+  client: Pick<RegistryClient, 'fetchCollection' | 'fetchCurator'>,
+  yes: boolean,
+): Promise<{ items: SkillSource[], skipped: number, failed: number }> {
+  const expanded: SkillSource[] = []
+  let skipped = 0
+  let failed = 0
+
+  const loadCollection = async (handle: string, name: string, confirm: boolean): Promise<void> => {
+    let transportFailed = false
+    const manifest = await client.fetchCollection(handle, name).catch((error) => {
+      p.log.error(`Failed to load @${handle}/${name}: ${error instanceof Error ? error.message : String(error)}`)
+      transportFailed = true
+      failed += 1
+      return null
+    })
+    if (!manifest) {
+      if (!transportFailed) {
+        p.log.error(`Collection @${handle}/${name} was not found.`)
+        failed += 1
+      }
+      return
+    }
+    if (manifest.items.length === 0) {
+      p.log.info(`Collection @${handle}/${name} is empty.`)
+      skipped += 1
+      return
+    }
+    if (manifest.preamble)
+      p.note(manifest.preamble, manifest.name)
+    if (confirm && !yes) {
+      const accepted = await p.confirm({ message: `Install ${manifest.items.length} skills from @${handle}/${name}?` })
+      if (p.isCancel(accepted) || !accepted) {
+        skipped += 1
+        return
+      }
+    }
+    expanded.push(...manifestItemsToSources(manifest.items))
+  }
+
+  for (const source of items) {
+    if (source.type === 'collection') {
+      await loadCollection(source.handle, source.name, true)
+      continue
+    }
+    if (source.type !== 'curator') {
+      expanded.push(source)
+      continue
+    }
+
+    let transportFailed = false
+    const curator = await client.fetchCurator(source.handle).catch((error) => {
+      p.log.error(`Failed to load @${source.handle}: ${error instanceof Error ? error.message : String(error)}`)
+      transportFailed = true
+      failed += 1
+      return null
+    })
+    if (!curator) {
+      if (!transportFailed) {
+        p.log.error(`Curator @${source.handle} was not found.`)
+        failed += 1
+      }
+      continue
+    }
+    if (curator.collections.length === 0) {
+      p.log.info(`Curator @${source.handle} has no collections.`)
+      skipped += 1
+      continue
+    }
+
+    let slugs = curator.collections.map(collection => collection.slug)
+    if (!yes) {
+      const selection = await p.multiselect({
+        message: `Select collections from @${source.handle}`,
+        required: false,
+        options: curator.collections.map(collection => ({
+          label: collection.name,
+          value: collection.slug,
+          hint: `${collection.itemCount} skills`,
+        })),
+      })
+      if (p.isCancel(selection)) {
+        skipped += 1
+        continue
+      }
+      slugs = selection as string[]
+    }
+    for (const slug of slugs)
+      await loadCollection(source.handle, slug, false)
+  }
+
+  return { items: expanded, skipped, failed }
+}
 
 async function getAudit(
   client: RegistryClient,
@@ -55,7 +167,10 @@ async function getAudit(
   const cached = cache.get(key)
   if (cached)
     return cached
-  const result = await client.audit({ owner, repo, name })
+  const result = await client.audit({ owner, repo, name }).catch((error) => {
+    p.log.warn(`Audit unavailable for ${key}: ${error instanceof Error ? error.message : String(error)}`)
+    return { status: 'unaudited' as const, audits: [] }
+  })
   cache.set(key, result)
   return result
 }
@@ -76,16 +191,18 @@ function logAuditFail(slug: string, result: AuditResult, owner: string, repo: st
 
 export async function installSkills(items: SkillSource[], opts: InstallOpts): Promise<InstallSummary> {
   const cwd = process.cwd()
-  const summary: InstallSummary = { installed: 0, skipped: 0, failed: 0 }
+  const summary: InstallSummary = { installed: 0, skipped: 0, failed: 0, repositories: [] }
   const client = createRegistryClient()
   const auditCache = opts.auditCache ?? new Map<string, AuditResult>()
+  const publicSources = await expandPublicSources(items, client, !!opts.yes)
+  summary.skipped += publicSources.skipped
+  summary.failed += publicSources.failed
 
   const gitSources: Array<{ source: GitSkillSource, skillFilter?: string }> = []
   const npmEntries: Array<{ name: string, spec: string }> = []
   const crateSpecs: string[] = []
-  const unsupported: string[] = []
 
-  for (const source of items) {
+  for (const source of publicSources.items) {
     switch (source.type) {
       case 'git':
         gitSources.push({ source: source.source, skillFilter: source.skillFilter })
@@ -101,24 +218,13 @@ export async function installSkills(items: SkillSource[], opts: InstallOpts): Pr
         npmEntries.push({ name: source.package, spec: source.tag ? `${source.package}@${source.tag}` : source.package })
         break
       case 'curator':
-        unsupported.push(`@${source.handle} (curator)`)
-        break
       case 'collection':
-        unsupported.push(`@${source.handle}/${source.name} (collection)`)
-        break
+        throw new Error(`Unexpanded public source: ${JSON.stringify(source)}`)
       default: {
         const _exhaustive: never = source
         throw new Error(`Unhandled SkillSource type: ${JSON.stringify(_exhaustive)}`)
       }
     }
-  }
-
-  if (unsupported.length > 0) {
-    p.log.error(`Curator and collection installs are not yet available:\n  ${unsupported.join('\n  ')}\n\nFollow https://skilld.dev for launch updates.`)
-    summary.skipped += unsupported.length
-    process.exitCode = 1
-    if (gitSources.length === 0 && npmEntries.length === 0 && crateSpecs.length === 0)
-      return summary
   }
 
   for (const { source, skillFilter: perSourceFilter } of gitSources) {
@@ -137,7 +243,11 @@ export async function installSkills(items: SkillSource[], opts: InstallOpts): Pr
       debug: opts.debug,
       skillFilter,
     })
-      .then(() => { summary.installed += 1 })
+      .then(() => {
+        summary.installed += 1
+        if (source.type === 'github' && source.owner && source.repo)
+          addRepository(summary.repositories, { owner: source.owner, repo: source.repo })
+      })
       .catch((err) => {
         summary.failed += 1
         p.log.error(`Failed to install ${source.type === 'local' ? source.localPath : `${source.owner}/${source.repo}`}: ${err instanceof Error ? err.message : String(err)}`)
@@ -155,7 +265,10 @@ export async function installSkills(items: SkillSource[], opts: InstallOpts): Pr
 
     const fallbackPackages: string[] = []
     for (const entry of dedupedEntries) {
-      const resolved = await client.resolveSkill(entry.name).catch(() => null)
+      const resolved = await client.resolveSkill(entry.name).catch((error) => {
+        p.log.warn(`Registry unavailable for ${entry.name}: ${error instanceof Error ? error.message : String(error)}. Using package documentation.`)
+        return null
+      })
       if (!resolved) {
         fallbackPackages.push(entry.spec)
         continue
@@ -189,6 +302,7 @@ export async function installSkills(items: SkillSource[], opts: InstallOpts): Pr
       if (result) {
         p.log.success(`Installed ${styleText('cyan', result.name)} from registry`)
         summary.installed += 1
+        addRepository(summary.repositories, { owner: auditOwner!, repo: auditRepo! })
       }
       else if (result === null) {
         fallbackPackages.push(entry.spec)

--- a/src/commands/sync/install-many.ts
+++ b/src/commands/sync/install-many.ts
@@ -61,6 +61,10 @@ function manifestItemsToSources(items: Parameters<typeof manifestToSources>[0]):
   )
 }
 
+type MissingCollectionAction
+  = | { _tag: 'Fail' }
+    | { _tag: 'UseNpm', package: string }
+
 export async function expandPublicSources(
   items: SkillSource[],
   client: Pick<RegistryClient, 'fetchCollection' | 'fetchCurator'>,
@@ -70,7 +74,12 @@ export async function expandPublicSources(
   let skipped = 0
   let failed = 0
 
-  const loadCollection = async (handle: string, name: string, confirm: boolean): Promise<void> => {
+  const loadCollection = async (
+    handle: string,
+    name: string,
+    confirm: boolean,
+    onMissing: MissingCollectionAction,
+  ): Promise<void> => {
     let transportFailed = false
     const manifest = await client.fetchCollection(handle, name).catch((error) => {
       p.log.error(`Failed to load @${handle}/${name}: ${error instanceof Error ? error.message : String(error)}`)
@@ -79,7 +88,10 @@ export async function expandPublicSources(
       return null
     })
     if (!manifest) {
-      if (!transportFailed) {
+      if (!transportFailed && onMissing._tag === 'UseNpm') {
+        expanded.push({ type: 'bare', package: onMissing.package })
+      }
+      else if (!transportFailed) {
         p.log.error(`Collection @${handle}/${name} was not found.`)
         failed += 1
       }
@@ -103,8 +115,8 @@ export async function expandPublicSources(
   }
 
   for (const source of items) {
-    if (source.type === 'collection') {
-      await loadCollection(source.handle, source.name, true)
+    if (source.type === 'collection-or-npm') {
+      await loadCollection(source.handle, source.name, true, { _tag: 'UseNpm', package: source.package })
       continue
     }
     if (source.type !== 'curator') {
@@ -150,7 +162,7 @@ export async function expandPublicSources(
       slugs = selection as string[]
     }
     for (const slug of slugs)
-      await loadCollection(source.handle, slug, false)
+      await loadCollection(source.handle, slug, false, { _tag: 'Fail' })
   }
 
   return { items: expanded, skipped, failed }
@@ -218,7 +230,7 @@ export async function installSkills(items: SkillSource[], opts: InstallOpts): Pr
         npmEntries.push({ name: source.package, spec: source.tag ? `${source.package}@${source.tag}` : source.package })
         break
       case 'curator':
-      case 'collection':
+      case 'collection-or-npm':
         throw new Error(`Unexpanded public source: ${JSON.stringify(source)}`)
       default: {
         const _exhaustive: never = source

--- a/src/commands/sync/update.ts
+++ b/src/commands/sync/update.ts
@@ -2,34 +2,17 @@ import type { AgentType, OptimizeModel } from '../../agent/index.ts'
 import { styleText } from 'node:util'
 import * as p from '@clack/prompts'
 import { defineCommand } from 'citty'
-import { loadSession, peekMarker, updateMarker } from '../../auth/store.ts'
 import { autoResolveAgent } from '../../cli/agent-prompt.ts'
 import { sharedArgs } from '../../cli/args.ts'
-import { renderDigest } from '../../cli/digest-render.ts'
 import { isInteractive } from '../../cli/env.ts'
 import { getInstalledGenerators, introLine } from '../../cli/intro.ts'
 import { readConfig } from '../../core/config.ts'
 import { resolveSkillName } from '../../core/prefix.ts'
 import { COMMA_OR_WHITESPACE_RE } from '../../core/regex.ts'
 import { getProjectState } from '../../core/skills.ts'
-import { createRegistryClient } from '../../registry/client.ts'
 import { syncCommand } from '../sync.ts'
+import { renderChangesDigest } from './changes-digest.ts'
 import { exportPortablePrompts } from './portable.ts'
-
-async function renderChangesDigest(): Promise<void> {
-  const session = await loadSession()
-  if (!session || session.scheme === 'env')
-    return
-  const marker = peekMarker()
-  const client = createRegistryClient({ session })
-  const digest = await client.my.changes({ since: marker?.lastDigestAt }).catch(() => null)
-  if (!digest || digest.entries.length === 0)
-    return
-  renderDigest(digest.entries)
-  // Use the server's windowEnd as the canonical watermark — round-trippable
-  // and aligns with skilld.dev's email digest cron.
-  updateMarker({ lastDigestAt: digest.windowEnd })
-}
 
 export const updateCommandDef = defineCommand({
   meta: { name: 'update', description: 'Update outdated skills' },
@@ -152,7 +135,10 @@ export const updateCommandDef = defineCommand({
       mode: 'update',
     })
 
-    if (!silent)
-      await renderChangesDigest()
+    if (!silent) {
+      await renderChangesDigest().catch((error) => {
+        p.log.warn(`Changes unavailable: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }
   },
 })

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -1,0 +1,114 @@
+import type { RepositoryRef } from '../registry/client.ts'
+import * as p from '@clack/prompts'
+import { defineCommand } from 'citty'
+import { loadSession } from '../auth/store.ts'
+import { iterateSkills } from '../core/skills.ts'
+import { createRegistryClient } from '../registry/client.ts'
+
+type RepositoryInputResult
+  = | { _tag: 'Ok', repositories: RepositoryRef[] }
+    | { _tag: 'Err', invalid: string[] }
+
+const REPOSITORY_RE = /^([\w.-]+)\/([\w.-]+)$/
+
+export function parseRepositoryInputs(inputs: string[]): RepositoryInputResult {
+  const repositories: RepositoryRef[] = []
+  const invalid: string[] = []
+  for (const input of inputs) {
+    const match = input.trim().match(REPOSITORY_RE)
+    if (!match) {
+      invalid.push(input)
+      continue
+    }
+    const repository = { owner: match[1]!, repo: match[2]! }
+    if (!repositories.some(item => item.owner === repository.owner && item.repo === repository.repo))
+      repositories.push(repository)
+  }
+  return invalid.length > 0 ? { _tag: 'Err', invalid } : { _tag: 'Ok', repositories }
+}
+
+export function installedRepositories(cwd = process.cwd()): RepositoryRef[] {
+  const values = [...iterateSkills({ scope: 'local', cwd })]
+    .flatMap(skill => skill.info?.repo ? [skill.info.repo] : [])
+  return values.flatMap((value) => {
+    const result = parseRepositoryInputs([value])
+    return result._tag === 'Ok' ? result.repositories : []
+  }).filter((repository, index, repositories) =>
+    repositories.findIndex(candidate => candidate.owner === repository.owner && candidate.repo === repository.repo) === index,
+  )
+}
+
+export type WatchRepositoriesResult
+  = | { _tag: 'Watched', inserted: number }
+    | { _tag: 'AuthRequired' }
+
+export async function watchRepositories(repositories: RepositoryRef[]): Promise<WatchRepositoriesResult> {
+  if (!await loadSession())
+    return { _tag: 'AuthRequired' }
+  const response = await createRegistryClient().my.watch(repositories)
+  return { _tag: 'Watched', inserted: response.inserted }
+}
+
+function commandInputs(args: Record<string, unknown>): string[] {
+  return [args.repository, ...((args._ as string[] | undefined) ?? [])]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+}
+
+export const watchCommandDef = defineCommand({
+  meta: { name: 'watch', description: 'Watch installed repositories for changes' },
+  args: {
+    repository: { type: 'positional', description: 'GitHub repository in owner/repo form', required: false },
+  },
+  async run({ args }) {
+    const inputs = commandInputs(args)
+    const parsed = inputs.length > 0
+      ? parseRepositoryInputs(inputs)
+      : { _tag: 'Ok' as const, repositories: installedRepositories() }
+    if (parsed._tag === 'Err') {
+      p.log.error(`Invalid repositories: ${parsed.invalid.join(', ')}. Use owner/repo.`)
+      process.exitCode = 1
+      return
+    }
+    if (parsed.repositories.length === 0) {
+      p.log.warn('No installed GitHub repositories found.')
+      return
+    }
+    const result = await watchRepositories(parsed.repositories).catch((error) => {
+      p.log.error(`Failed to watch repositories: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+      return null
+    })
+    if (result?._tag === 'AuthRequired') {
+      p.log.error('Not logged in. Run `skilld login` first.')
+      process.exitCode = 1
+    }
+    if (result?._tag === 'Watched')
+      p.log.success(`Watching ${parsed.repositories.length} repositories. ${result.inserted} added.`)
+  },
+})
+
+export const unwatchCommandDef = defineCommand({
+  meta: { name: 'unwatch', description: 'Stop watching a repository' },
+  args: {
+    repository: { type: 'positional', description: 'GitHub repository in owner/repo form', required: true },
+  },
+  async run({ args }) {
+    const parsed = parseRepositoryInputs([args.repository])
+    if (parsed._tag === 'Err') {
+      p.log.error(`Invalid repository: ${args.repository}. Use owner/repo.`)
+      process.exitCode = 1
+      return
+    }
+    if (!await loadSession()) {
+      p.log.error('Not logged in. Run `skilld login` first.')
+      process.exitCode = 1
+      return
+    }
+    await createRegistryClient().my.unwatch(parsed.repositories[0]!).then(() => {
+      p.log.success(`Stopped watching ${args.repository}.`)
+    }).catch((error) => {
+      p.log.error(`Failed to stop watching: ${error instanceof Error ? error.message : String(error)}`)
+      process.exitCode = 1
+    })
+  },
+})

--- a/src/core/prefix.ts
+++ b/src/core/prefix.ts
@@ -64,17 +64,17 @@ export function parseSkillInput(input: string): SkillSource {
     return { type: 'bare', package: rest }
   }
 
-  // @handle (curator) or @scope/pkg (npm scoped package)
+  // @handle (curator) or @handle/collection
   if (trimmed.startsWith('@')) {
     const rest = trimmed.slice(1)
     const slashIdx = rest.indexOf('/')
-    if (slashIdx === -1) {
+    if (slashIdx === -1)
       return { type: 'curator', handle: rest }
+    return {
+      type: 'collection',
+      handle: rest.slice(0, slashIdx),
+      name: rest.slice(slashIdx + 1),
     }
-    // @scope/pkg → treat as npm scoped package (bare, deprecated form)
-    // Collections must be installed via npm:@handle/coll or a future prefix.
-    const { name, tag } = splitPackageTag(trimmed)
-    return { type: 'bare', package: name, tag }
   }
 
   // Try existing git detection (SSH, URLs, local paths, owner/repo shorthand)

--- a/src/core/prefix.ts
+++ b/src/core/prefix.ts
@@ -17,6 +17,7 @@ import { parseGitSkillInput } from '../sources/git-skills.ts'
 
 const STATIC_REGEX_1 = /^[\w.-]+\/[\w.-]+/
 const EXPLICIT_NON_NPM_PREFIX_RE = /^(?:crate|gh|github):/
+const SCOPED_NPM_PACKAGE_RE = /^@[^/\s]+\/[^@\s]+(?:@.+)?$/
 
 export type SkillSource
   = | { type: 'npm', package: string, tag?: string }
@@ -34,6 +35,11 @@ export function parseNpmPackageInputs(inputs: string[]): NpmPackageInputResult {
   const packageSpecs: string[] = []
 
   for (const input of inputs) {
+    if (SCOPED_NPM_PACKAGE_RE.test(input)) {
+      const { name, tag } = splitPackageTag(input)
+      packageSpecs.push(tag ? `${name}@${tag}` : name)
+      continue
+    }
     const source = parseSkillInput(input)
     const isMalformedExplicitSource = source.type === 'bare' && EXPLICIT_NON_NPM_PREFIX_RE.test(input)
     if ((source.type !== 'npm' && source.type !== 'bare') || isMalformedExplicitSource || !source.package)

--- a/src/core/prefix.ts
+++ b/src/core/prefix.ts
@@ -7,7 +7,7 @@
  *   gh:owner/repo   → git skill
  *   github:o/r      → git skill (alias)
  *   @handle          → curator's skills
- *   @handle/coll     → specific collection
+ *   @handle/coll     → collection, with scoped npm fallback
  *
  * Bare names (no prefix) are deprecated but still resolve as npm: with a warning.
  */
@@ -24,7 +24,7 @@ export type SkillSource
     | { type: 'crate', package: string, version?: string }
     | { type: 'git', source: GitSkillSource, skillFilter?: string }
     | { type: 'curator', handle: string }
-    | { type: 'collection', handle: string, name: string }
+    | { type: 'collection-or-npm', handle: string, name: string, package: string }
     | { type: 'bare', package: string, tag?: string }
 
 export type NpmPackageInputResult
@@ -90,16 +90,20 @@ export function parseSkillInput(input: string): SkillSource {
     return { type: 'bare', package: rest }
   }
 
-  // @handle (curator) or @handle/collection
+  // @handle (curator), @handle/collection, or legacy @scope/package
   if (trimmed.startsWith('@')) {
-    const rest = trimmed.slice(1)
+    const { name: packageName, tag } = splitPackageTag(trimmed)
+    if (tag)
+      return { type: 'bare', package: packageName, tag }
+    const rest = packageName.slice(1)
     const slashIdx = rest.indexOf('/')
     if (slashIdx === -1)
       return { type: 'curator', handle: rest }
     return {
-      type: 'collection',
+      type: 'collection-or-npm',
       handle: rest.slice(0, slashIdx),
       name: rest.slice(slashIdx + 1),
+      package: packageName,
     }
   }
 
@@ -115,14 +119,15 @@ export function parseSkillInput(input: string): SkillSource {
 
 /**
  * Resolve a CLI input to the bare package/skill name used for lookup in the lockfile.
- * Strips `npm:` / `gh:` prefixes. Returns null for curator/collection (not addressable
- * as a single skill name).
+ * Strips `npm:` / `gh:` prefixes. Returns null for curators, which do not address
+ * a single skill name.
  */
 export function resolveSkillName(input: string): string | null {
   const source = parseSkillInput(input)
   switch (source.type) {
     case 'npm':
     case 'bare':
+    case 'collection-or-npm':
       return source.package
     case 'crate':
       return `crate:${source.package}`
@@ -131,7 +136,6 @@ export function resolveSkillName(input: string): string | null {
         return source.source.repo
       return null
     case 'curator':
-    case 'collection':
       return null
     default: {
       const _exhaustive: never = source

--- a/src/registry/client.ts
+++ b/src/registry/client.ts
@@ -6,31 +6,37 @@
  * the raw SKILL.md. For local development, set SKILLD_REGISTRY_URL (e.g.
  * http://localhost:3000/api) to point at a running Nuxt dev server.
  *
- * Returns null when a skill isn't curated, the API is unreachable, or the
- * skill has no resolvable SKILL.md, so callers fall through to the
- * doc-generation pipeline.
+ * Returns null when a skill is not curated or has no SKILL.md. Transport and
+ * contract failures propagate to the command boundary.
  */
 
 import type { AuditStatus } from 'skilld-protocol/constants'
 import type {
   AuditEntry,
-  AuthSession,
   ChangeEntry,
   CollectionManifest,
   CollectionManifestItem,
   CollectionSummary,
   CuratorPayload,
   DigestResponse,
-  InstallEventPayload,
   SkillDetailResponse,
-  SkillsResolveEntry,
   SkillsResolveResponse,
-  SubscriptionSummary,
 } from 'skilld-protocol/wire'
+import type { AuthedFetcher } from '../auth/client.ts'
 import { ofetch } from 'ofetch'
+import {
+  AuditEntrySchema,
+  CollectionManifestSchema,
+  CollectionSummarySchema,
+  CuratorPayloadSchema,
+  DigestResponseSchema,
+  SkillDetailResponseSchema,
+  SkillsResolveResponseSchema,
+} from 'skilld-protocol/wire'
+import { withAuth } from '../auth/client.ts'
 import { TRAILING_SLASH_RE } from '../core/regex.ts'
 
-export type { AuditEntry, AuditStatus, AuthSession, ChangeEntry, CollectionManifest, CollectionManifestItem, CollectionSummary, CuratorPayload, DigestResponse, InstallEventPayload, SkillDetailResponse, SkillsResolveResponse, SubscriptionSummary }
+export type { AuditEntry, AuditStatus, ChangeEntry, CollectionManifest, CollectionManifestItem, CollectionSummary, CuratorPayload, DigestResponse, SkillDetailResponse, SkillsResolveResponse }
 
 const DEFAULT_REGISTRY_URL = 'https://skilld.dev/api'
 
@@ -45,7 +51,6 @@ export interface RegistrySkill {
   owner: string
   repo: string
   displayName?: string
-  installs?: number
   official?: boolean
   branch?: string
   skillPath?: string
@@ -67,10 +72,9 @@ export interface AuditResult {
   audits: AuditEntry[]
 }
 
-interface AuditApiResponse {
-  riskLevel?: 'low' | 'medium' | 'high'
-  summary?: string
-  audits?: AuditEntry[]
+export interface RepositoryRef {
+  owner: string
+  repo: string
 }
 
 export interface RegistryClient {
@@ -81,9 +85,9 @@ export interface RegistryClient {
   fetchCurator: (login: string) => Promise<CuratorPayload | null>
   my: {
     collections: () => Promise<CollectionSummary[]>
-    subscriptions: () => Promise<SubscriptionSummary[]>
-    changes: (params: { since?: number }) => Promise<DigestResponse | null>
-    installs: (payload: InstallEventPayload) => Promise<void>
+    changes: (params: { since?: number }) => Promise<DigestResponse>
+    watch: (repos: RepositoryRef[]) => Promise<{ inserted: number }>
+    unwatch: (repo: RepositoryRef) => Promise<void>
   }
 }
 
@@ -125,35 +129,66 @@ export function aggregateAuditStatus(audits: AuditEntry[]): AuditStatus {
   return 'pass'
 }
 
-export function createRegistryClient(opts: { session?: AuthSession, baseUrl?: string } = {}): RegistryClient {
+export interface RegistryClientOptions {
+  baseUrl?: string
+  publicFetch?: AuthedFetcher
+  authenticatedFetch?: AuthedFetcher
+}
+
+function errorStatus(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null)
+    return null
+  if ('statusCode' in error && typeof error.statusCode === 'number')
+    return error.statusCode
+  if ('status' in error && typeof error.status === 'number')
+    return error.status
+  return null
+}
+
+async function optional<T>(request: Promise<T>): Promise<T | null> {
+  return request.catch((error) => {
+    if (errorStatus(error) === 404)
+      return null
+    throw error
+  })
+}
+
+function parseAuditResponse(value: unknown): AuditResult {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('Invalid audit response')
+  const record = value as Record<string, unknown>
+  const audits = AuditEntrySchema.array().parse(record.audits ?? [])
+  const riskLevel = record.riskLevel === 'low' || record.riskLevel === 'medium' || record.riskLevel === 'high'
+    ? record.riskLevel
+    : undefined
+  const summary = typeof record.summary === 'string' ? record.summary : undefined
+  return { status: aggregateAuditStatus(audits), riskLevel, summary, audits }
+}
+
+function parseWatchResponse(value: unknown): { inserted: number } {
+  if (typeof value !== 'object' || value === null || !('inserted' in value) || typeof value.inserted !== 'number')
+    throw new TypeError('Invalid watch response')
+  return { inserted: value.inserted }
+}
+
+export function createRegistryClient(opts: RegistryClientOptions = {}): RegistryClient {
   const base = (opts.baseUrl ?? getRegistryBase()).replace(TRAILING_SLASH_RE, '')
-  const headers = opts.session ? { Authorization: `Bearer ${opts.session.accessToken}` } : undefined
-
-  const fetcher = <T>(url: string, init?: Parameters<typeof ofetch<T>>[1]): Promise<T> => {
-    if (!headers && !init)
-      return ofetch<T>(url)
-    if (!headers)
-      return ofetch<T>(url, init)
-    return ofetch<T>(url, { ...init, headers: { ...headers, ...(init?.headers as any) } })
-  }
-
-  const requireSession = (): void => {
-    if (!opts.session)
-      throw new Error('auth required')
-  }
+  const publicFetch = opts.publicFetch ?? ofetch
+  const authenticatedFetch = opts.authenticatedFetch ?? withAuth(base)
 
   return {
     async resolveSkill(packageName, fetchOpts = {}) {
-      const resolved = await fetcher<Record<string, SkillsResolveEntry>>(`${base}/skills/resolve`, {
+      const resolved = SkillsResolveResponseSchema.parse(await publicFetch<unknown>(`${base}/skills/resolve`, {
         method: 'POST',
         body: { items: [{ packageName, owner: fetchOpts.owner }] },
-      }).catch(() => null)
+      }))
 
-      const hit = resolved?.[packageName]
+      const hit = resolved[packageName]
       if (!hit)
         return null
 
-      const detail = await fetcher<SkillDetailResponse>(`${base}/skills/${hit.owner}/${hit.repo}/${packageName}`).catch(() => null)
+      const rawDetail = await optional(publicFetch<unknown>(`${base}/skills/${hit.owner}/${hit.repo}/${packageName}`))
+      const detail = rawDetail === null ? null : SkillDetailResponseSchema.parse(rawDetail)
       if (!detail?.raw)
         return null
 
@@ -164,7 +199,6 @@ export function createRegistryClient(opts: { session?: AuthSession, baseUrl?: st
         owner: detail.owner,
         repo: `${detail.owner}/${detail.repo}`,
         displayName: detail.displayName,
-        installs: detail.installs,
         official: hit.official,
         branch: detail.branch,
         skillPath: detail.skillPath ?? undefined,
@@ -173,47 +207,41 @@ export function createRegistryClient(opts: { session?: AuthSession, baseUrl?: st
     },
 
     async fetchSkillDetail(owner, repo, name) {
-      return fetcher<SkillDetailResponse>(`${base}/skills/${owner}/${repo}/${name}`).catch(() => null)
+      const response = await optional(publicFetch<unknown>(`${base}/skills/${owner}/${repo}/${name}`))
+      return response === null ? null : SkillDetailResponseSchema.parse(response)
     },
 
     async audit({ owner, repo, name }) {
-      const res = await fetcher<AuditApiResponse>(`${base}/skill-live/${owner}/${repo}/${name}`).catch(() => null)
-      if (!res)
-        return { status: 'unaudited', audits: [] }
-      const audits = res.audits ?? []
-      return {
-        status: aggregateAuditStatus(audits),
-        riskLevel: res.riskLevel,
-        summary: res.summary,
-        audits,
-      }
+      return parseAuditResponse(await publicFetch<unknown>(`${base}/skill-live/${owner}/${repo}/${name}`))
     },
 
     async fetchCollection(login, slug) {
-      return fetcher<CollectionManifest>(`${base}/collections/by-author/${login}/${slug}/manifest`).catch(() => null)
+      const response = await optional(publicFetch<unknown>(`${base}/collections/by-author/${login}/${slug}/manifest`))
+      return response === null ? null : CollectionManifestSchema.parse(response)
     },
 
     async fetchCurator(login) {
-      return fetcher<CuratorPayload>(`${base}/curators/${login}`).catch(() => null)
+      const response = await optional(publicFetch<unknown>(`${base}/curators/${login}`))
+      return response === null ? null : CuratorPayloadSchema.parse(response)
     },
 
     my: {
       async collections() {
-        requireSession()
-        return fetcher<CollectionSummary[]>(`${base}/me/collections`).catch(() => [])
-      },
-      async subscriptions() {
-        requireSession()
-        return fetcher<SubscriptionSummary[]>(`${base}/me/subscriptions`).catch(() => [])
+        return CollectionSummarySchema.array().parse(await authenticatedFetch<unknown>(`${base}/cli/collections`))
       },
       async changes({ since }) {
-        requireSession()
         const qs = since != null ? `?since=${since}` : ''
-        return fetcher<DigestResponse>(`${base}/cli/changes${qs}`).catch(() => null)
+        return DigestResponseSchema.parse(await authenticatedFetch<unknown>(`${base}/cli/changes${qs}`))
       },
-      async installs(payload) {
-        requireSession()
-        await fetcher<void>(`${base}/me/installs`, { method: 'POST', body: payload }).catch(() => {})
+      async watch(repos) {
+        const response = await authenticatedFetch<unknown>(`${base}/me/subscriptions`, {
+          method: 'POST',
+          body: { source: 'cli', repos },
+        })
+        return parseWatchResponse(response)
+      },
+      async unwatch(repo) {
+        await authenticatedFetch<void>(`${base}/me/subscriptions/${repo.owner}/${repo.repo}`, { method: 'DELETE' })
       },
     },
   }
@@ -221,9 +249,7 @@ export function createRegistryClient(opts: { session?: AuthSession, baseUrl?: st
 
 /**
  * Fetch a curated package skill from the registry.
- * Returns null if no curated skill exists, the SKILL.md can't be loaded, or the API is unreachable.
- *
- * Thin wrapper over `createRegistryClient().resolveSkill` for back-compat.
+ * Returns null if no curated skill exists or the SKILL.md cannot be loaded.
  */
 export async function fetchRegistrySkill(
   packageName: string,

--- a/src/registry/collections.ts
+++ b/src/registry/collections.ts
@@ -1,0 +1,42 @@
+import type { SkillSource } from '../core/prefix.ts'
+import type { CollectionManifestItem } from './client.ts'
+
+/**
+ * Convert selected manifest items into `installSkills` inputs. Multiple gh
+ * items in the same repo collapse to one `git` source carrying the union of
+ * picked skill names as `skillFilter`, so a repo with N skills installs in
+ * one `syncGitSkills` call instead of N redundant ones.
+ */
+export function manifestToSources(items: CollectionManifestItem[]): Array<{ source: SkillSource, skillFilter?: string }> {
+  const npm: Array<{ source: SkillSource, skillFilter?: string }> = []
+  const crate: Array<{ source: SkillSource, skillFilter?: string }> = []
+  const ghByRepo = new Map<string, { owner: string, repo: string, names: string[] }>()
+
+  for (const item of items) {
+    if (item.kind === 'npm' && item.package) {
+      npm.push({ source: { type: 'npm', package: item.package } })
+      continue
+    }
+    if (item.kind === 'crate' && item.package) {
+      crate.push({ source: { type: 'crate', package: item.package } })
+      continue
+    }
+    if (item.kind === 'gh' && item.owner && item.repo) {
+      const key = `${item.owner}/${item.repo}`
+      const group = ghByRepo.get(key) ?? { owner: item.owner, repo: item.repo, names: [] }
+      if (item.name && !group.names.includes(item.name))
+        group.names.push(item.name)
+      ghByRepo.set(key, group)
+    }
+  }
+
+  const gh: Array<{ source: SkillSource, skillFilter?: string }> = []
+  for (const group of ghByRepo.values()) {
+    gh.push({
+      source: { type: 'git', source: { type: 'github', owner: group.owner, repo: group.repo } },
+      skillFilter: group.names.length ? group.names.join(',') : undefined,
+    })
+  }
+
+  return [...gh, ...npm, ...crate]
+}

--- a/test/unit/audit-aggregation.test.ts
+++ b/test/unit/audit-aggregation.test.ts
@@ -37,13 +37,12 @@ describe('aggregateAuditStatus', () => {
 })
 
 describe('createRegistryClient.audit', () => {
-  it('returns unaudited on network error', async () => {
+  it('propagates network errors', async () => {
     const { ofetch } = await import('ofetch')
     vi.mocked(ofetch).mockReset().mockRejectedValueOnce(new Error('network'))
     const { createRegistryClient } = await import('../../src/registry/client')
     const client = createRegistryClient()
-    const res = await client.audit({ owner: 'foo', repo: 'bar', name: 'baz' })
-    expect(res).toEqual({ status: 'unaudited', audits: [] })
+    await expect(client.audit({ owner: 'foo', repo: 'bar', name: 'baz' })).rejects.toThrow('network')
   })
 
   it('aggregates server response with audits + riskLevel + summary', async () => {
@@ -114,22 +113,31 @@ describe('gateInstall', () => {
 describe('createRegistryClient.my requires session', () => {
   it('throws auth required without a session', async () => {
     const { createRegistryClient } = await import('../../src/registry/client')
-    const client = createRegistryClient()
+    const authenticatedFetch = async (): Promise<never> => {
+      throw new Error('auth required')
+    }
+    const client = createRegistryClient({ authenticatedFetch })
     await expect(client.my.collections()).rejects.toThrow('auth required')
-    await expect(client.my.subscriptions()).rejects.toThrow('auth required')
     await expect(client.my.changes({})).rejects.toThrow('auth required')
-    await expect(client.my.installs({ slug: 'x', sourceKind: 'npm', surface: 'cli:add' })).rejects.toThrow('auth required')
+    await expect(client.my.watch([{ owner: 'nuxt', repo: 'nuxt' }])).rejects.toThrow('auth required')
   })
 
-  it('passes Bearer header when session present', async () => {
-    const { ofetch } = await import('ofetch')
-    vi.mocked(ofetch).mockReset().mockResolvedValueOnce([])
+  it('posts repositories through the authenticated transport', async () => {
+    const authenticatedFetch = vi.fn().mockResolvedValueOnce({ ok: true, inserted: 1 })
     const { createRegistryClient } = await import('../../src/registry/client')
-    const client = createRegistryClient({ session: { accessToken: 'tok', login: 'me' } })
-    await client.my.collections()
-    expect(ofetch).toHaveBeenCalledWith(
-      expect.stringContaining('/me/collections'),
-      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer tok' }) }),
-    )
+    const client = createRegistryClient({ authenticatedFetch })
+    await expect(client.my.watch([{ owner: 'nuxt', repo: 'nuxt' }])).resolves.toEqual({ inserted: 1 })
+    expect(authenticatedFetch).toHaveBeenCalledWith('https://skilld.dev/api/me/subscriptions', {
+      method: 'POST',
+      body: { source: 'cli', repos: [{ owner: 'nuxt', repo: 'nuxt' }] },
+    })
+  })
+
+  it('loads CLI collection summaries from the unambiguous route', async () => {
+    const authenticatedFetch = vi.fn().mockResolvedValueOnce([])
+    const { createRegistryClient } = await import('../../src/registry/client')
+    const client = createRegistryClient({ authenticatedFetch })
+    await expect(client.my.collections()).resolves.toEqual([])
+    expect(authenticatedFetch).toHaveBeenCalledWith('https://skilld.dev/api/cli/collections')
   })
 })

--- a/test/unit/auth-client.test.ts
+++ b/test/unit/auth-client.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAuthenticatedFetch } from '../../src/auth/client'
+
+describe('createAuthenticatedFetch', () => {
+  it('refreshes once and retries with the rotated token', async () => {
+    const expired = {
+      scheme: 'file' as const,
+      login: 'harlan',
+      accessToken: 'expired',
+      refreshToken: 'refresh',
+      host: 'https://skilld.dev',
+    }
+    const loadSession = vi.fn().mockResolvedValue(expired)
+    const saveSession = vi.fn().mockResolvedValue('file')
+    const unauthorized = Object.assign(new Error('unauthorized'), { statusCode: 401 })
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(unauthorized)
+      .mockResolvedValueOnce({
+        login: 'harlan',
+        accessToken: 'rotated',
+        refreshToken: 'next-refresh',
+        expiresAt: 1_800_000_000,
+      })
+      .mockResolvedValueOnce({ ok: true })
+
+    const authenticatedFetch = createAuthenticatedFetch({
+      baseUrl: 'https://skilld.dev/api',
+      fetch,
+      loadSession,
+      saveSession,
+    })
+
+    await expect(authenticatedFetch('https://skilld.dev/api/me/collections')).resolves.toEqual({ ok: true })
+    expect(fetch).toHaveBeenNthCalledWith(2, 'https://skilld.dev/api/cli/oauth/refresh', {
+      method: 'POST',
+      body: { refresh_token: 'refresh' },
+    })
+    expect(fetch).toHaveBeenNthCalledWith(3, 'https://skilld.dev/api/me/collections', {
+      headers: { Authorization: 'Bearer rotated' },
+    })
+    expect(saveSession).toHaveBeenCalledOnce()
+  })
+})

--- a/test/unit/collection-sources.test.ts
+++ b/test/unit/collection-sources.test.ts
@@ -24,7 +24,7 @@ describe('manifestToSources', () => {
 
   it('expands the collection command from skilld.dev without authentication', async () => {
     const result = await expandPublicSources([
-      { type: 'collection', handle: 'harlan', name: 'nuxt' },
+      { type: 'collection-or-npm', handle: 'harlan', name: 'nuxt', package: '@harlan/nuxt' },
     ], {
       fetchCollection: async () => ({
         name: 'Nuxt',
@@ -42,5 +42,31 @@ describe('manifestToSources', () => {
       skipped: 0,
       failed: 0,
     })
+  })
+
+  it('falls back to the existing scoped npm meaning when no collection exists', async () => {
+    const result = await expandPublicSources([
+      { type: 'collection-or-npm', handle: 'harlan', name: 'nuxt', package: '@harlan/nuxt' },
+    ], {
+      fetchCollection: async () => null,
+      fetchCurator: async () => null,
+    }, true)
+
+    expect(result).toEqual({
+      items: [{ type: 'bare', package: '@harlan/nuxt' }],
+      skipped: 0,
+      failed: 0,
+    })
+  })
+
+  it('surfaces collection transport failures without changing the source', async () => {
+    const result = await expandPublicSources([
+      { type: 'collection-or-npm', handle: 'harlan', name: 'nuxt', package: '@harlan/nuxt' },
+    ], {
+      fetchCollection: async () => Promise.reject(new Error('offline')),
+      fetchCurator: async () => null,
+    }, true)
+
+    expect(result).toEqual({ items: [], skipped: 0, failed: 1 })
   })
 })

--- a/test/unit/collection-sources.test.ts
+++ b/test/unit/collection-sources.test.ts
@@ -1,0 +1,46 @@
+import type { CollectionManifestItem } from 'skilld-protocol/wire'
+import { describe, expect, it } from 'vitest'
+import { expandPublicSources } from '../../src/commands/sync/install-many'
+import { manifestToSources } from '../../src/registry/collections'
+
+describe('manifestToSources', () => {
+  it('collapses GitHub skills by repository and preserves package sources', () => {
+    const items: CollectionManifestItem[] = [
+      { kind: 'gh', owner: 'nuxt', repo: 'nuxt', name: 'seo' },
+      { kind: 'gh', owner: 'nuxt', repo: 'nuxt', name: 'modules' },
+      { kind: 'npm', package: '@nuxt/ui' },
+      { kind: 'crate', package: 'serde' },
+    ]
+
+    expect(manifestToSources(items)).toEqual([
+      {
+        source: { type: 'git', source: { type: 'github', owner: 'nuxt', repo: 'nuxt' } },
+        skillFilter: 'seo,modules',
+      },
+      { source: { type: 'npm', package: '@nuxt/ui' } },
+      { source: { type: 'crate', package: 'serde' } },
+    ])
+  })
+
+  it('expands the collection command from skilld.dev without authentication', async () => {
+    const result = await expandPublicSources([
+      { type: 'collection', handle: 'harlan', name: 'nuxt' },
+    ], {
+      fetchCollection: async () => ({
+        name: 'Nuxt',
+        items: [{ kind: 'gh', owner: 'nuxt', repo: 'nuxt', name: 'seo' }],
+      }),
+      fetchCurator: async () => null,
+    }, true)
+
+    expect(result).toEqual({
+      items: [{
+        type: 'git',
+        source: { type: 'github', owner: 'nuxt', repo: 'nuxt' },
+        skillFilter: 'seo',
+      }],
+      skipped: 0,
+      failed: 0,
+    })
+  })
+})

--- a/test/unit/digest-render.test.ts
+++ b/test/unit/digest-render.test.ts
@@ -1,0 +1,17 @@
+import { stripVTControlCharacters } from 'node:util'
+import { describe, expect, it } from 'vitest'
+import { formatDigestLines } from '../../src/cli/digest-render'
+
+describe('formatDigestLines', () => {
+  it('links each changed skill to its exact skill page', () => {
+    const lines = formatDigestLines([{
+      repo: 'nuxt/nuxt',
+      skill: 'seo',
+      at: '2026-08-12T00:00:00.000Z',
+      summary: 'Improve canonical URL guidance',
+    }], Date.parse('2026-08-13T00:00:00.000Z')).map(stripVTControlCharacters)
+
+    expect(lines).toContain('    https://skilld.dev/gh/nuxt/nuxt/seo')
+    expect(lines.join('\n')).not.toContain('/me/activity')
+  })
+})

--- a/test/unit/prefix.test.ts
+++ b/test/unit/prefix.test.ts
@@ -82,7 +82,7 @@ describe('prefix parser', () => {
     })
   })
 
-  describe('@ prefix (curator and scoped npm)', () => {
+  describe('@ prefix (curator and collection)', () => {
     it('parses @handle as curator', () => {
       expect(parseSkillInput('@antfu')).toEqual({
         type: 'curator',
@@ -90,17 +90,17 @@ describe('prefix parser', () => {
       })
     })
 
-    it('parses @scope/pkg as bare scoped npm package', () => {
+    it('parses the collection command emitted by skilld.dev', () => {
       expect(parseSkillInput('@nuxt/fonts')).toEqual({
-        type: 'bare',
-        package: '@nuxt/fonts',
-        tag: undefined,
+        type: 'collection',
+        handle: 'nuxt',
+        name: 'fonts',
       })
     })
 
-    it('parses @scope/pkg@tag as bare scoped npm with tag', () => {
-      expect(parseSkillInput('@nuxt/fonts@1.0.0')).toEqual({
-        type: 'bare',
+    it('keeps scoped npm packages explicit', () => {
+      expect(parseSkillInput('npm:@nuxt/fonts@1.0.0')).toEqual({
+        type: 'npm',
         package: '@nuxt/fonts',
         tag: '1.0.0',
       })
@@ -178,8 +178,8 @@ describe('prefix parser', () => {
       expect(resolveSkillName('@antfu')).toBeNull()
     })
 
-    it('returns scoped name for @scope/pkg', () => {
-      expect(resolveSkillName('@nuxt/fonts')).toBe('@nuxt/fonts')
+    it('returns null for a collection', () => {
+      expect(resolveSkillName('@nuxt/fonts')).toBeNull()
     })
 
     it('returns crate:<name> for crate inputs', () => {

--- a/test/unit/prefix.test.ts
+++ b/test/unit/prefix.test.ts
@@ -103,17 +103,18 @@ describe('prefix parser', () => {
       })
     })
 
-    it('parses the collection command emitted by skilld.dev', () => {
+    it('keeps an untagged scoped package available as a collection or npm package', () => {
       expect(parseSkillInput('@nuxt/fonts')).toEqual({
-        type: 'collection',
+        type: 'collection-or-npm',
         handle: 'nuxt',
         name: 'fonts',
+        package: '@nuxt/fonts',
       })
     })
 
-    it('keeps scoped npm packages explicit', () => {
-      expect(parseSkillInput('npm:@nuxt/fonts@1.0.0')).toEqual({
-        type: 'npm',
+    it('keeps tagged scoped packages on npm', () => {
+      expect(parseSkillInput('@nuxt/fonts@1.0.0')).toEqual({
+        type: 'bare',
         package: '@nuxt/fonts',
         tag: '1.0.0',
       })
@@ -191,8 +192,8 @@ describe('prefix parser', () => {
       expect(resolveSkillName('@antfu')).toBeNull()
     })
 
-    it('returns null for a collection', () => {
-      expect(resolveSkillName('@nuxt/fonts')).toBeNull()
+    it('keeps the scoped package name addressable', () => {
+      expect(resolveSkillName('@nuxt/fonts')).toBe('@nuxt/fonts')
     })
 
     it('returns crate:<name> for crate inputs', () => {

--- a/test/unit/registry-client.test.ts
+++ b/test/unit/registry-client.test.ts
@@ -21,7 +21,7 @@ function mockResolveAndDetail(ofetch: ReturnType<typeof vi.fn>, opts: {
     repo,
     name: opts.packageName,
     displayName: opts.packageName,
-    installs: 1,
+    stars: 1,
     branch: 'main',
     skillPath: `skills/${opts.packageName}/SKILL.md`,
     raw: opts.raw ?? '# skill',
@@ -83,12 +83,12 @@ describe('registry client', () => {
     expect(ofetch).toHaveBeenNthCalledWith(1, 'http://localhost:3000/api/skills/resolve', expect.any(Object))
   })
 
-  it('returns null when resolve fails', async () => {
+  it('propagates resolve transport failures', async () => {
     const { ofetch } = await import('ofetch')
     vi.mocked(ofetch).mockRejectedValueOnce(new Error('network'))
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
-    expect(await fetchRegistrySkill('nonexistent')).toBeNull()
+    await expect(fetchRegistrySkill('nonexistent')).rejects.toThrow('network')
   })
 
   it('returns null when resolve has no hit', async () => {
@@ -104,7 +104,17 @@ describe('registry client', () => {
     const { ofetch } = await import('ofetch')
     vi.mocked(ofetch)
       .mockResolvedValueOnce({ vue: { owner: 'antfu', repo: 'skills', official: false } })
-      .mockResolvedValueOnce({ owner: 'antfu', repo: 'skills', name: 'vue', raw: null })
+      .mockResolvedValueOnce({
+        owner: 'antfu',
+        repo: 'skills',
+        name: 'vue',
+        displayName: 'Vue',
+        stars: 1,
+        branch: 'main',
+        skillPath: 'skills/vue/SKILL.md',
+        raw: null,
+        pushedAt: null,
+      })
 
     const { fetchRegistrySkill } = await import('../../src/registry/client')
     expect(await fetchRegistrySkill('vue')).toBeNull()

--- a/test/unit/watch.test.ts
+++ b/test/unit/watch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { parseRepositoryInputs } from '../../src/commands/watch'
+
+describe('parseRepositoryInputs', () => {
+  it('deduplicates GitHub repositories', () => {
+    expect(parseRepositoryInputs(['nuxt/nuxt', 'nuxt/nuxt'])).toEqual({
+      _tag: 'Ok',
+      repositories: [{ owner: 'nuxt', repo: 'nuxt' }],
+    })
+  })
+
+  it('returns invalid inputs as an error value', () => {
+    expect(parseRepositoryInputs(['https://github.com/nuxt/nuxt'])).toEqual({
+      _tag: 'Err',
+      invalid: ['https://github.com/nuxt/nuxt'],
+    })
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [x] ⚠️ Breaking change

### 📚 Description

skilld.dev already prints `npx skilld add @handle/collection`. The CLI now installs that public collection manifest. If no collection exists, it preserves the scoped npm package behavior. Tagged scoped packages always use npm.

`skilld watch`, `skilld unwatch`, `skilld changes`, and `add --watch` use the site subscriptions and digest endpoints. Registry requests share the token refresh path. API failures now surface instead of returning empty data.

Companion site change: https://github.com/skilld-dev/skilld.dev/pull/23

### ⚠️ Breaking Changes

The protocol detail response uses `stars` instead of the retired `installs` field. Skill live responses no longer include `installs` or `formatted`.

### 📝 Migration

Protocol consumers must replace detail `installs` with `stars`. Remove `installs` and `formatted` from skill live responses.