### PR TITLE
chore(release): archive native build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           tar -cf "${{ matrix.directory }}.tar" -C staging "${{ matrix.directory }}"
       - uses: actions/upload-artifact@v7
         with:
-          archive: false
+          compression-level: 0
           path: ${{ matrix.directory }}.tar
 
   publish:


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The v3 beta publish job cannot download raw artifacts from upload-artifact@v7. Wrap each tar file in an uncompressed ZIP so download-artifact@v7 can restore it.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).