### PR TITLE
fix(release): use available npm package names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Build JavaScript packages
         run: |
           pnpm --filter skilld-protocol build
-          pnpm --filter @skilld/harness build
+          pnpm --filter skilld-harness build
       - name: Check native package artifacts
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
       - run: pnpm --filter skilld-protocol check:v1
       - run: pnpm --filter skilld-protocol publint
       - run: pnpm --filter skilld-protocol attw
-      - run: pnpm --filter @skilld/harness publint
-      - run: pnpm --filter @skilld/harness attw
+      - run: pnpm --filter skilld-harness publint
+      - run: pnpm --filter skilld-harness attw
       - name: Pack root CLI
         run: |
           mkdir -p artifacts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Use focused commands during development:
 ```sh
 pnpm test:loader
 pnpm --filter skilld-protocol test:run
-pnpm --filter @skilld/harness test:run
+pnpm --filter skilld-harness test:run
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
 ```
@@ -29,7 +29,7 @@ It also manages account authentication and Agent target configuration.
 
 The skilld CLI contains no Skill generation logic or Agent runtime.
 
-`@skilld/harness` runs visible skilld-maintained Skills for generation and review.
+`skilld-harness` runs visible skilld-maintained Skills for generation and review.
 Agents can run the same Skill files directly without the Harness.
 
 Direct runs remain user reviewed.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,7 +7,7 @@ Use the terms in `GLOSSARY.md` exactly.
 - The skilld CLI is Rust.
 - skilld-maintained Skills support direct Agent generation, review, search, and install.
 - `skilld install skilld --global` installs search and install guidance for Agents.
-- Harness is the JavaScript `@skilld/harness` package.
+- Harness is the JavaScript `skilld-harness` package.
 - `skilld.dev` resolves Repositories into Artifacts with attestations.
 
 The skilld CLI and Harness do not import or execute each other.

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -11,8 +11,8 @@ Every public export, command, error, route, and document uses these terms.
 | Skill | Agent Skills specification | external standard | Agent, skilld CLI, Harness | Skill |
 | skilld-maintained Skill | `skills/*` | published asset | Agent, Harness | skilld-maintained Skill |
 | skilld CLI | `skilld` | published CLI | developer, CI | skilld CLI |
-| Harness | `@skilld/harness` | published package | application, CI | Harness |
-| Skill run | `@skilld/harness` | published type | Harness consumer | Skill run |
+| Harness | `skilld-harness` | published package | application, CI | Harness |
+| Skill run | `skilld-harness` | published type | Harness consumer | Skill run |
 | Repository | GitHub | external standard | skilld.dev, skilld CLI | repository |
 | Account | GitHub and skilld.dev | external standard | GitHub App, skilld.dev | account |
 | Artifact | `skilld.dev/api/v1` | published protocol | skilld CLI | Artifact |
@@ -106,7 +106,7 @@ None recorded.
 
 **Is:** the JavaScript package that runs skilld-maintained Skills with strict output checks.
 
-**Use for:** `@skilld/harness` and its public interface.
+**Use for:** `skilld-harness` and its public interface.
 
 **Never:** CLI engine, generator CLI, manager runtime.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Search, install, and keep Agent Skills current.
 skilld v3 has two products:
 
 - The native `skilld` CLI manages Skills.
-- The JavaScript [`@skilld/harness`](./packages/harness) package runs visible Skill generation and review instructions.
+- The JavaScript [`skilld-harness`](./packages/harness) package runs visible Skill generation and review instructions.
 
 The skilld CLI contains no Skill generation logic or Agent runtime.
 
@@ -124,15 +124,15 @@ Use these skilld-maintained Skills directly with your Agent:
 Direct Skill runs remain user reviewed.
 The instructions and changes stay visible to the user.
 
