### PR TITLE
fix(cli): cap Artifact resolution at 60 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ GitHub remains the source of truth.
 
 skilld.dev builds an immutable Artifact from an exact Git commit.
 The CLI checks its digest, Artifact attestation, check results, and archive before installation.
+The CLI stops pending Artifact creation after at most 60 seconds.
 
 Private Repository delivery requires both:
 

--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -22,7 +22,7 @@ const DIRECT_BLOB_LIMIT: usize = 12 * 1024 * 1024;
 const MAX_REDIRECTS: usize = 3;
 const MAX_RETRIES: usize = 2;
 const MAX_POLLS: usize = 120;
-const MAX_POLL_DURATION_MS: u64 = 10 * 60 * 1_000;
+const MAX_POLL_DURATION_MS: u64 = 60 * 1_000;
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -431,12 +431,7 @@ impl SkilldRemote {
                     poll_duration_ms = poll_duration_ms
                         .checked_add(poll_after_ms)
                         .filter(|duration| *duration <= MAX_POLL_DURATION_MS)
-                        .ok_or_else(|| {
-                            RemoteError::new(
-                                "RESOLUTION_TIMEOUT",
-                                "the Resolution exceeded the poll duration",
-                            )
-                        })?;
+                        .ok_or_else(resolution_timeout)?;
                     self.sleeper.sleep(
                         Duration::from_millis(poll_after_ms),
                         self.cancellation.as_ref(),
@@ -479,10 +474,7 @@ impl SkilldRemote {
                 }
             }
         }
