### PR TITLE
fix(cli): accept none as an agent target

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import pLimit from 'p-limit'
 import { join, resolve } from 'pathe'
 import { agents, detectImportedPackages, detectInstalledAgents } from './agent/index.ts'
 import { promptForAgent, resolveAgent } from './cli/agent-prompt.ts'
-import { sharedArgs } from './cli/args.ts'
+import { rootArgs } from './cli/args.ts'
 import { isInteractive, isRunningInsideAgent } from './cli/env.ts'
 import { formatStatus, getRepoHint, relativeTime } from './cli/intro.ts'
 import { guard, menuLoop } from './cli/menu.ts'
@@ -70,9 +70,8 @@ const main = defineCommand({
     version,
     description: 'Curated agent skills for your projects',
   },
-  args: {
-    agent: sharedArgs.agent,
-  },
+  // Citty parses root arguments before dispatching subcommands.
+  args: rootArgs,
   subCommands: {
     add: () => import('./commands/sync/add.ts').then(m => m.addCommandDef),
     update: () => import('./commands/sync/update.ts').then(m => m.updateCommandDef),

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -37,3 +37,15 @@ export const sharedArgs = {
     default: false,
   },
 }
+
+/** Agent argument for flows that can export portable prompts. */
+export const agentOrNoneArg = {
+  type: 'enum' as const,
+  options: [...Object.keys(agents), 'none'],
+  alias: 'a',
+  description: 'Target agent, or `none` to export portable prompts',
+}
+
+export const rootArgs = {
+  agent: agentOrNoneArg,
+}

--- a/src/commands/sync/add.ts
+++ b/src/commands/sync/add.ts
@@ -2,7 +2,7 @@ import type { AgentType, OptimizeModel } from '../../agent/index.ts'
 import * as p from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { autoResolveAgent } from '../../cli/agent-prompt.ts'
-import { sharedArgs } from '../../cli/args.ts'
+import { agentOrNoneArg, sharedArgs } from '../../cli/args.ts'
 import { hasCompletedWizard } from '../../core/config.ts'
 import { parseSkillInput } from '../../core/prefix.ts'
 import { COMMA_OR_WHITESPACE_RE } from '../../core/regex.ts'
@@ -34,6 +34,8 @@ export const addCommandDef = defineCommand({
       description: 'Watch installed repositories for changes',
     },
     ...sharedArgs,
+    // This command supports portable exports.
+    'agent': agentOrNoneArg,
   },
   async run({ args }) {
     const rawInputs = [...new Set(

--- a/src/commands/sync/update.ts
+++ b/src/commands/sync/update.ts
@@ -3,7 +3,7 @@ import { styleText } from 'node:util'
 import * as p from '@clack/prompts'
 import { defineCommand } from 'citty'
 import { autoResolveAgent } from '../../cli/agent-prompt.ts'
-import { sharedArgs } from '../../cli/args.ts'
+import { agentOrNoneArg, sharedArgs } from '../../cli/args.ts'
 import { isInteractive } from '../../cli/env.ts'
 import { getInstalledGenerators, introLine } from '../../cli/intro.ts'
 import { readConfig } from '../../core/config.ts'
@@ -29,6 +29,8 @@ export const updateCommandDef = defineCommand({
       default: false,
     },
     ...sharedArgs,
+    // This command supports portable exports.
+    agent: agentOrNoneArg,
   },
   async run({ args }) {
     const cwd = process.cwd()

--- a/test/unit/cli-flags.test.ts
+++ b/test/unit/cli-flags.test.ts
@@ -1,5 +1,9 @@
+import type { ArgsDef } from 'citty'
 import { parseArgs } from 'citty'
 import { describe, expect, it } from 'vitest'
+import { rootArgs, sharedArgs } from '../../src/cli/args.ts'
+import { addCommandDef } from '../../src/commands/sync/add.ts'
+import { updateCommandDef } from '../../src/commands/sync/update.ts'
 
 /**
  * Validates that CLI flag definitions parse correctly via citty.
@@ -50,5 +54,30 @@ describe('citty --no-X flag gotcha', () => {
     // Both are false — the flag has no effect
     expect(withFlag['no-search']).toBe(false)
     expect(withoutFlag['no-search']).toBe(false)
+  })
+})
+
+describe('--agent none', () => {
+  it.each([
+    ['root', ['add', 'vue', '--agent', 'none'], rootArgs],
+    ['add', ['vue', '--agent', 'none'], addCommandDef.args as ArgsDef],
+    ['update', ['--agent', 'none'], updateCommandDef.args as ArgsDef],
+  ])('reaches the portable export path through %s arguments', (_name, input, args) => {
+    expect(parseArgs(input, args).agent).toBe('none')
+  })
+
+  it('keeps installed agents selectable', () => {
+    expect(parseArgs(['--agent', 'claude-code'], rootArgs).agent).toBe('claude-code')
+  })
+
+  it('still rejects an agent that does not exist', () => {
+    expect(() => parseArgs(['--agent', 'notepad'], rootArgs)).toThrow()
+  })
+
+  it('remains invalid for commands without portable exports', () => {
+    expect(() => parseArgs(['vue', '--agent', 'none'], {
+      package: { type: 'positional' as const },
+      agent: sharedArgs.agent,
+    })).toThrow()
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`skilld add --agent none` and `skilld update --agent none` could not reach their portable export branches because Citty rejected `none` during root parsing. The root parser and both commands now share a portable agent argument; commands without portable exports keep the installed-agent list.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).