-Use [`@skilld/harness`](./packages/harness) when an application or CI needs strict output checks.
+Use [`skilld-harness`](./packages/harness) when an application or CI needs strict output checks.
 The Harness runs the same visible Skill files through an AI SDK Harness.
 
 ```sh
-pnpm add @skilld/harness @ai-sdk/harness ws zod
+pnpm add skilld-harness @ai-sdk/harness ws zod
 ```
 
 ```ts
-import { createSkillHarness } from '@skilld/harness'
+import { createSkillHarness } from 'skilld-harness'
 
 const skillHarness = createSkillHarness({ harness, sandbox })
 
@@ -143,7 +143,7 @@ const result = await skillHarness.run({
 })
 ```
 
-See the [`@skilld/harness` guide](./packages/harness/README.md) for its full contract.
+See the [`skilld-harness` guide](./packages/harness/README.md) for its full contract.
 
 ## Upgrade from v2
 

--- a/docs/adr/0001-v3-product-boundaries.md
+++ b/docs/adr/0001-v3-product-boundaries.md
@@ -16,7 +16,7 @@ The combined runtime also makes management slower and harder to port.
 
 The skilld CLI becomes Rust.
 
-Generation moves to visible skilld-maintained Skills and the JavaScript `@skilld/harness` package.
+Generation moves to visible skilld-maintained Skills and the JavaScript `skilld-harness` package.
 
 skilld-maintained Skills remain usable directly through an Agent.
 

--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -1,7 +1,7 @@
 # Migrate from skilld v2 to v3
 
 v3 replaces the JavaScript CLI with a native Rust CLI.
-It also moves Skill generation into visible Skills and `@skilld/harness`.
+It also moves Skill generation into visible Skills and `skilld-harness`.
 
 v3 does not import v2 configuration, credentials, or lockfiles.
 Complete these steps in order.
@@ -132,7 +132,7 @@ Use the visible skilld-maintained Skills for an interactive Agent run.
 The Agent shows the proposed files.
 You review and approve any replacement.
 
-Use `@skilld/harness` in CI or an application.
+Use `skilld-harness` in CI or an application.
 Harness enforces output limits, structure checks, and atomic promotion.
 
 An Agent run does not claim that Harness checks passed.