-        Err(RemoteError::new(
-            "RESOLUTION_TIMEOUT",
-            "the Resolution did not finish within the poll limit",
-        ))
+        Err(resolution_timeout())
     }
 
     fn grant(&self, artifact_id: &str) -> Result<ArtifactGrant, RemoteError> {
@@ -970,6 +962,13 @@ fn valid_resolution_id(value: &str) -> bool {
 
 fn cancelled() -> RemoteError {
     RemoteError::new("CANCELLED", "the remote operation was cancelled")
+}
+
+fn resolution_timeout() -> RemoteError {
+    RemoteError::new(
+        "RESOLUTION_TIMEOUT",
+        "Artifact creation stayed pending too long. Retry the same command.",
+    )
 }
 
 fn invalid_github() -> RemoteError {

--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::Deserialize;
@@ -22,8 +22,64 @@ const DIRECT_BLOB_LIMIT: usize = 12 * 1024 * 1024;
 const MAX_REDIRECTS: usize = 3;
 const MAX_RETRIES: usize = 2;
 const MAX_POLLS: usize = 120;
-const MAX_POLL_DURATION_MS: u64 = 60 * 1_000;
+const RESOLUTION_TIMEOUT_MS: u64 = 60 * 1_000;
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+struct ResolutionDeadline {
+    expires_at: Instant,
+    remaining_wait: Duration,
+}
+
+impl ResolutionDeadline {
+    fn new() -> Self {
+        let timeout = Duration::from_millis(RESOLUTION_TIMEOUT_MS);
+        Self {
+            expires_at: Instant::now()
+                .checked_add(timeout)
+                .expect("the fixed Resolution timeout is valid"),
+            remaining_wait: timeout,
+        }
+    }
+
+    fn remaining(&self) -> Result<Duration, RemoteError> {
+        let remaining = self
+            .expires_at
+            .checked_duration_since(Instant::now())
+            .unwrap_or_default()
+            .min(self.remaining_wait);
+        if remaining.is_zero() {
+            Err(resolution_timeout())
+        } else {
+            Ok(remaining)
+        }
+    }
+
+    fn sleep(
+        &mut self,
+        duration: Duration,
+        sleeper: &dyn Sleeper,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), RemoteError> {
+        if cancellation.is_cancelled() {
+            return Err(cancelled());
+        }
+        let remaining = self.remaining()?;
+        if duration >= remaining {
+            sleeper.sleep(remaining, cancellation)?;
+            if cancellation.is_cancelled() {
+                return Err(cancelled());
+            }
+            self.remaining_wait = Duration::ZERO;
+            return Err(resolution_timeout());
+        }
+        sleeper.sleep(duration, cancellation)?;
+        if cancellation.is_cancelled() {
+            return Err(cancelled());
+        }
+        self.remaining_wait = self.remaining_wait.saturating_sub(duration);
+        self.remaining().map(|_| ())
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum HttpMethod {
@@ -160,6 +216,7 @@ pub trait HttpAdapter: Send + Sync {
         &self,
         request: &HttpRequest,
         cancellation: &dyn Cancellation,
+        timeout: Option<Duration>,
     ) -> Result<HttpResponse, RemoteError>;
 }
 
@@ -274,8 +331,17 @@ impl SkilldRemote {
 
     fn execute(
         &self,
+        request: HttpRequest,
+        allowed: AllowedOrigin,
+    ) -> Result<HttpResponse, RemoteError> {
+        self.execute_with_deadline(request, allowed, None)
+    }
+
+    fn execute_with_deadline(
+        &self,
         mut request: HttpRequest,
         allowed: AllowedOrigin,
+        mut deadline: Option<&mut ResolutionDeadline>,
     ) -> Result<HttpResponse, RemoteError> {
         let mut redirects = 0_usize;
         loop {
@@ -285,7 +351,20 @@ impl SkilldRemote {
                 if self.cancellation.is_cancelled() {
                     return Err(cancelled());
                 }
-                match self.adapter.send(&request, self.cancellation.as_ref()) {
+                let timeout = deadline
+                    .as_deref()
+                    .map(ResolutionDeadline::remaining)
+                    .transpose()?;
+                let response = self
+                    .adapter
+                    .send(&request, self.cancellation.as_ref(), timeout);
+                if self.cancellation.is_cancelled() {
+                    return Err(cancelled());
+                }
+                if let Some(deadline) = deadline.as_deref() {
+                    deadline.remaining()?;
+                }
+                match response {
                     Ok(response) => {
                         if response.body.len() > request.response_limit {
                             return Err(RemoteError::new(
@@ -295,17 +374,16 @@ impl SkilldRemote {
                         }
                         if matches!(response.status, 429 | 503) && retry < MAX_RETRIES {
                             retry += 1;
-                            self.sleeper
-                                .sleep(retry_delay(&response, retry), self.cancellation.as_ref())?;
+                            self.sleep(retry_delay(&response, retry), deadline.as_deref_mut())?;
                             continue;
                         }
                         break response;
                     }
                     Err(error) if error.code == "HTTP_TRANSPORT" && retry < MAX_RETRIES => {
                         retry += 1;
-                        self.sleeper.sleep(
+                        self.sleep(
                             Duration::from_millis(100 * retry as u64),
-                            self.cancellation.as_ref(),
+                            deadline.as_deref_mut(),
                         )?;
                     }
                     Err(error) => return Err(error),
@@ -336,6 +414,19 @@ impl SkilldRemote {
                 return Err(problem_error(&response));
             }
             return Ok(response);
+        }
+    }
+
+    fn sleep(
+        &self,
+        duration: Duration,
+        deadline: Option<&mut ResolutionDeadline>,
+    ) -> Result<(), RemoteError> {
+        match deadline {
+            Some(deadline) => {
+                deadline.sleep(duration, self.sleeper.as_ref(), self.cancellation.as_ref())
+            }
+            None => self.sleeper.sleep(duration, self.cancellation.as_ref()),
         }
     }
 
@@ -374,6 +465,7 @@ impl SkilldRemote {
     }
 
     fn resolve(&self, source: &SourceRequest) -> Result<ArtifactDescriptor, RemoteError> {
+        let mut deadline = ResolutionDeadline::new();
         let body = serde_json::to_vec(&json!({ "source": source })).map_err(|_| {
             RemoteError::new("INVALID_SOURCE", "the source request cannot be encoded")
         })?;
@@ -387,7 +479,11 @@ impl SkilldRemote {
             body,
             response_limit: JSON_LIMIT,
         };
-        let response = self.execute(request, AllowedOrigin::Service(self.endpoint.clone()))?;
+        let response = self.execute_with_deadline(
+            request,
+            AllowedOrigin::Service(self.endpoint.clone()),
+            Some(&mut deadline),
+        )?;
         let mut resolution: Resolution = parse_json(&response.body)?;
         let resolution_id = resolution.resolution_id().to_owned();
         if !valid_resolution_id(&resolution_id) {
@@ -396,7 +492,6 @@ impl SkilldRemote {
                 "the Resolution identifier is invalid",
             ));
         }
-        let mut poll_duration_ms = 0_u64;
         for _ in 0..MAX_POLLS {
             if resolution.resolution_id() != resolution_id {
                 return Err(RemoteError::new(
@@ -428,12 +523,9 @@ impl SkilldRemote {
                             "the Resolution poll interval is invalid",
                         ));
                     }
-                    poll_duration_ms = poll_duration_ms
-                        .checked_add(poll_after_ms)
-                        .filter(|duration| *duration <= MAX_POLL_DURATION_MS)
-                        .ok_or_else(resolution_timeout)?;
-                    self.sleeper.sleep(
+                    deadline.sleep(
                         Duration::from_millis(poll_after_ms),
+                        self.sleeper.as_ref(),
                         self.cancellation.as_ref(),
                     )?;
                     let path = format!("/api/v1/resolutions/{}", path_segment(&resolution_id));
@@ -444,8 +536,11 @@ impl SkilldRemote {
                         body: vec![],
                         response_limit: JSON_LIMIT,
                     };
-                    let response =
-                        self.execute(request, AllowedOrigin::Service(self.endpoint.clone()))?;
+                    let response = self.execute_with_deadline(
+                        request,
+                        AllowedOrigin::Service(self.endpoint.clone()),
+                        Some(&mut deadline),
+                    )?;
                     resolution = parse_json(&response.body)?;
                 }
                 Resolution::Blocked { .. } => {

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -74,6 +74,25 @@ impl Sleeper for NoSleep {
     }
 }
 
+#[derive(Default)]
+struct RecordingSleeper {
+    elapsed: Mutex<Duration>,
+}
+
+impl Sleeper for RecordingSleeper {
+    fn sleep(
+        &self,
+        duration: Duration,
+        cancellation: &dyn Cancellation,
+    ) -> Result<(), RemoteError> {
+        if cancellation.is_cancelled() {
+            return Err(RemoteError::new("CANCELLED", "cancelled"));
+        }
+        *self.elapsed.lock().unwrap() += duration;
+        Ok(())
+    }
+}
+
 struct FixedToken;
 
 impl TokenProvider for FixedToken {
@@ -349,6 +368,43 @@ fn a_resolution_cannot_change_its_identity_while_polling() {
     let error = remote.prepare(&skilld_selector(), false).unwrap_err();
 
     assert_eq!(error.code, "INVALID_RESPONSE");
+}
+
+#[test]
+fn a_pending_resolution_times_out_after_at_most_sixty_seconds() {
+    let resolution_id = "018f47a4-2d38-7c5f-8d3e-1c5a6b7d8e9f";
+    let pending = || {
+        response(
+            200,
+            serde_json::to_vec(&json!({
+                "state": "pending",
+                "resolutionId": resolution_id,
+                "stage": "checking",
+                "pollAfterMs": 30_000
+            }))
+            .unwrap(),
+        )
+    };
+    let http = Arc::new(FakeHttp::with([pending(), pending(), pending()]));
+    let sleeper = Arc::new(RecordingSleeper::default());
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(NoTokenProvider),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap()
+    .with_sleeper(sleeper.clone());
+
+    let error = remote.prepare(&skilld_selector(), false).unwrap_err();
+
+    assert_eq!(error.code, "RESOLUTION_TIMEOUT");
+    assert_eq!(
+        error.message,
+        "Artifact creation stayed pending too long. Retry the same command."
+    );
+    assert_eq!(*sleeper.elapsed.lock().unwrap(), Duration::from_secs(60));
+    assert_eq!(http.requests.lock().unwrap().len(), 3);
 }
 
 #[test]

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fs;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -26,6 +27,7 @@ const ATTESTATION_DOMAIN: &[u8] = b"skilld-attestation-v1\0";
 struct FakeHttp {
     responses: Mutex<VecDeque<Result<HttpResponse, RemoteError>>>,
     requests: Mutex<Vec<HttpRequest>>,
+    timeouts: Mutex<Vec<Option<Duration>>>,
 }
 
 impl FakeHttp {
@@ -33,6 +35,7 @@ impl FakeHttp {
         Self {
             responses: Mutex::new(responses.into_iter().map(Ok).collect()),
             requests: Mutex::new(vec![]),
+            timeouts: Mutex::new(vec![]),
         }
     }
 }
@@ -42,8 +45,10 @@ impl HttpAdapter for FakeHttp {
         &self,
         request: &HttpRequest,
         _cancellation: &dyn Cancellation,
+        timeout: Option<Duration>,
     ) -> Result<HttpResponse, RemoteError> {
         self.requests.lock().unwrap().push(request.clone());
+        self.timeouts.lock().unwrap().push(timeout);
         self.responses
             .lock()
             .unwrap()
@@ -89,6 +94,30 @@ impl Sleeper for RecordingSleeper {
             return Err(RemoteError::new("CANCELLED", "cancelled"));
         }
         *self.elapsed.lock().unwrap() += duration;
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct TestCancellation(AtomicBool);
+
+impl Cancellation for TestCancellation {
+    fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}
+
+struct CancellingSleeper {
+    cancellation: Arc<TestCancellation>,
+}
+
+impl Sleeper for CancellingSleeper {
+    fn sleep(
+        &self,
+        _duration: Duration,
+        _cancellation: &dyn Cancellation,
+    ) -> Result<(), RemoteError> {
+        self.cancellation.0.store(true, Ordering::SeqCst);
         Ok(())
     }
 }
@@ -404,7 +433,76 @@ fn a_pending_resolution_times_out_after_at_most_sixty_seconds() {
         "Artifact creation stayed pending too long. Retry the same command."
     );
     assert_eq!(*sleeper.elapsed.lock().unwrap(), Duration::from_secs(60));
-    assert_eq!(http.requests.lock().unwrap().len(), 3);
+    assert_eq!(http.requests.lock().unwrap().len(), 2);
+}
+
+#[test]
+fn resolution_retry_waits_count_toward_the_sixty_second_limit() {
+    let resolution_id = "018f47a4-2d38-7c5f-8d3e-1c5a6b7d8e9f";
+    let pending = || {
+        response(
+            200,
+            serde_json::to_vec(&json!({
+                "state": "pending",
+                "resolutionId": resolution_id,
+                "stage": "checking",
+                "pollAfterMs": 30_000
+            }))
+            .unwrap(),
+        )
+    };
+    let mut retry = response(503, b"unavailable".to_vec());
+    retry
+        .headers
+        .insert("retry-after".to_owned(), "60".to_owned());
+    let http = Arc::new(FakeHttp::with([pending(), retry, pending(), pending()]));
+    let sleeper = Arc::new(RecordingSleeper::default());
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(NoTokenProvider),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap()
+    .with_sleeper(sleeper.clone());
+
+    let error = remote.prepare(&skilld_selector(), false).unwrap_err();
+
+    assert_eq!(error.code, "RESOLUTION_TIMEOUT");
+    assert_eq!(*sleeper.elapsed.lock().unwrap(), Duration::from_secs(60));
+    assert_eq!(http.requests.lock().unwrap().len(), 2);
+    let timeouts = http.timeouts.lock().unwrap();
+    assert!(timeouts[0].is_some_and(|timeout| timeout <= Duration::from_secs(60)));
+    assert!(timeouts[1].is_some_and(|timeout| timeout <= Duration::from_secs(30)));
+}
+
+#[test]
+fn cancellation_wins_when_the_resolution_deadline_is_reached() {
+    let http = Arc::new(FakeHttp::with([response(
+        200,
+        serde_json::to_vec(&json!({
+            "state": "pending",
+            "resolutionId": "018f47a4-2d38-7c5f-8d3e-1c5a6b7d8e9f",
+            "stage": "checking",
+            "pollAfterMs": 60_000
+        }))
+        .unwrap(),
+    )]));
+    let cancellation = Arc::new(TestCancellation::default());
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(NoTokenProvider),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap()
+    .with_cancellation(cancellation.clone())
+    .with_sleeper(Arc::new(CancellingSleeper { cancellation }));
+
+    let error = remote.prepare(&skilld_selector(), false).unwrap_err();
+
+    assert_eq!(error.code, "CANCELLED");
+    assert_eq!(http.requests.lock().unwrap().len(), 1);
 }
 
 #[test]

--- a/crates/skilld-native/src/lib.rs
+++ b/crates/skilld-native/src/lib.rs
@@ -76,6 +76,7 @@ impl HttpAdapter for NativeHttpAdapter {
         &self,
         request: &HttpRequest,
         cancellation: &dyn Cancellation,
+        timeout: Option<Duration>,
     ) -> Result<HttpResponse, RemoteError> {
         if cancellation.is_cancelled() {
             return Err(RemoteError::new(
@@ -89,12 +90,24 @@ impl HttpAdapter for NativeHttpAdapter {
                 for header in &request.headers {
                     builder = builder.header(&header.name, header.value.expose());
                 }
+                if let Some(timeout) = timeout {
+                    builder = builder
+                        .config()
+                        .timeout_global(Some(timeout.min(Duration::from_secs(30))))
+                        .build();
+                }
                 builder.call()
             }
             HttpMethod::Post => {
                 let mut builder = self.agent.post(&request.url);
                 for header in &request.headers {
                     builder = builder.header(&header.name, header.value.expose());
+                }
+                if let Some(timeout) = timeout {
+                    builder = builder
+                        .config()
+                        .timeout_global(Some(timeout.min(Duration::from_secs(30))))
+                        .build();
                 }
                 builder.send(request.body.as_slice())
             }


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`skilld install` could poll for ten minutes, then keep retrying network work past its deadline.

The whole Resolution path stops after 60 seconds with `RESOLUTION_TIMEOUT`. It tells the Agent to retry the same command.

Progress output is still missing. That needs a separate event path, so I left it out here.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).