### PR TITLE
chore(release): prepare v3.0.0-beta.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,10 @@ jobs:
             tar -xf "$archive" -C packages
           done < <(find native-artifacts -type f -name '*.tar' | sort)
       - run: pnpm install --frozen-lockfile
+      - id: npm_tag
+        name: Resolve shared npm tag
+        shell: bash
+        run: echo "value=$(node scripts/release/native-packages.mjs npm-tag)" >> "$GITHUB_OUTPUT"
       - name: Build JavaScript packages
         run: |
           pnpm --filter skilld-protocol build
@@ -142,29 +146,21 @@ jobs:
         run: |
           while IFS= read -r directory; do
             if test "$(node scripts/release/native-packages.mjs package-publish "packages/$directory")" = true; then
-              pnpm --dir "packages/$directory" publish --access public --no-git-checks
+              pnpm --dir "packages/$directory" publish --access public --no-git-checks --tag "${{ steps.npm_tag.outputs.value }}"
             fi
           done < <(node scripts/release/native-packages.mjs directories)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish root CLI
         shell: bash
         run: |
           if test "$(node scripts/release/native-packages.mjs package-publish .)" = true; then
-            pnpm publish --access public --no-git-checks
+            pnpm publish --access public --no-git-checks --tag "${{ steps.npm_tag.outputs.value }}"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish Harness
         shell: bash
         run: |
           if test "$(node scripts/release/native-packages.mjs package-publish packages/harness)" = true; then
