### PR TITLE
chore(release): disable ARM64 outline atomics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
           sudo apt-get install --yes musl-tools
       - name: Build native CLI
         run: cargo build --locked --release --package skilld-native --target ${{ matrix.target }}
+        env:
+          CFLAGS: ${{ matrix.cflags }}
       - name: Stage native CLI
         if: runner.os != 'Windows'
         shell: bash

--- a/scripts/release/native-packages.mjs
+++ b/scripts/release/native-packages.mjs
@@ -14,7 +14,7 @@ export const nativePackageSpecs = Object.freeze([
   nativePackage({ directory: 'cli-darwin-arm64', runner: 'macos-15', target: 'aarch64-apple-darwin', os: 'darwin', cpu: 'arm64', format: 'mach-o' }),
   nativePackage({ directory: 'cli-darwin-x64', runner: 'macos-15-intel', target: 'x86_64-apple-darwin', os: 'darwin', cpu: 'x64', format: 'mach-o' }),
   nativePackage({ directory: 'cli-linux-arm64-gnu', runner: 'ubuntu-24.04-arm', target: 'aarch64-unknown-linux-gnu', os: 'linux', cpu: 'arm64', libc: 'glibc', format: 'elf' }),
-  nativePackage({ directory: 'cli-linux-arm64-musl', runner: 'ubuntu-24.04-arm', target: 'aarch64-unknown-linux-musl', os: 'linux', cpu: 'arm64', libc: 'musl', format: 'elf' }),
+  nativePackage({ directory: 'cli-linux-arm64-musl', runner: 'ubuntu-24.04-arm', target: 'aarch64-unknown-linux-musl', os: 'linux', cpu: 'arm64', libc: 'musl', format: 'elf', cflags: '-mno-outline-atomics' }),
   nativePackage({ directory: 'cli-linux-x64-gnu', runner: 'ubuntu-24.04', target: 'x86_64-unknown-linux-gnu', os: 'linux', cpu: 'x64', libc: 'glibc', format: 'elf' }),
   nativePackage({ directory: 'cli-linux-x64-musl', runner: 'ubuntu-24.04', target: 'x86_64-unknown-linux-musl', os: 'linux', cpu: 'x64', libc: 'musl', format: 'elf' }),
   nativePackage({ directory: 'cli-win32-arm64-msvc', runner: 'windows-11-arm', target: 'aarch64-pc-windows-msvc', os: 'win32', cpu: 'arm64', format: 'pe' }),
@@ -26,6 +26,7 @@ export function nativeReleaseMatrix() {
     include: nativePackageSpecs.map(spec => ({
       directory: spec.directory,
       executable: spec.executable,
+      cflags: spec.cflags ?? '',
       libc: spec.libc ?? 'none',
       runner: spec.runner,
       target: spec.target,

--- a/tests/loader/native-packages.test.mjs
+++ b/tests/loader/native-packages.test.mjs
@@ -10,6 +10,7 @@ import { afterEach, it } from 'vitest'
 import {
   independentPackagePublishDecision,
   nativePackageSpecs,
+  nativeReleaseMatrix,
   npmTagForVersion,
   packagePublishDecision,
   verifyNativePackages,
@@ -108,6 +109,13 @@ it('publishes beta versions under the beta npm tag', () => {
 
 it('publishes stable versions under the latest npm tag', () => {
   assert.equal(npmTagForVersion('3.0.0'), 'latest')
+})
+
+it('disables GCC outline atomics for the ARM64 musl build', () => {
+  const release = nativeReleaseMatrix()
+  const arm64Musl = release.include.find(item => item.target === 'aarch64-unknown-linux-musl')
+
+  assert.equal(arm64Musl.cflags, '-mno-outline-atomics')
 })
 
 it('rejects a release when Harness has a different v3 version', async () => {


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v3 beta release stopped before publish because vendored libdbus emitted AArch64 LSE helper calls for the static musl target. Disable GCC outline atomics for that target.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).