### PR TITLE
chore(release): name native build artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           compression-level: 0
+          name: ${{ matrix.directory }}
           path: ${{ matrix.directory }}.tar
 
   publish:


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [x] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

GitHub only lists the newest archived upload when every matrix job uses the default artifact name. Give each native target its own name so publish restores all eight packages.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).