--- a/loader/resolve-artifact.mjs
+++ b/loader/resolve-artifact.mjs
@@ -1,12 +1,12 @@
 const nativePackages = new Map([
-  ['darwin:arm64', '@skilld/cli-darwin-arm64'],
-  ['darwin:x64', '@skilld/cli-darwin-x64'],
-  ['linux:arm64:gnu', '@skilld/cli-linux-arm64-gnu'],
-  ['linux:arm64:musl', '@skilld/cli-linux-arm64-musl'],
-  ['linux:x64:gnu', '@skilld/cli-linux-x64-gnu'],
-  ['linux:x64:musl', '@skilld/cli-linux-x64-musl'],
-  ['win32:arm64', '@skilld/cli-win32-arm64-msvc'],
-  ['win32:x64', '@skilld/cli-win32-x64-msvc'],
+  ['darwin:arm64', 'skilld-cli-darwin-arm64'],
+  ['darwin:x64', 'skilld-cli-darwin-x64'],
+  ['linux:arm64:gnu', 'skilld-cli-linux-arm64-gnu'],
+  ['linux:arm64:musl', 'skilld-cli-linux-arm64-musl'],
+  ['linux:x64:gnu', 'skilld-cli-linux-x64-gnu'],
+  ['linux:x64:musl', 'skilld-cli-linux-x64-musl'],
+  ['win32:arm64', 'skilld-cli-win32-arm64-msvc'],
+  ['win32:x64', 'skilld-cli-win32-x64-msvc'],
 ])
 
 export function detectLibc(report = process.report) {

--- a/package.json
+++ b/package.json
@@ -37,24 +37,24 @@
     "node": ">=18.18.0"
   },
   "scripts": {
-    "build": "pnpm --filter skilld-protocol build && pnpm --filter @skilld/harness build && cargo build --workspace",
+    "build": "pnpm --filter skilld-protocol build && pnpm --filter skilld-harness build && cargo build --workspace",
     "lint": "eslint . && cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings",
     "lint:fix": "eslint . --fix && cargo fmt --all",
-    "typecheck": "pnpm --filter skilld-protocol typecheck && pnpm --filter @skilld/harness typecheck",
+    "typecheck": "pnpm --filter skilld-protocol typecheck && pnpm --filter skilld-harness typecheck",
     "test": "vitest",
-    "test:run": "vitest run tests/loader && pnpm --filter skilld-protocol test:run && pnpm --filter @skilld/harness test:run && cargo test --workspace",
+    "test:run": "vitest run tests/loader && pnpm --filter skilld-protocol test:run && pnpm --filter skilld-harness test:run && cargo test --workspace",
     "prepack": "pnpm test:loader",
     "test:loader": "vitest run --config vitest.config.mjs"
   },
   "optionalDependencies": {
-    "@skilld/cli-darwin-arm64": "workspace:3.0.0-beta.0",
-    "@skilld/cli-darwin-x64": "workspace:3.0.0-beta.0",
-    "@skilld/cli-linux-arm64-gnu": "workspace:3.0.0-beta.0",
-    "@skilld/cli-linux-arm64-musl": "workspace:3.0.0-beta.0",
-    "@skilld/cli-linux-x64-gnu": "workspace:3.0.0-beta.0",
-    "@skilld/cli-linux-x64-musl": "workspace:3.0.0-beta.0",
-    "@skilld/cli-win32-arm64-msvc": "workspace:3.0.0-beta.0",
-    "@skilld/cli-win32-x64-msvc": "workspace:3.0.0-beta.0"
+    "skilld-cli-darwin-arm64": "workspace:3.0.0-beta.0",
+    "skilld-cli-darwin-x64": "workspace:3.0.0-beta.0",
+    "skilld-cli-linux-arm64-gnu": "workspace:3.0.0-beta.0",
+    "skilld-cli-linux-arm64-musl": "workspace:3.0.0-beta.0",
+    "skilld-cli-linux-x64-gnu": "workspace:3.0.0-beta.0",
+    "skilld-cli-linux-x64-musl": "workspace:3.0.0-beta.0",
+    "skilld-cli-win32-arm64-msvc": "workspace:3.0.0-beta.0",
+    "skilld-cli-win32-x64-msvc": "workspace:3.0.0-beta.0"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev-lint",

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-darwin-arm64",
+  "name": "skilld-cli-darwin-arm64",
   "version": "3.0.0-beta.0",
   "description": "macOS arm64 executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-darwin-x64",
+  "name": "skilld-cli-darwin-x64",
   "version": "3.0.0-beta.0",
   "description": "macOS x64 executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-linux-arm64-gnu/package.json
+++ b/packages/cli-linux-arm64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-linux-arm64-gnu",
+  "name": "skilld-cli-linux-arm64-gnu",
   "version": "3.0.0-beta.0",
   "description": "Linux arm64 GNU executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-linux-arm64-musl/package.json
+++ b/packages/cli-linux-arm64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-linux-arm64-musl",
+  "name": "skilld-cli-linux-arm64-musl",
   "version": "3.0.0-beta.0",
   "description": "Linux arm64 musl executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-linux-x64-gnu/package.json
+++ b/packages/cli-linux-x64-gnu/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-linux-x64-gnu",
+  "name": "skilld-cli-linux-x64-gnu",
   "version": "3.0.0-beta.0",
   "description": "Linux x64 GNU executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-linux-x64-musl/package.json
+++ b/packages/cli-linux-x64-musl/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-linux-x64-musl",
+  "name": "skilld-cli-linux-x64-musl",
   "version": "3.0.0-beta.0",
   "description": "Linux x64 musl executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-wasm32-wasi/package.json
+++ b/packages/cli-wasm32-wasi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-wasm32-wasi",
+  "name": "skilld-cli-wasm32-wasi",
   "type": "module",
   "version": "3.0.0-beta.0",
   "private": true,

--- a/packages/cli-win32-arm64-msvc/package.json
+++ b/packages/cli-win32-arm64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-win32-arm64-msvc",
+  "name": "skilld-cli-win32-arm64-msvc",
   "version": "3.0.0-beta.0",
   "description": "Windows arm64 executable for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-win32-x64-msvc/package.json
+++ b/packages/cli-win32-x64-msvc/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/cli-win32-x64-msvc",
+  "name": "skilld-cli-win32-x64-msvc",
   "version": "3.0.0-beta.0",
   "description": "Windows x64 executable for the skilld CLI",
   "license": "MIT",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -1,4 +1,4 @@
-# @skilld/harness
+# skilld-harness
 
 Run visible skilld-maintained Skills through an AI SDK Harness.
 
@@ -8,7 +8,7 @@ It then promotes generated Skills with an atomic directory rename.
 ## Install
 
 ```sh
-pnpm add @skilld/harness @ai-sdk/harness ws zod
+pnpm add skilld-harness @ai-sdk/harness ws zod
 ```
 
 Use Node 22 or newer.
@@ -17,7 +17,7 @@ The sandbox must provide POSIX `sh`, `rm`, `mkdir`, and GNU `find`.
 ## Run a Skill
 
 ```ts
-import { createSkillHarness } from '@skilld/harness'
+import { createSkillHarness } from 'skilld-harness'
 
 const skillHarness = createSkillHarness({
   harness,
@@ -42,13 +42,13 @@ The default adapter uses the Node global fetch implementation.
 
 ## Visible Skills
 
-Import `@skilld/harness/skills` to load the published Skill instructions.
+Import `skilld-harness/skills` to load the published Skill instructions.
 
 ```ts
 import {
   loadSkilldMaintainedSkill,
   skilldMaintainedSkillNames,
-} from '@skilld/harness/skills'
+} from 'skilld-harness/skills'
 
 const names = await skilldMaintainedSkillNames()
 const skill = await loadSkilldMaintainedSkill('generate-project-skill')

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@skilld/harness",
+  "name": "skilld-harness",
   "type": "module",
   "version": "3.0.0-beta.0",
   "description": "Run skilld-maintained Skills with checked, atomic output",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,28 +75,28 @@ importers:
         specifier: catalog:dev-test
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
-      '@skilld/cli-darwin-arm64':
+      skilld-cli-darwin-arm64:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-darwin-arm64
-      '@skilld/cli-darwin-x64':
+      skilld-cli-darwin-x64:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-darwin-x64
-      '@skilld/cli-linux-arm64-gnu':
+      skilld-cli-linux-arm64-gnu:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-arm64-gnu
-      '@skilld/cli-linux-arm64-musl':
+      skilld-cli-linux-arm64-musl:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-arm64-musl
-      '@skilld/cli-linux-x64-gnu':
+      skilld-cli-linux-x64-gnu:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-x64-gnu
-      '@skilld/cli-linux-x64-musl':
+      skilld-cli-linux-x64-musl:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-linux-x64-musl
-      '@skilld/cli-win32-arm64-msvc':
+      skilld-cli-win32-arm64-msvc:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-win32-arm64-msvc
-      '@skilld/cli-win32-x64-msvc':
+      skilld-cli-win32-x64-msvc:
         specifier: workspace:3.0.0-beta.0
         version: link:packages/cli-win32-x64-msvc
 

