### PR TITLE
fix(cli): restore direct sources from lockfile

### DIFF
--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -22,8 +22,8 @@ pub use remote::{
     RemoteSourceState, SecretValue, SkilldRemote, Sleeper, ThreadSleeper, TokenProvider,
 };
 use skilld_core::{
-    AGENT_TARGETS, AgentTargetId, DomainError, GlobalTargetPath, InstallMode, InstallRequest,
-    InstallScope, InstallSource, LockedSource, VERSION, select_target_ids,
+    AGENT_TARGETS, AgentTargetId, DomainError, GlobalTargetPath, InstallMode, InstallOperation,
+    InstallRequest, InstallScope, InstallSource, LockedSource, VERSION, select_target_ids,
 };
 
 #[derive(Debug, Parser)]
@@ -112,9 +112,11 @@ pub trait Host {
                 "Agent target selection is unavailable on this host",
             ));
         }
-        let source = request
-            .source
-            .ok_or_else(|| CommandError::unsupported_host("lockfile restore is unavailable"))?;
+        let InstallOperation::Install(source) = request.operation else {
+            return Err(CommandError::unsupported_host(
+                "lockfile restore is unavailable",
+            ));
+        };
         self.install(source, request.scope).map(|name| vec![name])
     }
 
@@ -345,19 +347,24 @@ fn dispatch<H: Host>(command: Command, host: &H) -> Result<Vec<String>, CommandE
             direct,
         } => {
             let scope = scope(global);
-            let source = source
-                .map(|source| InstallSource::parse(&source))
-                .map(|source| match (direct, source) {
+            let operation = match source {
+                Some(source) => match (direct, InstallSource::parse(&source)) {
                     (true, InstallSource::Remote(source)) => {
-                        Ok(InstallSource::DirectRemote(source))
+                        InstallOperation::Install(InstallSource::DirectRemote(source))
                     }
-                    (true, _) => Err(CommandError::input(
-                        "--direct needs an explicit public GitHub Repository selector",
-                    )),
-                    (false, source) => Ok(source),
-                })
-                .transpose()?;
-            if source == Some(InstallSource::BundledSkilld) && scope != InstallScope::Global {
+                    (true, _) => {
+                        return Err(CommandError::input(
+                            "--direct needs an explicit public GitHub Repository selector",
+                        ));
+                    }
+                    (false, source) => InstallOperation::Install(source),
+                },
+                None if direct => InstallOperation::DirectRestore,
+                None => InstallOperation::Restore,
+            };
+            if operation == InstallOperation::Install(InstallSource::BundledSkilld)
+                && scope != InstallScope::Global
+            {
                 return Err(CommandError::input(
                     "install the skilld-maintained Skill with --global",
                 ));
@@ -372,7 +379,7 @@ fn dispatch<H: Host>(command: Command, host: &H) -> Result<Vec<String>, CommandE
                 .transpose()
                 .map_err(CommandError::domain)?;
             let names = host.install_request(InstallRequest {
-                source,
+                operation,
                 scope,
                 targets,
                 mode,
@@ -749,7 +756,7 @@ impl LocalHost {
         Ok(name.to_string())
     }
 
-    fn restore(&self, request: &InstallRequest) -> Result<Vec<String>, CommandError> {
+    fn restore(&self, request: &InstallRequest, direct: bool) -> Result<Vec<String>, CommandError> {
         let (targets, known) = self.select_installs(request)?;
         let store = self.store(request.scope);
         let names = store.list(&known).map_err(CommandError::store)?;
@@ -805,17 +812,18 @@ impl LocalHost {
                 LockedSource::Remote {
                     source, commit_sha, ..
                 } => {
-                    if !matches!(
-                        view.skill.source_status,
-                        skilld_core::SourceStatus::Verified { .. }
-                    ) {
-                        return Err(CommandError {
-                            code: "UNVERIFIED_SOURCE",
-                            message:
-                                "restore an unverified Skill with an explicit --direct install"
-                                    .to_owned(),
-                        });
-                    }
+                    let direct = match view.skill.source_status {
+                        skilld_core::SourceStatus::Verified { .. } => false,
+                        skilld_core::SourceStatus::Unverified { .. } if direct => true,
+                        _ => {
+                            return Err(CommandError {
+                                code: "UNVERIFIED_SOURCE",
+                                message:
+                                    "run skilld install --direct to restore an unverified Skill"
+                                        .to_owned(),
+                            });
+                        }
+                    };
                     let selector = skilld_core::RemoteSelector::parse(&source)
                         .map_err(CommandError::remote)?;
                     let mut exact_source = selector.source().clone();
@@ -830,7 +838,7 @@ impl LocalHost {
                     };
                     let prepared = self
                         .remote_provider()?
-                        .prepare(&exact, false)
+                        .prepare(&exact, direct)
                         .map_err(CommandError::remote)?;
                     let staged = materialize_remote(&prepared.files)?;
                     store
@@ -858,7 +866,7 @@ impl Host for LocalHost {
 
     fn install(&self, source: InstallSource, scope: InstallScope) -> Result<String, CommandError> {
         self.install_request(InstallRequest {
-            source: Some(source),
+            operation: InstallOperation::Install(source),
             scope,
             targets: vec![],
             mode: None,
@@ -869,8 +877,10 @@ impl Host for LocalHost {
     }
 
     fn install_request(&self, request: InstallRequest) -> Result<Vec<String>, CommandError> {
-        let Some(source) = request.source.clone() else {
-            return self.restore(&request);
+        let source = match request.operation.clone() {
+            InstallOperation::Restore => return self.restore(&request, false),
+            InstallOperation::DirectRestore => return self.restore(&request, true),
+            InstallOperation::Install(source) => source,
         };
         let (targets, known) = self.select_installs(&request)?;
         match source {
@@ -1291,7 +1301,10 @@ mod tests {
         }
 
         fn install_request(&self, request: InstallRequest) -> Result<Vec<String>, CommandError> {
-            assert_eq!(request.source, Some(InstallSource::BundledSkilld));
+            assert_eq!(
+                request.operation,
+                InstallOperation::Install(InstallSource::BundledSkilld)
+            );
             assert_eq!(request.scope, InstallScope::Global);
             assert_eq!(request.targets, [AgentTargetId::Codex]);
             Ok(vec!["skilld".to_owned()])

--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -757,7 +757,12 @@ impl LocalHost {
     }
 
     fn restore(&self, request: &InstallRequest, direct: bool) -> Result<Vec<String>, CommandError> {
-        let (targets, known) = self.select_installs(request)?;
+        let (targets, known) = if request.targets.is_empty() {
+            (None, self.known_targets(request.scope)?)
+        } else {
+            let (targets, known) = self.select_installs(request)?;
+            (Some(targets), known)
+        };
         let store = self.store(request.scope);
         let names = store.list(&known).map_err(CommandError::store)?;
         if names.is_empty() {
@@ -776,24 +781,46 @@ impl LocalHost {
             let view = store
                 .view(&skill_name, &known)
                 .map_err(CommandError::store)?;
-            let restored_targets = targets
-                .iter()
-                .map(|target| {
-                    let mode = if request.mode.is_some() {
-                        target.mode
-                    } else {
-                        view.skill
-                            .targets
+            let restored_targets = if let Some(targets) = &targets {
+                targets
+                    .iter()
+                    .map(|target| {
+                        let mode = if request.mode.is_some() {
+                            target.mode
+                        } else {
+                            view.skill
+                                .targets
+                                .iter()
+                                .find(|locked| locked.agent == target.target.agent)
+                                .map_or(target.mode, |locked| locked.mode)
+                        };
+                        TargetInstall {
+                            target: target.target.clone(),
+                            mode,
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            } else {
+                view.skill
+                    .targets
+                    .iter()
+                    .map(|locked| {
+                        known
                             .iter()
-                            .find(|locked| locked.agent == target.target.agent)
-                            .map_or(target.mode, |locked| locked.mode)
-                    };
-                    TargetInstall {
-                        target: target.target.clone(),
-                        mode,
-                    }
-                })
-                .collect::<Vec<_>>();
+                            .find(|target| target.agent == locked.agent)
+                            .cloned()
+                            .map(|target| TargetInstall {
+                                target,
+                                mode: request.mode.unwrap_or(locked.mode),
+                            })
+                            .ok_or_else(|| {
+                                CommandError::domain(DomainError::InvalidTarget(
+                                    locked.agent.to_string(),
+                                ))
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+            };
             match view.skill.source {
                 LockedSource::Local { path } => {
                     let (source, locked_source) =

--- a/crates/skilld-command/tests/agent_targets.rs
+++ b/crates/skilld-command/tests/agent_targets.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 
 use skilld_command::{DetectionEnvironment, Host, LocalHost, TargetRoots};
-use skilld_core::{AgentTargetId, InstallRequest, InstallScope, InstallSource};
+use skilld_core::{AgentTargetId, InstallOperation, InstallRequest, InstallScope, InstallSource};
 
 fn source(root: &Path) -> std::path::PathBuf {
     let source = root.join("source/example");
@@ -57,7 +57,7 @@ fn every_project_signal_selects_the_matching_agent_target() {
 
         let names = host
             .install_request(InstallRequest {
-                source: Some(InstallSource::Local(source)),
+                operation: InstallOperation::Install(InstallSource::Local(source)),
                 scope: InstallScope::Project,
                 targets: vec![],
                 mode: None,
@@ -117,7 +117,7 @@ fn every_runtime_signal_selects_the_matching_agent_target() {
             .with_detection_environment(DetectionEnvironment::new([signal.to_owned()]));
 
         host.install_request(InstallRequest {
-            source: Some(InstallSource::Local(source)),
+            operation: InstallOperation::Install(InstallSource::Local(source)),
             scope: InstallScope::Project,
             targets: vec![],
             mode: None,
@@ -148,7 +148,7 @@ fn an_existing_global_target_directory_is_detected() {
     ));
 
     host.install_request(InstallRequest {
-        source: Some(InstallSource::Local(source)),
+        operation: InstallOperation::Install(InstallSource::Local(source)),
         scope: InstallScope::Global,
         targets: vec![],
         mode: None,

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -14,9 +14,9 @@ use skilld_command::{
 };
 use skilld_core::{
     AgentTargetId, ArtifactAttestation, ArtifactFile, AttestationSignature, CheckOutcome,
-    CheckResult, InstallMode, InstallRequest, InstallScope, InstallSource, LockedSource,
-    PreparedFile, RemoteError, RemoteSelector, RepositoryVisibility, ResolvedSource, SearchResult,
-    SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
+    CheckResult, InstallMode, InstallOperation, InstallRequest, InstallScope, InstallSource,
+    LockedSource, PreparedFile, RemoteError, RemoteSelector, RepositoryVisibility, ResolvedSource,
+    SearchResult, SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
 };
 
 const ROOT_DOMAIN: &[u8] = b"skilld-trusted-key-v1\0";
@@ -568,10 +568,11 @@ struct FakeProvider {
     content: Mutex<Vec<u8>>,
     stale: Mutex<bool>,
     fail_prepare: Mutex<bool>,
+    prepares: Mutex<Vec<(String, bool)>>,
 }
 
 impl FakeProvider {
-    fn prepared(&self, selector: &RemoteSelector) -> PreparedRemoteSkill {
+    fn prepared(&self, selector: &RemoteSelector, direct: bool) -> PreparedRemoteSkill {
         let bytes = self.content.lock().unwrap().clone();
         let file = PreparedFile {
             path: "SKILL.md".to_owned(),
@@ -586,11 +587,18 @@ impl FakeProvider {
                 commit_sha: "0123456789abcdef0123456789abcdef01234567".to_owned(),
                 skill_path: "skills/example".to_owned(),
             },
-            source_status: SourceStatus::Verified {
-                artifact_id: format!("sha256:{digest}"),
-                content_sha256: digest.clone(),
-                installed_sha256: digest,
-                attestation_key_id: "test-key".to_owned(),
+            source_status: if direct {
+                SourceStatus::Unverified {
+                    content_sha256: digest.clone(),
+                    installed_sha256: digest,
+                }
+            } else {
+                SourceStatus::Verified {
+                    artifact_id: format!("sha256:{digest}"),
+                    content_sha256: digest.clone(),
+                    installed_sha256: digest,
+                    attestation_key_id: "test-key".to_owned(),
+                }
             },
         }
     }
@@ -607,12 +615,16 @@ impl RemoteProvider for FakeProvider {
     fn prepare(
         &self,
         selector: &RemoteSelector,
-        _direct: bool,
+        direct: bool,
     ) -> Result<PreparedRemoteSkill, RemoteError> {
+        self.prepares
+            .lock()
+            .unwrap()
+            .push((selector.canonical(), direct));
         if *self.fail_prepare.lock().unwrap() {
             Err(RemoteError::new("CHECK_BLOCKED", "a required check failed"))
         } else {
-            Ok(self.prepared(selector))
+            Ok(self.prepared(selector, direct))
         }
     }
 
@@ -653,6 +665,7 @@ fn provider(content: &str) -> Arc<FakeProvider> {
         content: Mutex::new(content.as_bytes().to_vec()),
         stale: Mutex::new(false),
         fail_prepare: Mutex::new(false),
+        prepares: Mutex::new(vec![]),
     })
 }
 
@@ -665,7 +678,7 @@ fn verify_reports_changed_bytes_and_stale_sources() {
     let host = LocalHost::new(project.clone(), temporary.path().join("data"))
         .with_remote_provider(provider.clone());
     host.install_request(InstallRequest {
-        source: Some(InstallSource::Remote(
+        operation: InstallOperation::Install(InstallSource::Remote(
             "skilld:skilld-dev/skills/example".to_owned(),
         )),
         scope: InstallScope::Project,
@@ -697,7 +710,7 @@ fn remote_install_verify_and_failed_upgrade_use_the_normal_transaction() {
     let provider = provider("---\nname: example\ndescription: first\n---\n");
     let host = LocalHost::new(project.clone(), data).with_remote_provider(provider.clone());
     let request = InstallRequest {
-        source: Some(InstallSource::Remote(
+        operation: InstallOperation::Install(InstallSource::Remote(
             "skilld:skilld-dev/skills/example".to_owned(),
         )),
         scope: InstallScope::Project,
@@ -753,4 +766,183 @@ fn cli_direct_install_marks_review_as_required() {
         "Installed Skill example.\nReview the unverified Skill before use.\n"
     );
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn cli_direct_restore_uses_the_locked_commit() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = provider("---\nname: example\ndescription: direct\n---\n");
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let installed = run(
+        [
+            "skilld",
+            "install",
+            "github:skilld-dev/skills/skills/example",
+            "--direct",
+            "--agent",
+            "codex",
+        ],
+        &host,
+        &mut stdout,
+        &mut stderr,
+    );
+    assert_eq!(installed.exit_code, 0);
+    fs::remove_dir_all(project.join(".skills/example")).unwrap();
+    fs::remove_dir_all(project.join(".agents")).unwrap();
+    stdout.clear();
+    stderr.clear();
+
+    let restored = run(
+        ["skilld", "install", "--direct", "--agent", "codex"],
+        &host,
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(restored.exit_code, 0);
+    assert_eq!(
+        String::from_utf8(stdout).unwrap(),
+        "Installed Skill example.\nReview the unverified Skill before use.\n"
+    );
+    assert!(stderr.is_empty());
+    assert_eq!(
+        *provider.prepares.lock().unwrap(),
+        [
+            (
+                "github:skilld-dev/skills/skills/example".to_owned(),
+                true
+            ),
+            (
+                "github:skilld-dev/skills/skills/example#commit:0123456789abcdef0123456789abcdef01234567"
+                    .to_owned(),
+                true
+            )
+        ]
+    );
+    let view = host.view("example", InstallScope::Project).unwrap();
+    assert!(matches!(
+        view.skill.source_status,
+        SourceStatus::Unverified { .. }
+    ));
+    assert!(matches!(
+        view.skill.source,
+        LockedSource::Remote { ref commit_sha, .. }
+            if commit_sha == "0123456789abcdef0123456789abcdef01234567"
+    ));
+    assert_eq!(view.skill.targets[0].agent, AgentTargetId::Codex);
+    assert_eq!(view.skill.targets[0].mode, InstallMode::Copy);
+    assert!(project.join(".agents/skills/example/SKILL.md").exists());
+}
+
+#[test]
+fn cli_plain_restore_rejects_an_unverified_source_with_the_recovery_command() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = provider("---\nname: example\n---\n");
+    let host = LocalHost::new(project, temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    assert_eq!(
+        run(
+            [
+                "skilld",
+                "install",
+                "github:skilld-dev/skills/skills/example",
+                "--direct",
+                "--agent",
+                "codex",
+            ],
+            &host,
+            &mut stdout,
+            &mut stderr,
+        )
+        .exit_code,
+        0
+    );
+    stdout.clear();
+    stderr.clear();
+
+    let restored = run(
+        ["skilld", "install", "--agent", "codex"],
+        &host,
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(restored.exit_code, 2);
+    assert!(stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(stderr).unwrap(),
+        "UNVERIFIED_SOURCE: run skilld install --direct to restore an unverified Skill\n"
+    );
+    assert_eq!(provider.prepares.lock().unwrap().len(), 1);
+}
+
+#[test]
+fn cli_verified_restore_keeps_artifact_delivery() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = provider("---\nname: example\ndescription: verified\n---\n");
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    assert_eq!(
+        run(
+            [
+                "skilld",
+                "install",
+                "skilld:skilld-dev/skills/example",
+                "--agent",
+                "codex",
+            ],
+            &host,
+            &mut stdout,
+            &mut stderr,
+        )
+        .exit_code,
+        0
+    );
+    fs::remove_dir_all(project.join(".skills/example")).unwrap();
+    fs::remove_dir_all(project.join(".agents")).unwrap();
+    stdout.clear();
+    stderr.clear();
+
+    let restored = run(
+        ["skilld", "install", "--agent", "codex"],
+        &host,
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(restored.exit_code, 0);
+    assert_eq!(
+        String::from_utf8(stdout).unwrap(),
+        "Installed Skill example.\n"
+    );
+    assert!(stderr.is_empty());
+    assert_eq!(
+        *provider.prepares.lock().unwrap(),
+        [
+            ("skilld:skilld-dev/skills/example".to_owned(), false),
+            (
+                "skilld:skilld-dev/skills/example#commit:0123456789abcdef0123456789abcdef01234567"
+                    .to_owned(),
+                false
+            )
+        ]
+    );
+    let view = host.view("example", InstallScope::Project).unwrap();
+    assert!(matches!(
+        view.skill.source_status,
+        SourceStatus::Verified { .. }
+    ));
 }

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -798,7 +798,7 @@ fn cli_direct_restore_uses_the_locked_commit() {
     stderr.clear();
 
     let restored = run(
-        ["skilld", "install", "--direct", "--agent", "codex"],
+        ["skilld", "install", "--direct"],
         &host,
         &mut stdout,
         &mut stderr,

--- a/crates/skilld-core/src/lib.rs
+++ b/crates/skilld-core/src/lib.rs
@@ -152,8 +152,15 @@ impl InstallPlan {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub enum InstallOperation {
+    Install(InstallSource),
+    Restore,
+    DirectRestore,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct InstallRequest {
-    pub source: Option<InstallSource>,
+    pub operation: InstallOperation,
     pub scope: InstallScope,
     pub targets: Vec<AgentTargetId>,
     pub mode: Option<InstallMode>,


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`skilld install --direct` rejected the unverified source it had just written to the lockfile. A clean checkout without Agent configuration also failed before reading locked targets.

Restore reads the recorded GitHub commit and Agent targets. Without `--direct`, the source stays rejected.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).