### PR TITLE
fix(auth): reuse existing login sessions

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -7,13 +7,14 @@
  *   - Otherwise → PKCE loopback.
  */
 
+import type { StoredSession } from '../auth/store.ts'
 import { styleText } from 'node:util'
 import * as p from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { runDeviceFlow } from '../auth/device-flow.ts'
 import { isGhaOidcAvailable, runOidcExchange } from '../auth/oidc.ts'
 import { runPkceFlow } from '../auth/pkce-flow.ts'
-import { saveSession } from '../auth/store.ts'
+import { loadSession, saveSession } from '../auth/store.ts'
 import { getRegistryBase } from '../registry/client.ts'
 import { track } from '../telemetry.ts'
 import { version } from '../version.ts'
@@ -28,12 +29,33 @@ function shouldUseDevice(force: boolean): boolean {
   return !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY
 }
 
+export type LoginRequirement
+  = | { _tag: 'Reuse', session: StoredSession }
+    | { _tag: 'Authenticate' }
+
+export function resolveLoginRequirement(
+  session: StoredSession | null,
+  nowSeconds = Math.floor(Date.now() / 1000),
+): LoginRequirement {
+  if (!session)
+    return { _tag: 'Authenticate' }
+  if (session.refreshToken || session.expiresAt === undefined || session.expiresAt > nowSeconds)
+    return { _tag: 'Reuse', session }
+  return { _tag: 'Authenticate' }
+}
+
 export const loginCommandDef = defineCommand({
   meta: { name: 'login', description: 'Authenticate with skilld.dev' },
   args: {
     device: { type: 'boolean', description: 'Use RFC 8628 device flow' },
   },
   async run({ args }) {
+    const requirement = resolveLoginRequirement(await loadSession())
+    if (requirement._tag === 'Reuse') {
+      p.log.success(`Already logged in as ${styleText('cyan', `@${requirement.session.login}`)}`)
+      return
+    }
+
     const registryBase = getRegistryBase()
 
     if (isGhaOidcAvailable()) {

--- a/test/unit/login-command.test.ts
+++ b/test/unit/login-command.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  loadSession: vi.fn(),
+  saveSession: vi.fn(),
+  runDeviceFlow: vi.fn(),
+  runOidcExchange: vi.fn(),
+  runPkceFlow: vi.fn(),
+  success: vi.fn(),
+}))
+
+vi.mock('../../src/auth/store', () => ({
+  loadSession: mocks.loadSession,
+  saveSession: mocks.saveSession,
+}))
+vi.mock('../../src/auth/device-flow', () => ({ runDeviceFlow: mocks.runDeviceFlow }))
+vi.mock('../../src/auth/oidc', () => ({
+  isGhaOidcAvailable: () => false,
+  runOidcExchange: mocks.runOidcExchange,
+}))
+vi.mock('../../src/auth/pkce-flow', () => ({ runPkceFlow: mocks.runPkceFlow }))
+vi.mock('@clack/prompts', () => ({
+  log: { success: mocks.success },
+}))
+
+const { loginCommandDef } = await import('../../src/commands/login')
+
+describe('login command', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('does not start authentication when the existing session can refresh', async () => {
+    mocks.loadSession.mockResolvedValue({
+      scheme: 'file',
+      login: 'harlan-zw',
+      accessToken: 'expired',
+      refreshToken: 'refresh',
+      expiresAt: 100,
+      host: 'https://skilld.dev',
+    })
+
+    await loginCommandDef.run!({ args: { device: false } } as any)
+
+    expect(mocks.runOidcExchange).not.toHaveBeenCalled()
+    expect(mocks.runDeviceFlow).not.toHaveBeenCalled()
+    expect(mocks.runPkceFlow).not.toHaveBeenCalled()
+    expect(mocks.success).toHaveBeenCalledWith('Already logged in as @harlan-zw')
+  })
+})

--- a/test/unit/login.test.ts
+++ b/test/unit/login.test.ts
@@ -1,0 +1,28 @@
+import type { StoredSession } from '../../src/auth/store'
+import { describe, expect, it } from 'vitest'
+import { resolveLoginRequirement } from '../../src/commands/login'
+
+const session: StoredSession = {
+  scheme: 'file',
+  login: 'harlan-zw',
+  accessToken: 'access',
+  refreshToken: 'refresh',
+  expiresAt: 100,
+  host: 'https://skilld.dev',
+}
+
+describe('resolveLoginRequirement', () => {
+  it('reuses a refreshable session after its access token expires', () => {
+    expect(resolveLoginRequirement(session, 200)).toEqual({ _tag: 'Reuse', session })
+  })
+
+  it('reuses an unexpired session without a refresh token', () => {
+    const current = { ...session, refreshToken: undefined, expiresAt: 300 }
+    expect(resolveLoginRequirement(current, 200)).toEqual({ _tag: 'Reuse', session: current })
+  })
+
+  it('authenticates again when a nonrefreshable session expires', () => {
+    const expired = { ...session, refreshToken: undefined }
+    expect(resolveLoginRequirement(expired, 200)).toEqual({ _tag: 'Authenticate' })
+  })
+})


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Running `skilld login` with a refreshable session opened the browser and replaced its credentials. It now returns the active account immediately. Expired sessions without a refresh token still authenticate.