### PR TITLE
chore(release): prepare v3.0.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-auth"
-version = "3.0.0-beta.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "base64",
  "getrandom 0.3.4",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-command"
-version = "3.0.0-beta.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "base64",
  "clap",
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-core"
-version = "3.0.0-beta.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-native"
-version = "3.0.0-beta.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "skilld-auth",
  "skilld-command",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "skilld-wasi"
-version = "3.0.0-beta.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "skilld-command",
  "skilld-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 resolver = "3"
 
 [workspace.package]
-version = "3.0.0-beta.0"
+version = "3.0.0-beta.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/skilld-dev/skilld"

--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -35,7 +35,7 @@ They are your rollback copy.
 Install the v3 CLI:
 
 ```sh
-npm install --global skilld@3.0.0-beta.0
+npm install --global skilld@3.0.0-beta.1
 skilld --version
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skilld",
   "type": "module",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "packageManager": "pnpm@11.21.0",
   "description": "Search, install, and keep Skills current",
   "author": {
@@ -47,14 +47,14 @@
     "test:loader": "vitest run --config vitest.config.mjs"
   },
   "optionalDependencies": {
-    "skilld-cli-darwin-arm64": "workspace:3.0.0-beta.0",
-    "skilld-cli-darwin-x64": "workspace:3.0.0-beta.0",
-    "skilld-cli-linux-arm64-gnu": "workspace:3.0.0-beta.0",
-    "skilld-cli-linux-arm64-musl": "workspace:3.0.0-beta.0",
-    "skilld-cli-linux-x64-gnu": "workspace:3.0.0-beta.0",
-    "skilld-cli-linux-x64-musl": "workspace:3.0.0-beta.0",
-    "skilld-cli-win32-arm64-msvc": "workspace:3.0.0-beta.0",
-    "skilld-cli-win32-x64-msvc": "workspace:3.0.0-beta.0"
+    "skilld-cli-darwin-arm64": "workspace:3.0.0-beta.1",
+    "skilld-cli-darwin-x64": "workspace:3.0.0-beta.1",
+    "skilld-cli-linux-arm64-gnu": "workspace:3.0.0-beta.1",
+    "skilld-cli-linux-arm64-musl": "workspace:3.0.0-beta.1",
+    "skilld-cli-linux-x64-gnu": "workspace:3.0.0-beta.1",
+    "skilld-cli-linux-x64-musl": "workspace:3.0.0-beta.1",
+    "skilld-cli-win32-arm64-msvc": "workspace:3.0.0-beta.1",
+    "skilld-cli-win32-x64-msvc": "workspace:3.0.0-beta.1"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev-lint",

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-darwin-arm64",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "macOS arm64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-darwin-x64",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "macOS x64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-arm64-gnu/package.json
+++ b/packages/cli-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-linux-arm64-gnu",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Linux arm64 GNU executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-arm64-musl/package.json
+++ b/packages/cli-linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-linux-arm64-musl",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Linux arm64 musl executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-x64-gnu/package.json
+++ b/packages/cli-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-linux-x64-gnu",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Linux x64 GNU executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-linux-x64-musl/package.json
+++ b/packages/cli-linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-linux-x64-musl",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Linux x64 musl executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-wasm32-wasi/package.json
+++ b/packages/cli-wasm32-wasi/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skilld-cli-wasm32-wasi",
   "type": "module",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "private": true,
   "description": "WASIp2 fallback host for the skilld CLI",
   "license": "MIT",

--- a/packages/cli-win32-arm64-msvc/package.json
+++ b/packages/cli-win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-win32-arm64-msvc",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Windows arm64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/cli-win32-x64-msvc/package.json
+++ b/packages/cli-win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skilld-cli-win32-x64-msvc",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Windows x64 executable for the skilld CLI",
   "license": "MIT",
   "repository": "github:skilld-dev/skilld",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "skilld-harness",
   "type": "module",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "Run skilld-maintained Skills with checked, atomic output",
   "author": {
     "name": "Harlan Wilton",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,28 +76,28 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(vite@7.3.1(@types/node@26.2.0)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
     optionalDependencies:
       skilld-cli-darwin-arm64:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-darwin-arm64
       skilld-cli-darwin-x64:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-darwin-x64
       skilld-cli-linux-arm64-gnu:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-linux-arm64-gnu
       skilld-cli-linux-arm64-musl:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-linux-arm64-musl
       skilld-cli-linux-x64-gnu:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-linux-x64-gnu
       skilld-cli-linux-x64-musl:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-linux-x64-musl
       skilld-cli-win32-arm64-msvc:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-win32-arm64-msvc
       skilld-cli-win32-x64-msvc:
-        specifier: workspace:3.0.0-beta.0
+        specifier: workspace:3.0.0-beta.1
         version: link:packages/cli-win32-x64-msvc
 
   packages/cli-darwin-arm64: {}

--- a/tests/loader/native-packages.test.mjs
+++ b/tests/loader/native-packages.test.mjs
@@ -104,7 +104,7 @@ it('keeps v3 packages aligned and versions the protocol independently', async ()
 })
 
 it('publishes beta versions under the beta npm tag', () => {
-  assert.equal(npmTagForVersion('3.0.0-beta.0'), 'beta')
+  assert.equal(npmTagForVersion('3.0.0-beta.1'), 'beta')
 })
 
 it('publishes stable versions under the latest npm tag', () => {


### PR DESCRIPTION
## Summary

- advance shared v3 packages and Rust crates to `3.0.0-beta.1`
- align native optional dependencies and lockfiles
- update the v3 migration install command

## Verification

- `node scripts/release/native-packages.mjs versions v3.0.0-beta.1`
- `pnpm test:loader`
- `cargo check --workspace`

Authored by Codex on behalf of Harlan.