--- a/scripts/release/native-packages.mjs
+++ b/scripts/release/native-packages.mjs
@@ -203,7 +203,7 @@ function nativePackage(spec) {
     ...spec,
     executable,
     executableMode: spec.os !== 'win32',
-    packageName: `@skilld/${spec.directory}`,
+    packageName: `skilld-${spec.directory}`,
   })
 }
 

--- a/tests/loader/native-packages.test.mjs
+++ b/tests/loader/native-packages.test.mjs
@@ -122,7 +122,7 @@ it('rejects a release when Harness has a different v3 version', async () => {
   const root = await temporaryDirectory()
   await writeReleaseManifests(root, '3.0.0-alpha.2', '2.4.0')
   await writeFile(join(root, 'packages/harness/package.json'), JSON.stringify({
-    name: '@skilld/harness',
+    name: 'skilld-harness',
     version: '3.0.0-alpha.1',
   }))
 
@@ -190,9 +190,9 @@ it('fails when the registry returns another package version', () => {
 
 it('skips a shared package that a partial release already published', () => {
   const decision = packagePublishDecision({
-    packageName: '@skilld/cli-linux-x64-gnu',
+    packageName: 'skilld-cli-linux-x64-gnu',
     response: {
-      body: { name: '@skilld/cli-linux-x64-gnu', version: '3.0.0-alpha.1' },
+      body: { name: 'skilld-cli-linux-x64-gnu', version: '3.0.0-alpha.1' },
       status: 200,
     },
     version: '3.0.0-alpha.1',
@@ -200,7 +200,7 @@ it('skips a shared package that a partial release already published', () => {
 
   assert.deepEqual(decision, {
     _tag: 'Skip',
-    packageName: '@skilld/cli-linux-x64-gnu',
+    packageName: 'skilld-cli-linux-x64-gnu',
     version: '3.0.0-alpha.1',
   })
 })
@@ -237,7 +237,7 @@ async function writeNativePackage(root, spec) {
 async function writeReleaseManifests(root, sharedVersion, protocolVersion) {
   const manifests = [
     ['package.json', { name: 'skilld', version: sharedVersion }],
-    ['packages/harness/package.json', { name: '@skilld/harness', version: sharedVersion }],
+    ['packages/harness/package.json', { name: 'skilld-harness', version: sharedVersion }],
     ['packages/protocol/package.json', { name: 'skilld-protocol', version: protocolVersion }],
     ...nativePackageSpecs.map(spec => [
       `packages/${spec.directory}/package.json`,

--- a/tests/loader/resolve-artifact.test.mjs
+++ b/tests/loader/resolve-artifact.test.mjs
@@ -14,14 +14,14 @@ it('maps every supported host to one native package', () => {
     nativePackage({ platform: 'win32', arch: 'arm64' }),
     nativePackage({ platform: 'win32', arch: 'x64' }),
   ], [
-    '@skilld/cli-darwin-arm64',
-    '@skilld/cli-darwin-x64',
-    '@skilld/cli-linux-arm64-gnu',
-    '@skilld/cli-linux-arm64-musl',
-    '@skilld/cli-linux-x64-gnu',
-    '@skilld/cli-linux-x64-musl',
-    '@skilld/cli-win32-arm64-msvc',
-    '@skilld/cli-win32-x64-msvc',
+    'skilld-cli-darwin-arm64',
+    'skilld-cli-darwin-x64',
+    'skilld-cli-linux-arm64-gnu',
+    'skilld-cli-linux-arm64-musl',
+    'skilld-cli-linux-x64-gnu',
+    'skilld-cli-linux-x64-musl',
+    'skilld-cli-win32-arm64-msvc',
+    'skilld-cli-win32-x64-msvc',
   ])
   assert.equal(detectLibc({ getReport: () => ({ header: { glibcVersionRuntime: '2.39' } }) }), 'gnu')
   assert.equal(detectLibc({ getReport: () => ({ header: {} }) }), 'musl')
@@ -38,7 +38,7 @@ it('selects only the native executable', async () => {
     return '/native/skilld'
   })
 
-  assert.deepEqual(requests, [['@skilld/cli-linux-x64-gnu', 'bin/skilld']])
+  assert.deepEqual(requests, [['skilld-cli-linux-x64-gnu', 'bin/skilld']])
   assert.deepEqual(result, { _tag: 'Native', executable: '/native/skilld' })
 })
 


### PR DESCRIPTION
## Summary

- replace the unavailable `@skilld` npm scope with unscoped `skilld-*` packages
- keep native loader, release tooling, workspace manifests, docs, and tests aligned
- use `skilld-harness` for the Harness package

## Verification

- `pnpm test:run`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- all nine npm package names return 404 and are available

Authored by Codex on behalf of Harlan.