-            pnpm --dir packages/harness publish --access public --no-git-checks
+            pnpm --dir packages/harness publish --access public --no-git-checks --tag "${{ steps.npm_tag.outputs.value }}"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish independent protocol
         if: steps.protocol_release.outputs.publish == 'true'
         run: pnpm --dir packages/protocol publish --access public --no-git-checks
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-auth"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.0"
 dependencies = [
  "base64",
  "getrandom 0.3.4",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-command"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.0"
 dependencies = [
  "base64",
  "clap",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-core"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.0"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-native"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.0"
 dependencies = [
  "skilld-auth",
  "skilld-command",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-wasi"
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.0"
 dependencies = [
  "skilld-command",
  "skilld-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "3.0.0-alpha.1"
+version = "3.0.0-beta.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/skilld-dev/skilld"

--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -35,7 +35,7 @@ They are your rollback copy.
 Install the v3 CLI:
 
 ```sh
-npm install --global skilld@3.0.0-alpha.1
+npm install --global skilld@3.0.0-beta.0
 skilld --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skilld",
   "type": "module",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "packageManager": "pnpm@11.21.0",
   "description": "Search, install, and keep Skills current",
   "author": {
@@ -47,14 +47,14 @@
     "test:loader": "vitest run --config vitest.config.mjs"
   },
   "optionalDependencies": {
-    "@skilld/cli-darwin-arm64": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-darwin-x64": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-linux-arm64-gnu": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-linux-arm64-musl": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-linux-x64-gnu": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-linux-x64-musl": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-win32-arm64-msvc": "workspace:3.0.0-alpha.1",
-    "@skilld/cli-win32-x64-msvc": "workspace:3.0.0-alpha.1"
+    "@skilld/cli-darwin-arm64": "workspace:3.0.0-beta.0",
+    "@skilld/cli-darwin-x64": "workspace:3.0.0-beta.0",
+    "@skilld/cli-linux-arm64-gnu": "workspace:3.0.0-beta.0",
+    "@skilld/cli-linux-arm64-musl": "workspace:3.0.0-beta.0",
+    "@skilld/cli-linux-x64-gnu": "workspace:3.0.0-beta.0",
+    "@skilld/cli-linux-x64-musl": "workspace:3.0.0-beta.0",
+    "@skilld/cli-win32-arm64-msvc": "workspace:3.0.0-beta.0",
+    "@skilld/cli-win32-x64-msvc": "workspace:3.0.0-beta.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev-lint",

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-darwin-arm64",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "macOS arm64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-darwin-x64",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "macOS x64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-arm64-gnu/package.json
+++ b/packages/cli-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-linux-arm64-gnu",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Linux arm64 GNU executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-arm64-musl/package.json
+++ b/packages/cli-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-linux-arm64-musl",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Linux arm64 musl executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-x64-gnu/package.json
+++ b/packages/cli-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-linux-x64-gnu",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Linux x64 GNU executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-x64-musl/package.json
+++ b/packages/cli-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-linux-x64-musl",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Linux x64 musl executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-wasm32-wasi/package.json
+++ b/packages/cli-wasm32-wasi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skilld/cli-wasm32-wasi",
   "type": "module",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "private": true,
   "description": "WASIp2 fallback host for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-win32-arm64-msvc/package.json
+++ b/packages/cli-win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-win32-arm64-msvc",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Windows arm64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-win32-x64-msvc/package.json
+++ b/packages/cli-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilld/cli-win32-x64-msvc",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Windows x64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@skilld/harness",
   "type": "module",
-  "version": "3.0.0-alpha.1",
+  "version": "3.0.0-beta.0",
   "description": "Run skilld-maintained Skills with checked, atomic output",
   "author": {
     "name": "Harlan Wilton",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,28 +76,28 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       '@skilld/cli-darwin-arm64':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-darwin-arm64
       '@skilld/cli-darwin-x64':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-darwin-x64
       '@skilld/cli-linux-arm64-gnu':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-arm64-gnu
       '@skilld/cli-linux-arm64-musl':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-arm64-musl
       '@skilld/cli-linux-x64-gnu':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-x64-gnu
       '@skilld/cli-linux-x64-musl':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-x64-musl
       '@skilld/cli-win32-arm64-msvc':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-win32-arm64-msvc
       '@skilld/cli-win32-x64-msvc':
-        specifier: workspace:3.0.0-alpha.1
+        specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-win32-x64-msvc
 
   packages/cli-darwin-arm64: {}

--- a/scripts/release/native-packages.mjs
+++ b/scripts/release/native-packages.mjs
@@ -8,6 +8,7 @@ import { promisify } from 'node:util'
 const execFileAsync = promisify(execFile)
 const NPM_REGISTRY = 'https://registry.npmjs.org/'
 const REGISTRY_RESPONSE_LIMIT = 1024 * 1024
+const SEMVER_WITH_NPM_CHANNEL = /^\d+\.\d+\.\d+(?:-([a-z][a-z0-9-]*)(?:\.[0-9a-z-]+)*)?(?:\+[0-9a-z.-]+)?$/
 
 export const nativePackageSpecs = Object.freeze([
   nativePackage({ directory: 'cli-darwin-arm64', runner: 'macos-15', target: 'aarch64-apple-darwin', os: 'darwin', cpu: 'arm64', format: 'mach-o' }),
@@ -131,6 +132,13 @@ export async function verifyReleaseVersions(repositoryRoot, tag) {
     protocol: { name: protocol.name, version: protocol.version },
     sharedVersion: root.version,
   }
+}
+
+export function npmTagForVersion(version) {
+  const match = SEMVER_WITH_NPM_CHANNEL.exec(version)
+  if (!match)
+    throw new Error(`Cannot derive an npm tag from ${version}`)
+  return match[1] ?? 'latest'
 }
 
 export function packagePublishDecision({ packageName, response, version }) {
@@ -274,6 +282,11 @@ async function main([command, argument]) {
     process.stdout.write(`Independent protocol: ${versions.protocol.version}\n`)
     return
   }
+  if (command === 'npm-tag') {
+    const manifest = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8'))
+    process.stdout.write(`${npmTagForVersion(manifest.version)}\n`)
+    return
+  }
   if (command === 'protocol-publish') {
     const manifest = JSON.parse(await readFile(join(process.cwd(), 'packages/protocol/package.json'), 'utf8'))
     const decision = await lookupIndependentPackage({
@@ -295,7 +308,7 @@ async function main([command, argument]) {
     process.stdout.write(`${decision._tag === 'Publish'}\n`)
     return
   }
-  throw new Error('Expected directories, matrix, package-publish, protocol-publish, verify, verify-packed, or versions')
+  throw new Error('Expected directories, matrix, npm-tag, package-publish, protocol-publish, verify, verify-packed, or versions')
 }
 
 if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {

--- a/tests/loader/native-packages.test.mjs
+++ b/tests/loader/native-packages.test.mjs
@@ -10,6 +10,7 @@ import { afterEach, it } from 'vitest'
 import {
   independentPackagePublishDecision,
   nativePackageSpecs,
+  npmTagForVersion,
   packagePublishDecision,
   verifyNativePackages,
   verifyPackedNativePackage,
@@ -99,6 +100,14 @@ it('keeps v3 packages aligned and versions the protocol independently', async ()
     protocol: { name: 'skilld-protocol', version: '2.4.0' },
     sharedVersion: '3.0.0-alpha.2',
   })
+})
+
+it('publishes beta versions under the beta npm tag', () => {
+  assert.equal(npmTagForVersion('3.0.0-beta.0'), 'beta')
+})
+
+it('publishes stable versions under the latest npm tag', () => {
+  assert.equal(npmTagForVersion('3.0.0'), 'latest')
 })
 
 it('rejects a release when Harness has a different v3 version', async () => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

v3 landed with alpha package versions, and the release workflow would put prereleases on npm's default `latest` tag. This prepares `3.0.0-beta.0` and derives the shared npm tag from the version. `skilld-protocol` remains independently versioned.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).