### PR TITLE
feat(cli): add Agent-aware search output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 ## Product boundary
 
-The native `skilld` CLI searches, installs, lists, views, removes, upgrades, and verifies Skills.
+The native `skilld` CLI searches, installs, lists, views, removes, updates, and verifies Skills.
 It also manages account authentication and Agent target configuration.
 
 The skilld CLI contains no Skill generation logic or Agent runtime.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1708,6 +1708,7 @@ dependencies = [
  "sha2 0.11.0",
  "skilld-core",
  "tempfile",
+ "unicode-width",
  "url",
 ]
 
@@ -1951,7 +1952,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1959,6 +1960,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,10 +1728,12 @@ dependencies = [
 name = "skilld-native"
 version = "3.0.0-beta.1"
 dependencies = [
+ "nix",
  "skilld-auth",
  "skilld-command",
  "skilld-core",
  "tempfile",
+ "terminal_size",
  "ureq",
  "url",
 ]
@@ -1833,6 +1835,16 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
  "rustix",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ skilld-command = { path = "crates/skilld-command" }
 skilld-core = { path = "crates/skilld-core" }
 subtle = "2.6.1"
 tempfile = "3.27.0"
+terminal_size = "0.4.4"
 unicode-width = "0.2.2"
 url = "2.5.8"
 wit-bindgen = "0.60.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ skilld-command = { path = "crates/skilld-command" }
 skilld-core = { path = "crates/skilld-core" }
 subtle = "2.6.1"
 tempfile = "3.27.0"
+unicode-width = "0.2.2"
 url = "2.5.8"
 wit-bindgen = "0.60.0"
 zeroize = "1.9.0"

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -19,6 +19,7 @@ Every public export, command, error, route, and document uses these terms.
 | Artifact attestation | `skilld.dev/api/v1` | published protocol | skilld CLI | attestation |
 | Check result | `skilld.dev/api/v1` | published protocol | skilld CLI, developer | check result |
 | Source status | lockfile and protocol | published value | skilld CLI, CI | source status |
+| Update relation | skilld CLI JSON v1 | published value | Agent, developer, CI | update relation |
 | Agent target | skilld CLI | published configuration | Agent | Agent target |
 
 | Identifier | Term |
@@ -28,7 +29,8 @@ Every public export, command, error, route, and document uses these terms.
 | `skilld list` | installed Skills |
 | `skilld view` | Skill details |
 | `skilld remove` | Skill removal |
-| `skilld upgrade` | Skill upgrade |
+| `skilld update` | Skill update |
+| `skilld update --check --json` | update relation check |
 | `skilld verify` | source verification |
 | `skilld install skilld --global` | global skilld Skill install |
 | `skilld auth login` | account login |
@@ -94,7 +96,7 @@ None recorded.
 
 ### skilld CLI
 
-**Is:** the Rust command line interface that searches, installs, upgrades, and removes Skills.
+**Is:** the Rust command line interface that searches, installs, updates, and removes Skills.
 
 **Use for:** the command product and its manager logic.
 
@@ -181,6 +183,16 @@ None recorded.
 **Never:** safety state, trust score, verification tier.
 
 **Casing:** `Source status` in headings, `sourceStatus` in identifiers.
+
+### Update relation
+
+**Is:** the Git relationship between an installed Skill commit and its current source commit.
+
+**Use for:** `current`, `available`, `behind`, `diverged`, `pinned`, `notTracked`, or `unavailable` JSON values.
+
+**Never:** upgrade status, version status, release status.
+
+**Casing:** `Update relation` in headings, `relation` in JSON.
 
 ### Agent target
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ skilld view vue
 
 # Keep Skills current
 skilld verify vue
-skilld upgrade vue
+skilld update vue
+
+# Check update relations for an Agent or CI
+skilld update --check --json
 
 # Remove a Skill
 skilld remove vue

--- a/crates/skilld-command/Cargo.toml
+++ b/crates/skilld-command/Cargo.toml
@@ -26,6 +26,8 @@ skilld-core.workspace = true
 
 tempfile.workspace = true
 
+unicode-width.workspace = true
+
 url = "2.5.7"
 
 [target.'cfg(not(target_os = "wasi"))'.dependencies]

--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -197,73 +197,88 @@ pub trait Host {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CommandErrorKind {
+    Usage,
+    Operation,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CommandError {
+    pub kind: CommandErrorKind,
     pub code: &'static str,
     pub message: String,
 }
 
 impl CommandError {
-    pub fn unsupported_host(message: impl Into<String>) -> Self {
+    pub fn usage(code: &'static str, message: impl Into<String>) -> Self {
         Self {
-            code: "UNSUPPORTED_HOST",
+            kind: CommandErrorKind::Usage,
+            code,
             message: message.into(),
         }
+    }
+
+    pub fn operation(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            kind: CommandErrorKind::Operation,
+            code,
+            message: message.into(),
+        }
+    }
+
+    pub fn unsupported_host(message: impl Into<String>) -> Self {
+        Self::operation("UNSUPPORTED_HOST", message)
     }
 
     pub fn service(message: impl Into<String>) -> Self {
-        Self {
-            code: "SERVICE_UNAVAILABLE",
-            message: message.into(),
-        }
+        Self::operation("SERVICE_UNAVAILABLE", message)
     }
 
     pub fn not_implemented(message: impl Into<String>) -> Self {
-        Self {
-            code: "NOT_IMPLEMENTED",
-            message: message.into(),
-        }
+        Self::operation("NOT_IMPLEMENTED", message)
     }
 
     pub fn input(message: impl Into<String>) -> Self {
-        Self {
-            code: "INVALID_SOURCE",
-            message: message.into(),
-        }
+        Self::usage("INVALID_SOURCE", message)
     }
 
     pub fn config(message: impl Into<String>) -> Self {
-        Self {
-            code: "INVALID_CONFIG",
-            message: message.into(),
-        }
+        Self::usage("INVALID_CONFIG", message)
     }
 
     pub fn filesystem(message: impl Into<String>) -> Self {
-        Self {
-            code: "SERVICE_UNAVAILABLE",
-            message: message.into(),
-        }
+        Self::operation("SERVICE_UNAVAILABLE", message)
     }
 
     pub fn domain(error: DomainError) -> Self {
-        Self {
-            code: error.code(),
-            message: error.to_string(),
-        }
+        Self::usage(error.code(), error.to_string())
     }
 
     pub fn store(error: StoreError) -> Self {
-        Self {
-            code: error.code(),
-            message: error.to_string(),
-        }
+        Self::operation(error.code(), error.to_string())
     }
 
     pub fn remote(error: skilld_core::RemoteError) -> Self {
+        let kind = if matches!(
+            error.code,
+            "INVALID_SEARCH" | "INVALID_SOURCE" | "DIRECT_SOURCE_REQUIRED"
+        ) {
+            CommandErrorKind::Usage
+        } else {
+            CommandErrorKind::Operation
+        };
         Self {
+            kind,
             code: error.code,
             message: error.message,
+        }
+    }
+
+    fn exit_code(&self) -> u8 {
+        match self.kind {
+            CommandErrorKind::Usage => 2,
+            CommandErrorKind::Operation => 1,
         }
     }
 }
@@ -311,7 +326,14 @@ where
     O: Write,
     E: Write,
 {
-    let cli = match Cli::try_parse_from(args) {
+    let args = args.into_iter().map(Into::into).collect::<Vec<OsString>>();
+    let (requested_json, requested_plain) = requested_output(&args);
+    let requested_mode = if requested_json && requested_plain {
+        OutputMode::Plain
+    } else {
+        resolve_mode(requested_json, requested_plain, context)
+    };
+    let cli = match Cli::try_parse_from(&args) {
         Ok(cli) => cli,
         Err(error) => {
             let display = matches!(
@@ -319,8 +341,33 @@ where
                 ErrorKind::DisplayHelp | ErrorKind::DisplayVersion
             );
             let target: &mut dyn Write = if display { stdout } else { stderr };
-            if write!(target, "{error}").is_err() {
-                return CommandResult { exit_code: 2 };
+            let rendered = if requested_mode == OutputMode::JsonV1 {
+                if display {
+                    output::render_display(
+                        error.kind(),
+                        &display_path(&args),
+                        error.to_string().trim(),
+                    )
+                } else {
+                    let message = error
+                        .to_string()
+                        .lines()
+                        .next()
+                        .unwrap_or("invalid command arguments")
+                        .trim_start_matches("error: ")
+                        .to_owned();
+                    render_error(
+                        &CommandError::usage("INVALID_ARGUMENT", message),
+                        requested_mode,
+                    )
+                }
+            } else {
+                error.to_string().into_bytes()
+            };
+            if target.write_all(&rendered).is_err() {
+                return CommandResult {
+                    exit_code: if display { 1 } else { 2 },
+                };
             }
             return CommandResult {
                 exit_code: if display { 0 } else { 2 },
@@ -330,10 +377,10 @@ where
 
     let mode = resolve_mode(cli.json, cli.plain, context);
     if mode == OutputMode::JsonV1 && !matches!(&cli.command, Command::Search { .. }) {
-        let error = CommandError {
-            code: "UNSUPPORTED_OUTPUT",
-            message: "JSON output is available for Skill search only".to_owned(),
-        };
+        let error = CommandError::usage(
+            "UNSUPPORTED_OUTPUT",
+            "JSON output is available for Skill search only",
+        );
         if stderr.write_all(&render_error(&error, mode)).is_err() {
             return CommandResult { exit_code: 2 };
         }
@@ -342,33 +389,87 @@ where
 
     match dispatch(cli.command, host) {
         Ok(CommandOutput::Lines(lines)) => {
+            let mut bytes = Vec::new();
             for line in lines {
-                if writeln!(stdout, "{line}").is_err() {
-                    return CommandResult { exit_code: 2 };
-                }
+                bytes.extend_from_slice(line.as_bytes());
+                bytes.push(b'\n');
             }
-            CommandResult { exit_code: 0 }
+            write_success(&bytes, mode, stdout, stderr)
         }
         Ok(CommandOutput::Search(outcome)) => match render_search(&outcome, mode) {
-            Ok(bytes) => match stdout.write_all(&bytes) {
-                Ok(()) => CommandResult { exit_code: 0 },
-                Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {
-                    CommandResult { exit_code: 0 }
-                }
-                Err(_) => CommandResult { exit_code: 2 },
-            },
+            Ok(bytes) => write_success(&bytes, mode, stdout, stderr),
             Err(error) => {
                 if stderr.write_all(&render_error(&error, mode)).is_err() {
-                    return CommandResult { exit_code: 2 };
+                    return CommandResult {
+                        exit_code: error.exit_code(),
+                    };
                 }
-                CommandResult { exit_code: 2 }
+                CommandResult {
+                    exit_code: error.exit_code(),
+                }
             }
         },
         Err(error) => {
             if stderr.write_all(&render_error(&error, mode)).is_err() {
-                return CommandResult { exit_code: 2 };
+                return CommandResult {
+                    exit_code: error.exit_code(),
+                };
             }
-            CommandResult { exit_code: 2 }
+            CommandResult {
+                exit_code: error.exit_code(),
+            }
+        }
+    }
+}
+
+fn requested_output(args: &[OsString]) -> (bool, bool) {
+    let mut json = false;
+    let mut plain = false;
+    for argument in args.iter().skip(1) {
+        if argument == "--" {
+            break;
+        }
+        if argument == "--json" {
+            json = true;
+        } else if argument == "--plain" {
+            plain = true;
+        }
+    }
+    (json, plain)
+}
+
+fn display_path(args: &[OsString]) -> String {
+    let commands = [
+        "search", "install", "list", "view", "remove", "upgrade", "verify", "auth", "config",
+    ];
+    let mut path = vec!["skilld"];
+    if let Some(command) = args
+        .iter()
+        .skip(1)
+        .filter_map(|argument| argument.to_str())
+        .find(|argument| commands.contains(argument))
+    {
+        path.push(command);
+    }
+    path.join(" ")
+}
+
+fn write_success<O: Write, E: Write>(
+    bytes: &[u8],
+    mode: OutputMode,
+    stdout: &mut O,
+    stderr: &mut E,
+) -> CommandResult {
+    match stdout.write_all(bytes) {
+        Ok(()) => CommandResult { exit_code: 0 },
+        Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {
+            CommandResult { exit_code: 0 }
+        }
+        Err(_) => {
+            let error =
+                CommandError::operation("OUTPUT_WRITE_FAILED", "Skill output could not be written");
+            let _ = stderr.write_all(&render_error(&error, mode));
+            CommandResult { exit_code: 1 }
         }
     }
 }
@@ -496,7 +597,13 @@ fn dispatch<H: Host>(command: Command, host: &H) -> Result<CommandOutput, Comman
             command: ConfigCommand::List,
         } => host.config_list().map(CommandOutput::Lines),
         Command::Search { query } => {
-            let query = query.join(" ");
+            let query = query.join(" ").trim().to_owned();
+            if query.is_empty() || query.len() > 200 {
+                return Err(CommandError::usage(
+                    "INVALID_SEARCH",
+                    "Skill search needs a query up to 200 bytes",
+                ));
+            }
             let response = host.search(&query)?;
             let items = response
                 .items
@@ -569,10 +676,6 @@ impl DetectionEnvironment {
 
     fn has(&self, name: &str) -> bool {
         self.variables.contains(name)
-    }
-
-    pub fn detects_agent(&self) -> bool {
-        !self.variables.is_empty()
     }
 }
 
@@ -834,13 +937,13 @@ impl LocalHost {
         let store = self.store(request.scope);
         let names = store.list(&known).map_err(CommandError::store)?;
         if names.is_empty() {
-            return Err(CommandError {
-                code: "LOCKFILE_NOT_FOUND",
-                message: format!(
+            return Err(CommandError::operation(
+                "LOCKFILE_NOT_FOUND",
+                format!(
                     "no installed Skills exist in {} scope",
                     request.scope.as_str()
                 ),
-            });
+            ));
         }
         let mut restored = Vec::new();
         for name in names {
@@ -911,12 +1014,11 @@ impl LocalHost {
                         skilld_core::SourceStatus::Verified { .. } => false,
                         skilld_core::SourceStatus::Unverified { .. } if direct => true,
                         _ => {
-                            return Err(CommandError {
-                                code: "UNVERIFIED_SOURCE",
-                                message:
-                                    "run skilld install --direct to restore an unverified Skill"
-                                        .to_owned(),
-                            });
+                            return Err(CommandError::operation(
+                                "UNVERIFIED_SOURCE",
+                                "run skilld install --direct to restore an unverified Skill"
+                                    .to_owned(),
+                            ));
                         }
                     };
                     let selector = skilld_core::RemoteSelector::parse(&source)
@@ -1065,10 +1167,9 @@ impl Host for LocalHost {
             let view = store
                 .verify_content(&name, &known)
                 .map_err(|error| match error {
-                    StoreError::Conflict(message) => CommandError {
-                        code: "CONTENT_CHANGED",
-                        message,
-                    },
+                    StoreError::Conflict(message) => {
+                        CommandError::operation("CONTENT_CHANGED", message)
+                    }
                     error => CommandError::store(error),
                 })?;
             match (&view.skill.source, &view.skill.source_status) {
@@ -1089,21 +1190,18 @@ impl Host for LocalHost {
                             lines.push(format!("Verified Skill {}.", name.as_str()));
                         }
                         RemoteSourceState::Stale { .. } => {
-                            return Err(CommandError {
-                                code: "SOURCE_STALE",
-                                message: format!(
-                                    "Skill {} has a newer or changed source",
-                                    name.as_str()
-                                ),
-                            });
+                            return Err(CommandError::operation(
+                                "SOURCE_STALE",
+                                format!("Skill {} has a newer or changed source", name.as_str()),
+                            ));
                         }
                     }
                 }
                 (_, skilld_core::SourceStatus::Unverified { .. }) => {
-                    return Err(CommandError {
-                        code: "UNVERIFIED_SOURCE",
-                        message: format!("Skill {} has an unverified source", name.as_str()),
-                    });
+                    return Err(CommandError::operation(
+                        "UNVERIFIED_SOURCE",
+                        format!("Skill {} has an unverified source", name.as_str()),
+                    ));
                 }
                 _ => lines.push(format!("Checked local Skill {}.", name.as_str())),
             }
@@ -1130,10 +1228,10 @@ impl Host for LocalHost {
                 view.skill.source_status,
                 skilld_core::SourceStatus::Verified { .. }
             ) {
-                return Err(CommandError {
-                    code: "UNVERIFIED_SOURCE",
-                    message: format!("Skill {name} needs another explicit --direct install"),
-                });
+                return Err(CommandError::operation(
+                    "UNVERIFIED_SOURCE",
+                    format!("Skill {name} needs another explicit --direct install"),
+                ));
             }
             let selector =
                 skilld_core::RemoteSelector::parse(source).map_err(CommandError::remote)?;
@@ -1145,10 +1243,10 @@ impl Host for LocalHost {
             let staged_name =
                 skilld_core::SkillName::from_source(staged.path()).map_err(CommandError::domain)?;
             if staged_name != skill_name {
-                return Err(CommandError {
-                    code: "SOURCE_MISMATCH",
-                    message: format!("the upgraded Skill name changed from {name}"),
-                });
+                return Err(CommandError::operation(
+                    "SOURCE_MISMATCH",
+                    format!("the upgraded Skill name changed from {name}"),
+                ));
             }
             let targets = view
                 .skill

--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -1,5 +1,6 @@
 mod config;
 mod local_store;
+mod output;
 mod remote;
 
 use std::collections::BTreeSet;
@@ -16,6 +17,7 @@ pub use local_store::{
     AllowTransaction, LocalStore, ResolvedTarget, SkillView, StoreError, TargetInstall,
     TransactionGate,
 };
+pub use output::OutputContext;
 pub use remote::{
     Cancellation, HeaderValue, HttpAdapter, HttpHeader, HttpMethod, HttpRequest, HttpResponse,
     NativeRemoteConfig, NeverCancelled, NoTokenProvider, PreparedRemoteSkill, RemoteProvider,
@@ -26,6 +28,8 @@ use skilld_core::{
     InstallRequest, InstallScope, InstallSource, LockedSource, VERSION, select_target_ids,
 };
 
+use output::{OutputMode, SearchItem, SearchOutcome, render_error, render_search, resolve_mode};
+
 #[derive(Debug, Parser)]
 #[command(
     name = "skilld",
@@ -34,6 +38,12 @@ use skilld_core::{
     disable_help_subcommand = true
 )]
 pub struct Cli {
+    /// Output stable JSON for Agents and automation.
+    #[arg(long, global = true, conflicts_with = "plain")]
+    json: bool,
+    /// Output stable text without terminal formatting.
+    #[arg(long, global = true, conflicts_with = "json")]
+    plain: bool,
     #[command(subcommand)]
     command: Command,
 }
@@ -132,7 +142,7 @@ pub trait Host {
         ))
     }
 
-    fn search(&self, _query: &str) -> Result<Vec<skilld_core::SearchResult>, CommandError> {
+    fn search(&self, _query: &str) -> Result<skilld_core::SearchResponse, CommandError> {
         Err(CommandError::unsupported_host(
             "Skill search is unavailable on this host",
         ))
@@ -271,7 +281,29 @@ pub struct CommandResult {
     pub exit_code: u8,
 }
 
+enum CommandOutput {
+    Lines(Vec<String>),
+    Search(SearchOutcome),
+}
+
 pub fn run<I, T, H, O, E>(args: I, host: &H, stdout: &mut O, stderr: &mut E) -> CommandResult
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+    H: Host,
+    O: Write,
+    E: Write,
+{
+    run_with_output(args, host, OutputContext::Plain, stdout, stderr)
+}
+
+pub fn run_with_output<I, T, H, O, E>(
+    args: I,
+    host: &H,
+    context: OutputContext,
+    stdout: &mut O,
+    stderr: &mut E,
+) -> CommandResult
 where
     I: IntoIterator<Item = T>,
     T: Into<OsString> + Clone,
@@ -296,8 +328,20 @@ where
         }
     };
 
+    let mode = resolve_mode(cli.json, cli.plain, context);
+    if mode == OutputMode::JsonV1 && !matches!(&cli.command, Command::Search { .. }) {
+        let error = CommandError {
+            code: "UNSUPPORTED_OUTPUT",
+            message: "JSON output is available for Skill search only".to_owned(),
+        };
+        if stderr.write_all(&render_error(&error, mode)).is_err() {
+            return CommandResult { exit_code: 2 };
+        }
+        return CommandResult { exit_code: 2 };
+    }
+
     match dispatch(cli.command, host) {
-        Ok(lines) => {
+        Ok(CommandOutput::Lines(lines)) => {
             for line in lines {
                 if writeln!(stdout, "{line}").is_err() {
                     return CommandResult { exit_code: 2 };
@@ -305,8 +349,23 @@ where
             }
             CommandResult { exit_code: 0 }
         }
+        Ok(CommandOutput::Search(outcome)) => match render_search(&outcome, mode) {
+            Ok(bytes) => match stdout.write_all(&bytes) {
+                Ok(()) => CommandResult { exit_code: 0 },
+                Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {
+                    CommandResult { exit_code: 0 }
+                }
+                Err(_) => CommandResult { exit_code: 2 },
+            },
+            Err(error) => {
+                if stderr.write_all(&render_error(&error, mode)).is_err() {
+                    return CommandResult { exit_code: 2 };
+                }
+                CommandResult { exit_code: 2 }
+            }
+        },
         Err(error) => {
-            if writeln!(stderr, "{error}").is_err() {
+            if stderr.write_all(&render_error(&error, mode)).is_err() {
                 return CommandResult { exit_code: 2 };
             }
             CommandResult { exit_code: 2 }
@@ -337,7 +396,7 @@ pub fn run_stdio_probe<R: Read, O: Write, E: Write>(
     }
 }
 
-fn dispatch<H: Host>(command: Command, host: &H) -> Result<Vec<String>, CommandError> {
+fn dispatch<H: Host>(command: Command, host: &H) -> Result<CommandOutput, CommandError> {
     match command {
         Command::Install {
             source,
@@ -391,70 +450,75 @@ fn dispatch<H: Host>(command: Command, host: &H) -> Result<Vec<String>, CommandE
             if direct {
                 lines.push("Review the unverified Skill before use.".to_owned());
             }
-            Ok(lines)
+            Ok(CommandOutput::Lines(lines))
         }
-        Command::List { global } => host.list(scope(global)),
-        Command::View { skill, global } => render_view(host.view(&skill, scope(global))?),
+        Command::List { global } => host.list(scope(global)).map(CommandOutput::Lines),
+        Command::View { skill, global } => {
+            render_view(host.view(&skill, scope(global))?).map(CommandOutput::Lines)
+        }
         Command::Remove { skill, global } => {
             host.remove(&skill, scope(global))?;
-            Ok(vec![format!("Removed Skill {skill}.")])
+            Ok(CommandOutput::Lines(vec![format!(
+                "Removed Skill {skill}."
+            )]))
         }
         Command::Auth {
             command: AuthCommand::Status,
-        } => Ok(vec![if host.auth_status()? {
+        } => Ok(CommandOutput::Lines(vec![if host.auth_status()? {
             "Authenticated.".to_owned()
         } else {
             "Not authenticated.".to_owned()
-        }]),
+        }])),
         Command::Auth {
             command: AuthCommand::Login,
         } => {
             host.auth_login()?;
-            Ok(vec!["Authentication started.".to_owned()])
+            Ok(CommandOutput::Lines(vec![
+                "Authentication started.".to_owned(),
+            ]))
         }
         Command::Auth {
             command: AuthCommand::Logout,
         } => {
             host.auth_logout()?;
-            Ok(vec!["Logged out.".to_owned()])
+            Ok(CommandOutput::Lines(vec!["Logged out.".to_owned()]))
         }
         Command::Config {
             command: ConfigCommand::Get { key },
-        } => Ok(vec![host.config_get(&key)?]),
+        } => Ok(CommandOutput::Lines(vec![host.config_get(&key)?])),
         Command::Config {
             command: ConfigCommand::Set { key, value },
         } => {
             host.config_set(&key, &value)?;
-            Ok(vec![format!("Set {key}.")])
+            Ok(CommandOutput::Lines(vec![format!("Set {key}.")]))
         }
         Command::Config {
             command: ConfigCommand::List,
-        } => host.config_list(),
-        Command::Search { query } => host
-            .search(&query.join(" "))?
-            .into_iter()
-            .map(|result| {
-                let selector = result.selector().map_err(CommandError::remote)?;
-                let description = result
-                    .description
-                    .unwrap_or_default()
-                    .chars()
-                    .map(|character| {
-                        if character.is_control() {
-                            ' '
-                        } else {
-                            character
-                        }
+        } => host.config_list().map(CommandOutput::Lines),
+        Command::Search { query } => {
+            let query = query.join(" ");
+            let response = host.search(&query)?;
+            let items = response
+                .items
+                .into_iter()
+                .map(|result| {
+                    let selector = result.selector().map_err(CommandError::remote)?;
+                    Ok(SearchItem {
+                        name: result.name,
+                        selector: selector.to_string(),
+                        description: result.description,
+                        stargazer_count: result.stargazer_count,
                     })
-                    .collect::<String>();
-                Ok(format!(
-                    "{}\t{}\t{}\t{} stars",
-                    result.name, selector, description, result.stargazer_count
-                ))
-            })
-            .collect(),
-        Command::Upgrade { skill } => host.upgrade(skill.as_deref()),
-        Command::Verify { skill } => host.verify(skill.as_deref()),
+                })
+                .collect::<Result<Vec<_>, CommandError>>()?;
+            Ok(CommandOutput::Search(SearchOutcome {
+                query,
+                items,
+                total: response.total,
+            }))
+        }
+        Command::Upgrade { skill } => host.upgrade(skill.as_deref()).map(CommandOutput::Lines),
+        Command::Verify { skill } => host.verify(skill.as_deref()).map(CommandOutput::Lines),
     }
 }
 
@@ -505,6 +569,10 @@ impl DetectionEnvironment {
 
     fn has(&self, name: &str) -> bool {
         self.variables.contains(name)
+    }
+
+    pub fn detects_agent(&self) -> bool {
+        !self.variables.is_empty()
     }
 }
 
@@ -980,7 +1048,7 @@ impl Host for LocalHost {
             .logout()
     }
 
-    fn search(&self, query: &str) -> Result<Vec<skilld_core::SearchResult>, CommandError> {
+    fn search(&self, query: &str) -> Result<skilld_core::SearchResponse, CommandError> {
         self.remote_provider()?
             .search(query, 20)
             .map_err(CommandError::remote)

--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -24,11 +24,16 @@ pub use remote::{
     RemoteSourceState, SecretValue, SkilldRemote, Sleeper, ThreadSleeper, TokenProvider,
 };
 use skilld_core::{
-    AGENT_TARGETS, AgentTargetId, DomainError, GlobalTargetPath, InstallMode, InstallOperation,
-    InstallRequest, InstallScope, InstallSource, LockedSource, VERSION, select_target_ids,
+    AGENT_TARGETS, AgentTargetId, CommitSha, DomainError, GlobalTargetPath, InstallMode,
+    InstallOperation, InstallRequest, InstallScope, InstallSource, LockedSource, NotTrackedReason,
+    SourceRef, UpdateCheckV1, UpdateFailure, UpdateLatestCommit, UpdateModelError, UpdatePlan,
+    UpdatePlanItem, UpdateRelation, VERSION, select_target_ids,
 };
 
-use output::{OutputMode, SearchItem, SearchOutcome, render_error, render_search, resolve_mode};
+use output::{
+    OutputMode, SearchItem, SearchOutcome, render_error, render_search, render_update_check,
+    resolve_mode,
+};
 
 #[derive(Debug, Parser)]
 #[command(
@@ -81,8 +86,13 @@ enum Command {
         #[arg(long)]
         global: bool,
     },
-    /// Upgrade installed Skills.
-    Upgrade { skill: Option<String> },
+    /// Update installed Skills.
+    Update {
+        skill: Option<String>,
+        /// Check update relations without changing files.
+        #[arg(long)]
+        check: bool,
+    },
     /// Verify a Skill source.
     Verify { skill: Option<String> },
     /// Manage account authentication.
@@ -154,9 +164,15 @@ pub trait Host {
         ))
     }
 
-    fn upgrade(&self, _name: Option<&str>) -> Result<Vec<String>, CommandError> {
+    fn update(&self, _name: Option<&str>) -> Result<Vec<String>, CommandError> {
         Err(CommandError::unsupported_host(
-            "Skill upgrade is unavailable on this host",
+            "Skill update is unavailable on this host",
+        ))
+    }
+
+    fn update_check(&self, _name: Option<&str>) -> Result<UpdateCheckV1, CommandError> {
+        Err(CommandError::unsupported_host(
+            "Skill update checks are unavailable on this host",
         ))
     }
 
@@ -299,6 +315,7 @@ pub struct CommandResult {
 enum CommandOutput {
     Lines(Vec<String>),
     Search(SearchOutcome),
+    UpdateCheck(UpdateCheckV1),
 }
 
 pub fn run<I, T, H, O, E>(args: I, host: &H, stdout: &mut O, stderr: &mut E) -> CommandResult
@@ -376,10 +393,19 @@ where
     };
 
     let mode = resolve_mode(cli.json, cli.plain, context);
-    if mode == OutputMode::JsonV1 && !matches!(&cli.command, Command::Search { .. }) {
+    if matches!(&cli.command, Command::Update { check: true, .. }) && mode != OutputMode::JsonV1 {
+        let error = CommandError::usage("UNSUPPORTED_OUTPUT", "Skill update checks need --json");
+        if stderr.write_all(&render_error(&error, mode)).is_err() {
+            return CommandResult { exit_code: 2 };
+        }
+        return CommandResult { exit_code: 2 };
+    }
+    let supports_json = matches!(&cli.command, Command::Search { .. })
+        || matches!(&cli.command, Command::Update { check: true, .. });
+    if mode == OutputMode::JsonV1 && !supports_json {
         let error = CommandError::usage(
             "UNSUPPORTED_OUTPUT",
-            "JSON output is available for Skill search only",
+            "JSON output is available for Skill search and update checks",
         );
         if stderr.write_all(&render_error(&error, mode)).is_err() {
             return CommandResult { exit_code: 2 };
@@ -397,6 +423,19 @@ where
             write_success(&bytes, mode, stdout, stderr)
         }
         Ok(CommandOutput::Search(outcome)) => match render_search(&outcome, mode) {
+            Ok(bytes) => write_success(&bytes, mode, stdout, stderr),
+            Err(error) => {
+                if stderr.write_all(&render_error(&error, mode)).is_err() {
+                    return CommandResult {
+                        exit_code: error.exit_code(),
+                    };
+                }
+                CommandResult {
+                    exit_code: error.exit_code(),
+                }
+            }
+        },
+        Ok(CommandOutput::UpdateCheck(outcome)) => match render_update_check(&outcome, mode) {
             Ok(bytes) => write_success(&bytes, mode, stdout, stderr),
             Err(error) => {
                 if stderr.write_all(&render_error(&error, mode)).is_err() {
@@ -440,7 +479,7 @@ fn requested_output(args: &[OsString]) -> (bool, bool) {
 
 fn display_path(args: &[OsString]) -> String {
     let commands = [
-        "search", "install", "list", "view", "remove", "upgrade", "verify", "auth", "config",
+        "search", "install", "list", "view", "remove", "update", "verify", "auth", "config",
     ];
     let mut path = vec!["skilld"];
     if let Some(command) = args
@@ -624,7 +663,14 @@ fn dispatch<H: Host>(command: Command, host: &H) -> Result<CommandOutput, Comman
                 total: response.total,
             }))
         }
-        Command::Upgrade { skill } => host.upgrade(skill.as_deref()).map(CommandOutput::Lines),
+        Command::Update { skill, check } => {
+            if check {
+                host.update_check(skill.as_deref())
+                    .map(CommandOutput::UpdateCheck)
+            } else {
+                host.update(skill.as_deref()).map(CommandOutput::Lines)
+            }
+        }
         Command::Verify { skill } => host.verify(skill.as_deref()).map(CommandOutput::Lines),
     }
 }
@@ -898,6 +944,144 @@ impl LocalHost {
         self.remote.as_deref().ok_or_else(|| {
             CommandError::service("remote Artifact delivery is unavailable in this build")
         })
+    }
+
+    fn update_relation(
+        &self,
+        skill: &skilld_core::LockedSkill,
+    ) -> Result<UpdateRelation, CommandError> {
+        let (source, locked_commit_sha) = match &skill.source {
+            LockedSource::Local { .. } => {
+                return Ok(UpdateRelation::NotTracked {
+                    reason: NotTrackedReason::Local,
+                });
+            }
+            LockedSource::BundledSkilld => {
+                return Ok(UpdateRelation::NotTracked {
+                    reason: NotTrackedReason::Bundled,
+                });
+            }
+            LockedSource::Remote {
+                source, commit_sha, ..
+            } => (
+                source,
+                CommitSha::parse(commit_sha.clone()).map_err(update_model_error)?,
+            ),
+        };
+
+        let selector = match skilld_core::RemoteSelector::parse(source) {
+            Ok(selector) => selector,
+            Err(error) => {
+                return Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Unknown,
+                    error.code,
+                    error.message,
+                ));
+            }
+        };
+        if let Some(SourceRef::Commit { value }) = &selector.source().r#ref {
+            let pinned_commit_sha = match CommitSha::parse(value.clone()) {
+                Ok(commit_sha) => commit_sha,
+                Err(error) => {
+                    return Ok(unavailable_update(
+                        locked_commit_sha,
+                        UpdateLatestCommit::Unknown,
+                        "INVALID_SOURCE",
+                        error.to_string(),
+                    ));
+                }
+            };
+            if pinned_commit_sha != locked_commit_sha {
+                return Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Known {
+                        commit_sha: pinned_commit_sha,
+                    },
+                    "INVALID_LOCKFILE",
+                    "the locked commit differs from its source selector",
+                ));
+            }
+            return Ok(UpdateRelation::Pinned {
+                commit_sha: locked_commit_sha,
+            });
+        }
+
+        let artifact_id = match &skill.source_status {
+            skilld_core::SourceStatus::Verified { artifact_id, .. } => artifact_id,
+            skilld_core::SourceStatus::Unverified { .. } => {
+                return Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Unknown,
+                    "UNVERIFIED_SOURCE",
+                    "run an explicit --direct install to update this Skill",
+                ));
+            }
+            skilld_core::SourceStatus::Local { .. } => {
+                return Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Unknown,
+                    "INVALID_LOCKFILE",
+                    "the remote Skill has a local source status",
+                ));
+            }
+        };
+        let provider = match self.remote_provider() {
+            Ok(provider) => provider,
+            Err(error) => {
+                return Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Unknown,
+                    error.code,
+                    error.message,
+                ));
+            }
+        };
+        let state = match provider.source_state(&selector, artifact_id, locked_commit_sha.as_str())
+        {
+            Ok(state) => state,
+            Err(error) => {
+                return Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Unknown,
+                    error.code,
+                    error.message,
+                ));
+            }
+        };
+        match state {
+            RemoteSourceState::Current => Ok(UpdateRelation::Current {
+                commit_sha: locked_commit_sha,
+            }),
+            RemoteSourceState::Stale {
+                current_commit_sha, ..
+            } => {
+                let latest_commit_sha = match CommitSha::parse(current_commit_sha) {
+                    Ok(commit_sha) => commit_sha,
+                    Err(error) => {
+                        return Ok(unavailable_update(
+                            locked_commit_sha,
+                            UpdateLatestCommit::Unknown,
+                            "INVALID_RESPONSE",
+                            error.to_string(),
+                        ));
+                    }
+                };
+                if latest_commit_sha == locked_commit_sha {
+                    return Ok(UpdateRelation::Current {
+                        commit_sha: locked_commit_sha,
+                    });
+                }
+                Ok(unavailable_update(
+                    locked_commit_sha,
+                    UpdateLatestCommit::Known {
+                        commit_sha: latest_commit_sha,
+                    },
+                    "COMPARISON_UNAVAILABLE",
+                    "skilld.dev does not provide Git comparison data",
+                ))
+            }
+        }
     }
 
     fn install_remote(
@@ -1209,12 +1393,12 @@ impl Host for LocalHost {
         Ok(lines)
     }
 
-    fn upgrade(&self, requested: Option<&str>) -> Result<Vec<String>, CommandError> {
+    fn update(&self, requested: Option<&str>) -> Result<Vec<String>, CommandError> {
         let scope = InstallScope::Project;
         let known = self.known_targets(scope)?;
         let store = self.store(scope);
         let names = selected_names(&store, &known, requested)?;
-        let mut upgraded = Vec::new();
+        let mut updated = Vec::new();
         for name in names {
             let skill_name =
                 skilld_core::SkillName::parse(name.clone()).map_err(CommandError::domain)?;
@@ -1245,7 +1429,7 @@ impl Host for LocalHost {
             if staged_name != skill_name {
                 return Err(CommandError::operation(
                     "SOURCE_MISMATCH",
-                    format!("the upgraded Skill name changed from {name}"),
+                    format!("the updated Skill name changed from {name}"),
                 ));
             }
             let targets = view
@@ -1277,9 +1461,27 @@ impl Host for LocalHost {
                     &known,
                 )
                 .map_err(CommandError::store)?;
-            upgraded.push(format!("Upgraded Skill {name}."));
+            updated.push(format!("Updated Skill {name}."));
         }
-        Ok(upgraded)
+        Ok(updated)
+    }
+
+    fn update_check(&self, requested: Option<&str>) -> Result<UpdateCheckV1, CommandError> {
+        let scope = InstallScope::Project;
+        let known = self.known_targets(scope)?;
+        let store = self.store(scope);
+        let names = selected_names(&store, &known, requested)?;
+        let mut items = Vec::with_capacity(names.len());
+        for name in names {
+            let skill_name = skilld_core::SkillName::parse(name).map_err(CommandError::domain)?;
+            let view = store
+                .view(&skill_name, &known)
+                .map_err(CommandError::store)?;
+            let relation = self.update_relation(&view.skill)?;
+            items.push(UpdatePlanItem::new(skill_name, relation));
+        }
+        let plan = UpdatePlan::new(items).map_err(update_model_error)?;
+        Ok(UpdateCheckV1::new(plan))
     }
 }
 
@@ -1347,6 +1549,23 @@ fn selected_names(
     } else {
         store.list(known).map_err(CommandError::store)
     }
+}
+
+fn unavailable_update(
+    locked_commit_sha: CommitSha,
+    latest_commit: UpdateLatestCommit,
+    code: impl Into<String>,
+    message: impl Into<String>,
+) -> UpdateRelation {
+    UpdateRelation::Unavailable {
+        locked_commit_sha,
+        latest_commit,
+        failure: UpdateFailure::new(code, message),
+    }
+}
+
+fn update_model_error(error: UpdateModelError) -> CommandError {
+    CommandError::operation("INVALID_LOCKFILE", error.to_string())
 }
 
 fn detects_environment(agent: AgentTargetId, environment: &DetectionEnvironment) -> bool {
@@ -1509,9 +1728,28 @@ mod tests {
         assert_eq!(
             command_names(),
             [
-                "search", "install", "list", "view", "remove", "upgrade", "verify", "auth",
-                "config"
+                "search", "install", "list", "view", "remove", "update", "verify", "auth", "config"
             ]
+        );
+    }
+
+    #[test]
+    fn upgrade_is_not_a_command_alias() {
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let result = run(
+            ["skilld", "upgrade"],
+            &RecordingHost,
+            &mut stdout,
+            &mut stderr,
+        );
+
+        assert_eq!(result.exit_code, 2);
+        assert!(stdout.is_empty());
+        assert!(
+            String::from_utf8(stderr)
+                .unwrap()
+                .contains("unrecognized subcommand 'upgrade'")
         );
     }
 

--- a/crates/skilld-command/src/output.rs
+++ b/crates/skilld-command/src/output.rs
@@ -1,5 +1,6 @@
 use clap::error::ErrorKind;
 use serde::Serialize;
+use skilld_core::UpdateCheckV1;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{CommandError, CommandErrorKind};
@@ -76,22 +77,15 @@ pub(crate) fn render_search(
     match mode {
         OutputMode::Human { width, color } => Ok(render_human(outcome, width, color).into_bytes()),
         OutputMode::Plain => Ok(render_plain(outcome).into_bytes()),
-        OutputMode::JsonV1 => serde_json::to_vec(&JsonSuccess {
-            schema_version: JSON_SCHEMA_VERSION,
-            tag: "Success",
-            command: "search",
-            data: JsonSearchData {
+        OutputMode::JsonV1 => render_json_success(
+            "search",
+            JsonSearchData {
                 query: &outcome.query,
                 items: &outcome.items,
                 total: outcome.total,
             },
-            notices: Vec::new(),
-        })
-        .map(|mut bytes| {
-            bytes.push(b'\n');
-            bytes
-        })
-        .map_err(|_| CommandError::service("Skill search output could not be encoded")),
+            "Skill search output could not be encoded",
+        ),
     }
 }
 
@@ -107,6 +101,31 @@ pub(crate) fn render_display(kind: ErrorKind, path: &str, text: &str) -> Vec<u8>
     } else {
         ("help", JsonDisplayData::Help { path, text })
     };
+    render_json_success(command, data, "display output could not be encoded")
+        .unwrap_or_else(|_| b"OUTPUT_RENDER_FAILED: display output could not be encoded\n".to_vec())
+}
+
+pub(crate) fn render_update_check(
+    outcome: &UpdateCheckV1,
+    mode: OutputMode,
+) -> Result<Vec<u8>, CommandError> {
+    if mode != OutputMode::JsonV1 {
+        return Err(CommandError::service(
+            "Skill update check output needs JSON mode",
+        ));
+    }
+    render_json_success(
+        "update",
+        outcome,
+        "Skill update check output could not be encoded",
+    )
+}
+
+fn render_json_success<T: Serialize>(
+    command: &'static str,
+    data: T,
+    encoding_error: &'static str,
+) -> Result<Vec<u8>, CommandError> {
     serde_json::to_vec(&JsonSuccess {
         schema_version: JSON_SCHEMA_VERSION,
         tag: "Success",
@@ -118,7 +137,7 @@ pub(crate) fn render_display(kind: ErrorKind, path: &str, text: &str) -> Vec<u8>
         bytes.push(b'\n');
         bytes
     })
-    .unwrap_or_else(|_| b"OUTPUT_RENDER_FAILED: display output could not be encoded\n".to_vec())
+    .map_err(|_| CommandError::service(encoding_error))
 }
 
 pub(crate) fn render_error(error: &CommandError, mode: OutputMode) -> Vec<u8> {

--- a/crates/skilld-command/src/output.rs
+++ b/crates/skilld-command/src/output.rs
@@ -1,7 +1,8 @@
+use clap::error::ErrorKind;
 use serde::Serialize;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
-use crate::CommandError;
+use crate::{CommandError, CommandErrorKind};
 
 const JSON_SCHEMA_VERSION: u8 = 1;
 const MIN_WIDTH: u16 = 20;
@@ -16,13 +17,13 @@ pub enum OutputContext {
 impl OutputContext {
     pub fn auto(
         stdout_is_terminal: bool,
-        detected_agent: bool,
+        active_agent: bool,
         ci: bool,
         no_color: bool,
         term_is_dumb: bool,
         width: u16,
     ) -> Self {
-        if detected_agent || ci || !stdout_is_terminal {
+        if active_agent || ci || !stdout_is_terminal {
             return Self::Plain;
         }
         Self::HumanTerminal {
@@ -94,11 +95,40 @@ pub(crate) fn render_search(
     }
 }
 
+pub(crate) fn render_display(kind: ErrorKind, path: &str, text: &str) -> Vec<u8> {
+    let (command, data) = if kind == ErrorKind::DisplayVersion {
+        (
+            "version",
+            JsonDisplayData::Version {
+                name: "skilld",
+                version: skilld_core::VERSION,
+            },
+        )
+    } else {
+        ("help", JsonDisplayData::Help { path, text })
+    };
+    serde_json::to_vec(&JsonSuccess {
+        schema_version: JSON_SCHEMA_VERSION,
+        tag: "Success",
+        command,
+        data,
+        notices: Vec::new(),
+    })
+    .map(|mut bytes| {
+        bytes.push(b'\n');
+        bytes
+    })
+    .unwrap_or_else(|_| b"OUTPUT_RENDER_FAILED: display output could not be encoded\n".to_vec())
+}
+
 pub(crate) fn render_error(error: &CommandError, mode: OutputMode) -> Vec<u8> {
     if mode == OutputMode::JsonV1 {
         return serde_json::to_vec(&JsonFailure {
             schema_version: JSON_SCHEMA_VERSION,
-            tag: "OperationError",
+            tag: match error.kind {
+                CommandErrorKind::Usage => "UsageError",
+                CommandErrorKind::Operation => "OperationError",
+            },
             error: JsonError {
                 code: error.code,
                 message: &error.message,
@@ -290,13 +320,26 @@ fn styled(value: &str, style: &str, color: bool) -> String {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct JsonSuccess<'a> {
+struct JsonSuccess<T> {
     schema_version: u8,
     #[serde(rename = "_tag")]
     tag: &'static str,
     command: &'static str,
-    data: JsonSearchData<'a>,
+    data: T,
     notices: Vec<JsonNotice>,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+enum JsonDisplayData<'a> {
+    Help {
+        path: &'a str,
+        text: &'a str,
+    },
+    Version {
+        name: &'static str,
+        version: &'static str,
+    },
 }
 
 #[derive(Serialize)]

--- a/crates/skilld-command/src/output.rs
+++ b/crates/skilld-command/src/output.rs
@@ -151,7 +151,13 @@ fn render_human(outcome: &SearchOutcome, width: u16, color: bool) -> String {
     ));
 
     if outcome.items.is_empty() {
-        output.push_str("\nNo Skills found.\n");
+        output.push('\n');
+        let empty = format!("No Skills found for {}.", terminal_text(&outcome.query));
+        for line in wrap(&empty, width) {
+            output.push_str(&line);
+            output.push('\n');
+        }
+        output.push_str("Try a shorter search.\n");
         return output;
     }
 
@@ -184,7 +190,8 @@ fn render_human(outcome: &SearchOutcome, width: u16, color: bool) -> String {
                 output.push('\n');
             }
         }
-        for line in wrap(&terminal_text(&item.selector), width.saturating_sub(2)) {
+        let install = format!("Install: skilld install {}", terminal_text(&item.selector));
+        for line in wrap(&install, width.saturating_sub(2)) {
             output.push_str("  ");
             output.push_str(&styled(&line, "\u{1b}[2m", color));
             output.push('\n');

--- a/crates/skilld-command/src/output.rs
+++ b/crates/skilld-command/src/output.rs
@@ -1,0 +1,319 @@
+use serde::Serialize;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::CommandError;
+
+const JSON_SCHEMA_VERSION: u8 = 1;
+const MIN_WIDTH: u16 = 20;
+const MAX_WIDTH: u16 = 240;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OutputContext {
+    HumanTerminal { width: u16, color: bool },
+    Plain,
+}
+
+impl OutputContext {
+    pub fn auto(
+        stdout_is_terminal: bool,
+        detected_agent: bool,
+        ci: bool,
+        no_color: bool,
+        term_is_dumb: bool,
+        width: u16,
+    ) -> Self {
+        if detected_agent || ci || !stdout_is_terminal {
+            return Self::Plain;
+        }
+        Self::HumanTerminal {
+            width: width.clamp(MIN_WIDTH, MAX_WIDTH),
+            color: !no_color && !term_is_dumb,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum OutputMode {
+    Human { width: u16, color: bool },
+    Plain,
+    JsonV1,
+}
+
+pub(crate) fn resolve_mode(json: bool, plain: bool, context: OutputContext) -> OutputMode {
+    if json {
+        OutputMode::JsonV1
+    } else if plain {
+        OutputMode::Plain
+    } else {
+        match context {
+            OutputContext::HumanTerminal { width, color } => OutputMode::Human { width, color },
+            OutputContext::Plain => OutputMode::Plain,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SearchOutcome {
+    pub query: String,
+    pub items: Vec<SearchItem>,
+    pub total: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SearchItem {
+    pub name: String,
+    pub selector: String,
+    pub description: Option<String>,
+    pub stargazer_count: u64,
+}
+
+pub(crate) fn render_search(
+    outcome: &SearchOutcome,
+    mode: OutputMode,
+) -> Result<Vec<u8>, CommandError> {
+    match mode {
+        OutputMode::Human { width, color } => Ok(render_human(outcome, width, color).into_bytes()),
+        OutputMode::Plain => Ok(render_plain(outcome).into_bytes()),
+        OutputMode::JsonV1 => serde_json::to_vec(&JsonSuccess {
+            schema_version: JSON_SCHEMA_VERSION,
+            tag: "Success",
+            command: "search",
+            data: JsonSearchData {
+                query: &outcome.query,
+                items: &outcome.items,
+                total: outcome.total,
+            },
+            notices: Vec::new(),
+        })
+        .map(|mut bytes| {
+            bytes.push(b'\n');
+            bytes
+        })
+        .map_err(|_| CommandError::service("Skill search output could not be encoded")),
+    }
+}
+
+pub(crate) fn render_error(error: &CommandError, mode: OutputMode) -> Vec<u8> {
+    if mode == OutputMode::JsonV1 {
+        return serde_json::to_vec(&JsonFailure {
+            schema_version: JSON_SCHEMA_VERSION,
+            tag: "OperationError",
+            error: JsonError {
+                code: error.code,
+                message: &error.message,
+            },
+        })
+        .map(|mut bytes| {
+            bytes.push(b'\n');
+            bytes
+        })
+        .unwrap_or_else(|_| b"OUTPUT_RENDER_FAILED: error output could not be encoded\n".to_vec());
+    }
+    format!("{error}\n").into_bytes()
+}
+
+fn render_plain(outcome: &SearchOutcome) -> String {
+    let mut output = String::new();
+    for item in &outcome.items {
+        output.push_str(&escape_plain(&item.name));
+        output.push('\t');
+        output.push_str(&escape_plain(&item.selector));
+        output.push('\t');
+        output.push_str(&item.stargazer_count.to_string());
+        output.push('\t');
+        output.push_str(&escape_plain(
+            item.description.as_deref().unwrap_or_default(),
+        ));
+        output.push('\n');
+    }
+    output
+}
+
+fn render_human(outcome: &SearchOutcome, width: u16, color: bool) -> String {
+    let width = usize::from(width);
+    let mut output = String::new();
+    let heading = format!("Skill search  {}", terminal_text(&outcome.query));
+    for line in wrap(&heading, width) {
+        output.push_str(&styled(&line, "\u{1b}[1m\u{1b}[36m", color));
+        output.push('\n');
+    }
+    let shown = outcome.items.len();
+    output.push_str(&format!(
+        "{} of {} {}\n",
+        shown,
+        outcome.total,
+        if outcome.total == 1 {
+            "Skill"
+        } else {
+            "Skills"
+        }
+    ));
+
+    if outcome.items.is_empty() {
+        output.push_str("\nNo Skills found.\n");
+        return output;
+    }
+
+    for item in &outcome.items {
+        output.push('\n');
+        let name = terminal_text(&item.name);
+        let stars = format!("{} stars", grouped_number(item.stargazer_count));
+        if 2 + display_width(&name) + 2 + display_width(&stars) <= width {
+            let gap = width - 2 - display_width(&name) - display_width(&stars);
+            output.push_str("  ");
+            output.push_str(&styled(&name, "\u{1b}[1m", color));
+            output.push_str(&" ".repeat(gap));
+            output.push_str(&styled(&stars, "\u{1b}[33m", color));
+            output.push('\n');
+        } else {
+            for line in wrap(&name, width.saturating_sub(2)) {
+                output.push_str("  ");
+                output.push_str(&styled(&line, "\u{1b}[1m", color));
+                output.push('\n');
+            }
+            output.push_str("  ");
+            output.push_str(&styled(&stars, "\u{1b}[33m", color));
+            output.push('\n');
+        }
+
+        if let Some(description) = &item.description {
+            for line in wrap(&terminal_text(description), width.saturating_sub(2)) {
+                output.push_str("  ");
+                output.push_str(&line);
+                output.push('\n');
+            }
+        }
+        for line in wrap(&terminal_text(&item.selector), width.saturating_sub(2)) {
+            output.push_str("  ");
+            output.push_str(&styled(&line, "\u{1b}[2m", color));
+            output.push('\n');
+        }
+    }
+    output
+}
+
+fn escape_plain(value: &str) -> String {
+    let mut output = String::new();
+    for character in value.chars() {
+        match character {
+            '\\' => output.push_str("\\\\"),
+            '\t' => output.push_str("\\t"),
+            '\r' => output.push_str("\\r"),
+            '\n' => output.push_str("\\n"),
+            character if character.is_control() => {
+                output.push_str(&format!("\\u{{{:04X}}}", u32::from(character)));
+            }
+            character => output.push(character),
+        }
+    }
+    output
+}
+
+fn terminal_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
+}
+
+fn wrap(value: &str, width: usize) -> Vec<String> {
+    let width = width.max(1);
+    let mut lines = Vec::new();
+    let mut current = String::new();
+
+    for word in value.split_whitespace() {
+        let separator = usize::from(!current.is_empty());
+        if display_width(&current) + separator + display_width(word) > width && !current.is_empty()
+        {
+            lines.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        if display_width(word) <= width {
+            current.push_str(word);
+        } else {
+            let mut chunk = String::new();
+            for character in word.chars() {
+                let character_width = UnicodeWidthChar::width(character).unwrap_or(0);
+                if !chunk.is_empty() && display_width(&chunk) + character_width > width {
+                    lines.push(std::mem::take(&mut chunk));
+                }
+                chunk.push(character);
+            }
+            current = chunk;
+        }
+    }
+    if !current.is_empty() || lines.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+fn display_width(value: &str) -> usize {
+    UnicodeWidthStr::width(value)
+}
+
+fn grouped_number(value: u64) -> String {
+    let digits = value.to_string();
+    let mut output = String::new();
+    for (index, character) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index) % 3 == 0 {
+            output.push(',');
+        }
+        output.push(character);
+    }
+    output
+}
+
+fn styled(value: &str, style: &str, color: bool) -> String {
+    if color {
+        format!("{style}{value}\u{1b}[0m")
+    } else {
+        value.to_owned()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonSuccess<'a> {
+    schema_version: u8,
+    #[serde(rename = "_tag")]
+    tag: &'static str,
+    command: &'static str,
+    data: JsonSearchData<'a>,
+    notices: Vec<JsonNotice>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonSearchData<'a> {
+    query: &'a str,
+    items: &'a [SearchItem],
+    total: u64,
+}
+
+#[derive(Serialize)]
+struct JsonNotice;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonFailure<'a> {
+    schema_version: u8,
+    #[serde(rename = "_tag")]
+    tag: &'static str,
+    error: JsonError<'a>,
+}
+
+#[derive(Serialize)]
+struct JsonError<'a> {
+    code: &'a str,
+    message: &'a str,
+}

--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -9,7 +9,7 @@ use serde::Deserialize;
 use serde_json::json;
 use skilld_core::{
     ArtifactAttestation, LockedSource, PreparedFile, RemoteError, RemoteSelector,
-    RepositoryVisibility, SearchResult, SourceRef, SourceRequest, SourceSelector, SourceStatus,
+    RepositoryVisibility, SearchResponse, SourceRef, SourceRequest, SourceSelector, SourceStatus,
     TrustedRoot, TrustedRootPin, VerifiedTrustedRoot, parse_search_response,
     prepare_unverified_files, verify_artifact, verify_attestation, verify_trusted_root,
 };
@@ -250,7 +250,7 @@ pub enum RemoteSourceState {
 }
 
 pub trait RemoteProvider: Send + Sync {
-    fn search(&self, query: &str, limit: u8) -> Result<Vec<SearchResult>, RemoteError>;
+    fn search(&self, query: &str, limit: u8) -> Result<SearchResponse, RemoteError>;
 
     fn prepare(
         &self,
@@ -786,7 +786,7 @@ impl SkilldRemote {
 }
 
 impl RemoteProvider for SkilldRemote {
-    fn search(&self, query: &str, limit: u8) -> Result<Vec<SearchResult>, RemoteError> {
+    fn search(&self, query: &str, limit: u8) -> Result<SearchResponse, RemoteError> {
         let query = query.trim();
         if query.is_empty() || query.len() > 200 || !(1..=50).contains(&limit) {
             return Err(RemoteError::new(
@@ -806,7 +806,7 @@ impl RemoteProvider for SkilldRemote {
             response_limit: SEARCH_LIMIT,
         };
         let response = self.execute(request, AllowedOrigin::Service(self.endpoint.clone()))?;
-        parse_search_response(&response.body).map(|response| response.items)
+        parse_search_response(&response.body)
     }
 
     fn prepare(

--- a/crates/skilld-command/tests/output.rs
+++ b/crates/skilld-command/tests/output.rs
@@ -201,12 +201,38 @@ fn human_search_is_polished_and_respects_terminal_width() {
     assert!(stdout.contains("1 of 14 Skills"));
     assert!(stdout.contains("227,068 stars"));
     assert!(stdout.contains("skilld:mattpocock/skills/grill-me"));
+    assert!(stdout.contains("Install: skilld install"));
     assert!(
         stdout
             .lines()
             .all(|line| UnicodeWidthStr::width(line) <= 40)
     );
     assert!(!stdout.contains('\u{1b}'));
+}
+
+#[test]
+fn human_empty_search_names_the_query_and_suggests_a_next_step() {
+    let mut response = response();
+    response.items.clear();
+    response.total = 0;
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let result = run_with_output(
+        ["skilld", "search", "grill"],
+        &SearchHost {
+            response: Ok(response),
+        },
+        OutputContext::auto(true, false, false, true, false, 40),
+        &mut stdout,
+        &mut stderr,
+    );
+    let stdout = String::from_utf8(stdout).unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(stderr.is_empty());
+    assert!(stdout.contains("No Skills found for grill."));
+    assert!(stdout.contains("Try a shorter search."));
 }
 
 #[test]

--- a/crates/skilld-command/tests/output.rs
+++ b/crates/skilld-command/tests/output.rs
@@ -107,6 +107,29 @@ fn json_search_returns_one_versioned_document() {
 }
 
 #[test]
+fn json_help_and_version_return_versioned_documents() {
+    let root_help = run(&["skilld", "--json", "--help"], OutputContext::Plain);
+    let search_help = run(
+        &["skilld", "search", "--json", "--help"],
+        OutputContext::Plain,
+    );
+    let version = run(&["skilld", "--json", "--version"], OutputContext::Plain);
+
+    assert_eq!(root_help.0, 0);
+    assert!(root_help.2.is_empty());
+    let root = serde_json::from_str::<serde_json::Value>(&root_help.1).unwrap();
+    assert_eq!(root["command"], "help");
+    assert_eq!(root["data"]["path"], "skilld");
+    let search = serde_json::from_str::<serde_json::Value>(&search_help.1).unwrap();
+    assert_eq!(search["command"], "help");
+    assert_eq!(search["data"]["path"], "skilld search");
+    let version = serde_json::from_str::<serde_json::Value>(&version.1).unwrap();
+    assert_eq!(version["command"], "version");
+    assert_eq!(version["data"]["name"], "skilld");
+    assert_eq!(version["data"]["version"], env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
 fn non_terminal_and_ci_output_are_stable_plain_records() {
     let expected = concat!(
         "grill-me\tskilld:mattpocock/skills/grill-me\t227068\t",
@@ -127,14 +150,27 @@ fn non_terminal_and_ci_output_are_stable_plain_records() {
 }
 
 #[test]
-fn detected_agent_output_is_plain_even_with_a_tty() {
+fn human_terminal_is_formatted_without_an_explicit_machine_flag() {
     let agent_with_tty = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, false, false, false, false, 120),
+    );
+
+    assert_eq!(agent_with_tty.0, 0);
+    assert!(agent_with_tty.1.contains("Skill search"));
+    assert!(agent_with_tty.1.contains('\u{1b}'));
+    assert!(agent_with_tty.2.is_empty());
+}
+
+#[test]
+fn active_agent_terminal_is_plain_without_an_explicit_machine_flag() {
+    let result = run(
         &["skilld", "search", "grill"],
         OutputContext::auto(true, true, false, false, false, 120),
     );
 
     assert_eq!(
-        agent_with_tty,
+        result,
         (
             0,
             concat!(
@@ -320,6 +356,37 @@ fn conflicting_output_flags_fail_before_search() {
 }
 
 #[test]
+fn json_search_parse_errors_are_tagged_usage_errors() {
+    let after = run(
+        &["skilld", "search", "grill", "--json", "--unknown"],
+        OutputContext::Plain,
+    );
+    let before = run(
+        &["skilld", "--json", "search", "grill", "--unknown"],
+        OutputContext::Plain,
+    );
+
+    assert_eq!(after.0, 2);
+    assert!(after.1.is_empty());
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&after.2).unwrap()["_tag"],
+        "UsageError"
+    );
+    assert_eq!(before, after);
+}
+
+#[test]
+fn empty_json_search_is_a_tagged_usage_error() {
+    let (exit, stdout, stderr) = run(&["skilld", "search", "--json"], OutputContext::Plain);
+
+    assert_eq!(exit, 2);
+    assert!(stdout.is_empty());
+    let error = serde_json::from_str::<serde_json::Value>(&stderr).unwrap();
+    assert_eq!(error["_tag"], "UsageError");
+    assert_eq!(error["error"]["code"], "INVALID_SEARCH");
+}
+
+#[test]
 fn json_search_errors_are_tagged_and_written_to_stderr() {
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -333,7 +400,7 @@ fn json_search_errors_are_tagged_and_written_to_stderr() {
         &mut stderr,
     );
 
-    assert_eq!(result.exit_code, 2);
+    assert_eq!(result.exit_code, 1);
     assert!(stdout.is_empty());
     assert_eq!(
         serde_json::from_slice::<serde_json::Value>(&stderr).unwrap(),
@@ -346,6 +413,27 @@ fn json_search_errors_are_tagged_and_written_to_stderr() {
             }
         })
     );
+}
+
+#[test]
+fn stdout_failures_report_an_operation_error() {
+    let mut stdout = WriteErrorWriter;
+    let mut stderr = Vec::new();
+
+    let result = run_with_output(
+        ["skilld", "search", "grill", "--json"],
+        &SearchHost {
+            response: Ok(response()),
+        },
+        OutputContext::Plain,
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(result.exit_code, 1);
+    let error = serde_json::from_slice::<serde_json::Value>(&stderr).unwrap();
+    assert_eq!(error["_tag"], "OperationError");
+    assert_eq!(error["error"]["code"], "OUTPUT_WRITE_FAILED");
 }
 
 fn strip_ansi(value: &str) -> String {
@@ -365,6 +453,18 @@ struct BrokenPipeWriter;
 impl Write for BrokenPipeWriter {
     fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
         Err(io::Error::from(io::ErrorKind::BrokenPipe))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct WriteErrorWriter;
+
+impl Write for WriteErrorWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        Err(io::Error::other("write failed"))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/crates/skilld-command/tests/output.rs
+++ b/crates/skilld-command/tests/output.rs
@@ -1,0 +1,347 @@
+use skilld_command::{CommandError, Host, OutputContext, run_with_output};
+use skilld_core::{
+    InstallScope, InstallSource, SearchResponse, SearchResult, SourceProvider, SourceRequest,
+    SourceSelector,
+};
+use std::io::{self, Write};
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Clone)]
+struct SearchHost {
+    response: Result<SearchResponse, CommandError>,
+}
+
+impl Host for SearchHost {
+    fn list(&self, _scope: InstallScope) -> Result<Vec<String>, CommandError> {
+        unreachable!("list is outside this test")
+    }
+
+    fn install(
+        &self,
+        _source: InstallSource,
+        _scope: InstallScope,
+    ) -> Result<String, CommandError> {
+        unreachable!("install is outside this test")
+    }
+
+    fn search(&self, _query: &str) -> Result<SearchResponse, CommandError> {
+        self.response.clone()
+    }
+}
+
+fn response() -> SearchResponse {
+    SearchResponse {
+        items: vec![SearchResult {
+            name: "grill-me".to_owned(),
+            description: Some(
+                "A focused Skill description that wraps cleanly on a narrow terminal.".to_owned(),
+            ),
+            source: SourceRequest {
+                provider: SourceProvider::Github,
+                owner: "mattpocock".to_owned(),
+                repository: "skills".to_owned(),
+                selector: SourceSelector::NamedSkill {
+                    name: "grill-me".to_owned(),
+                },
+                r#ref: None,
+            },
+            stargazer_count: 227_068,
+        }],
+        total: 14,
+    }
+}
+
+fn run(args: &[&str], context: OutputContext) -> (u8, String, String) {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let result = run_with_output(
+        args,
+        &SearchHost {
+            response: Ok(response()),
+        },
+        context,
+        &mut stdout,
+        &mut stderr,
+    );
+    (
+        result.exit_code,
+        String::from_utf8(stdout).unwrap(),
+        String::from_utf8(stderr).unwrap(),
+    )
+}
+
+#[test]
+fn json_search_returns_one_versioned_document() {
+    let (exit, stdout, stderr) = run(
+        &["skilld", "search", "grill", "--json"],
+        OutputContext::auto(true, true, false, false, false, 80),
+    );
+    let global_form = run(
+        &["skilld", "--json", "search", "grill"],
+        OutputContext::auto(true, true, false, false, false, 80),
+    );
+
+    assert_eq!(exit, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&stdout).unwrap(),
+        serde_json::json!({
+            "schemaVersion": 1,
+            "_tag": "Success",
+            "command": "search",
+            "data": {
+                "query": "grill",
+                "items": [{
+                    "name": "grill-me",
+                    "selector": "skilld:mattpocock/skills/grill-me",
+                    "description": "A focused Skill description that wraps cleanly on a narrow terminal.",
+                    "stargazerCount": 227068
+                }],
+                "total": 14
+            },
+            "notices": []
+        })
+    );
+    assert!(stdout.ends_with('\n'));
+    assert_eq!(global_form, (exit, stdout, stderr));
+}
+
+#[test]
+fn non_terminal_and_ci_output_are_stable_plain_records() {
+    let expected = concat!(
+        "grill-me\tskilld:mattpocock/skills/grill-me\t227068\t",
+        "A focused Skill description that wraps cleanly on a narrow terminal.\n"
+    );
+
+    let non_terminal = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(false, false, false, false, false, 80),
+    );
+    let ci_with_tty = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, false, true, false, false, 120),
+    );
+
+    assert_eq!(non_terminal, (0, expected.to_owned(), String::new()));
+    assert_eq!(ci_with_tty, non_terminal);
+}
+
+#[test]
+fn detected_agent_output_is_plain_even_with_a_tty() {
+    let agent_with_tty = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, true, false, false, false, 120),
+    );
+
+    assert_eq!(
+        agent_with_tty,
+        (
+            0,
+            concat!(
+                "grill-me\tskilld:mattpocock/skills/grill-me\t227068\t",
+                "A focused Skill description that wraps cleanly on a narrow terminal.\n"
+            )
+            .to_owned(),
+            String::new()
+        )
+    );
+}
+
+#[test]
+fn explicit_plain_overrides_a_human_terminal() {
+    let (_, stdout, stderr) = run(
+        &["skilld", "search", "grill", "--plain"],
+        OutputContext::auto(true, false, false, false, false, 120),
+    );
+
+    assert!(stderr.is_empty());
+    assert_eq!(
+        stdout,
+        concat!(
+            "grill-me\tskilld:mattpocock/skills/grill-me\t227068\t",
+            "A focused Skill description that wraps cleanly on a narrow terminal.\n"
+        )
+    );
+}
+
+#[test]
+fn plain_search_escapes_record_delimiters() {
+    let mut response = response();
+    response.items[0].description = Some("first\nsecond\tvalue\u{1b}".to_owned());
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let result = run_with_output(
+        ["skilld", "search", "grill", "--plain"],
+        &SearchHost {
+            response: Ok(response),
+        },
+        OutputContext::auto(true, false, false, false, false, 80),
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(result.exit_code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(
+        String::from_utf8(stdout).unwrap(),
+        "grill-me\tskilld:mattpocock/skills/grill-me\t227068\tfirst\\nsecond\\tvalue\\u{001B}\n"
+    );
+}
+
+#[test]
+fn human_search_is_polished_and_respects_terminal_width() {
+    let (_, stdout, stderr) = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, false, false, true, false, 40),
+    );
+
+    assert!(stderr.is_empty());
+    assert!(stdout.contains("Skill search"));
+    assert!(stdout.contains("1 of 14 Skills"));
+    assert!(stdout.contains("227,068 stars"));
+    assert!(stdout.contains("skilld:mattpocock/skills/grill-me"));
+    assert!(
+        stdout
+            .lines()
+            .all(|line| UnicodeWidthStr::width(line) <= 40)
+    );
+    assert!(!stdout.contains('\u{1b}'));
+}
+
+#[test]
+fn human_search_uses_display_cells_and_sanitizes_terminal_controls() {
+    let mut response = response();
+    response.items[0].name = "\u{6280}\u{80fd}\u{1f642}".to_owned();
+    response.items[0].description =
+        Some("\u{6f22}\u{5b57}\u{1f642} cafe\u{301} \u{1b}[31mred".to_owned());
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let result = run_with_output(
+        ["skilld", "search", "grill"],
+        &SearchHost {
+            response: Ok(response),
+        },
+        OutputContext::auto(true, false, false, true, false, 20),
+        &mut stdout,
+        &mut stderr,
+    );
+    let stdout = String::from_utf8(stdout).unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(stderr.is_empty());
+    assert!(stdout.contains("\u{6280}\u{80fd}\u{1f642}"));
+    assert!(stdout.contains("\u{6f22}\u{5b57}\u{1f642}"));
+    assert!(stdout.contains("cafe\u{301}"));
+    assert!(!stdout.contains('\u{1b}'));
+    assert!(
+        stdout
+            .lines()
+            .all(|line| UnicodeWidthStr::width(line) <= 20)
+    );
+}
+
+#[test]
+fn broken_pipe_is_a_successful_search_exit() {
+    let mut stdout = BrokenPipeWriter;
+    let mut stderr = Vec::new();
+
+    let result = run_with_output(
+        ["skilld", "search", "grill", "--plain"],
+        &SearchHost {
+            response: Ok(response()),
+        },
+        OutputContext::Plain,
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(result.exit_code, 0);
+    assert!(stderr.is_empty());
+}
+
+#[test]
+fn color_capabilities_change_ansi_only() {
+    let (_, colored, _) = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, false, false, false, false, 100),
+    );
+    let (_, no_color, _) = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, false, false, true, false, 100),
+    );
+    let (_, dumb_terminal, _) = run(
+        &["skilld", "search", "grill"],
+        OutputContext::auto(true, false, false, false, true, 100),
+    );
+
+    assert!(colored.contains('\u{1b}'));
+    assert_eq!(strip_ansi(&colored), no_color);
+    assert_eq!(no_color, dumb_terminal);
+}
+
+#[test]
+fn conflicting_output_flags_fail_before_search() {
+    let (exit, stdout, stderr) = run(
+        &["skilld", "search", "grill", "--json", "--plain"],
+        OutputContext::auto(false, false, false, false, false, 80),
+    );
+
+    assert_eq!(exit, 2);
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("cannot be used with"));
+}
+
+#[test]
+fn json_search_errors_are_tagged_and_written_to_stderr() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let result = run_with_output(
+        ["skilld", "search", "grill", "--json"],
+        &SearchHost {
+            response: Err(CommandError::service("Skill search timed out")),
+        },
+        OutputContext::auto(false, false, false, false, false, 80),
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(result.exit_code, 2);
+    assert!(stdout.is_empty());
+    assert_eq!(
+        serde_json::from_slice::<serde_json::Value>(&stderr).unwrap(),
+        serde_json::json!({
+            "schemaVersion": 1,
+            "_tag": "OperationError",
+            "error": {
+                "code": "SERVICE_UNAVAILABLE",
+                "message": "Skill search timed out"
+            }
+        })
+    );
+}
+
+fn strip_ansi(value: &str) -> String {
+    [
+        "\u{1b}[1m",
+        "\u{1b}[2m",
+        "\u{1b}[36m",
+        "\u{1b}[33m",
+        "\u{1b}[0m",
+    ]
+    .into_iter()
+    .fold(value.to_owned(), |value, code| value.replace(code, ""))
+}
+
+struct BrokenPipeWriter;
+
+impl Write for BrokenPipeWriter {
+    fn write(&mut self, _buffer: &[u8]) -> io::Result<usize> {
+        Err(io::Error::from(io::ErrorKind::BrokenPipe))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -17,7 +17,8 @@ use skilld_core::{
     AgentTargetId, ArtifactAttestation, ArtifactFile, AttestationSignature, CheckOutcome,
     CheckResult, InstallMode, InstallOperation, InstallRequest, InstallScope, InstallSource,
     LockedSource, PreparedFile, RemoteError, RemoteSelector, RepositoryVisibility, ResolvedSource,
-    SearchResponse, SearchResult, SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
+    SearchResponse, SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
+    UpdateCheckV1, UpdateLatestCommit, UpdateRelation,
 };
 
 const ROOT_DOMAIN: &[u8] = b"skilld-trusted-key-v1\0";
@@ -856,7 +857,7 @@ fn verify_reports_changed_bytes_and_stale_sources() {
 }
 
 #[test]
-fn remote_install_verify_and_failed_upgrade_use_the_normal_transaction() {
+fn remote_install_verify_and_failed_update_use_the_normal_transaction() {
     let temporary = tempfile::tempdir().unwrap();
     let project = temporary.path().join("project");
     let data = temporary.path().join("data");
@@ -881,13 +882,71 @@ fn remote_install_verify_and_failed_upgrade_use_the_normal_transaction() {
     *provider.content.lock().unwrap() = b"---\nname: example\ndescription: second\n---\n".to_vec();
     *provider.fail_prepare.lock().unwrap() = true;
 
-    let error = host.upgrade(Some("example")).unwrap_err();
+    let error = host.update(Some("example")).unwrap_err();
 
     assert_eq!(error.code, "CHECK_BLOCKED");
     assert_eq!(
         fs::read(project.join(".skills/example/SKILL.md")).unwrap(),
         before
     );
+}
+
+#[test]
+fn update_check_keeps_an_uncompared_commit_unavailable() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = provider("---\nname: example\ndescription: first\n---\n");
+    let host = LocalHost::new(project, temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    host.install_request(InstallRequest {
+        operation: skilld_core::InstallOperation::Install(InstallSource::Remote(
+            "skilld:skilld-dev/skills/example".to_owned(),
+        )),
+        scope: InstallScope::Project,
+        targets: vec![AgentTargetId::Codex],
+        mode: Some(InstallMode::Copy),
+    })
+    .unwrap();
+    *provider.stale.lock().unwrap() = true;
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+
+    let result = run(
+        ["skilld", "update", "example", "--check", "--json"],
+        &host,
+        &mut stdout,
+        &mut stderr,
+    );
+    let mut global_stdout = Vec::new();
+    let mut global_stderr = Vec::new();
+    let global_result = run(
+        ["skilld", "--json", "update", "example", "--check"],
+        &host,
+        &mut global_stdout,
+        &mut global_stderr,
+    );
+    let outcome: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
+    let check: UpdateCheckV1 = serde_json::from_value(outcome["data"].clone()).unwrap();
+
+    assert_eq!(result.exit_code, 0);
+    assert!(stderr.is_empty());
+    assert_eq!(global_result.exit_code, 0);
+    assert!(global_stderr.is_empty());
+    assert_eq!(global_stdout, stdout);
+    assert_eq!(outcome["schemaVersion"], 1);
+    assert_eq!(outcome["_tag"], "Success");
+    assert_eq!(outcome["command"], "update");
+    assert_eq!(outcome["notices"], serde_json::json!([]));
+    assert!(matches!(
+        check.items()[0].relation(),
+        UpdateRelation::Unavailable {
+            latest_commit: UpdateLatestCommit::Known { commit_sha },
+            failure,
+            ..
+        } if commit_sha.as_str() == "ffffffffffffffffffffffffffffffffffffffff"
+            && failure.code == "COMPARISON_UNAVAILABLE"
+    ));
 }
 
 #[test]
@@ -1030,7 +1089,7 @@ fn cli_plain_restore_rejects_an_unverified_source_with_the_recovery_command() {
         &mut stderr,
     );
 
-    assert_eq!(restored.exit_code, 2);
+    assert_eq!(restored.exit_code, 1);
     assert!(stdout.is_empty());
     assert_eq!(
         String::from_utf8(stderr).unwrap(),

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -17,7 +17,7 @@ use skilld_core::{
     AgentTargetId, ArtifactAttestation, ArtifactFile, AttestationSignature, CheckOutcome,
     CheckResult, InstallMode, InstallOperation, InstallRequest, InstallScope, InstallSource,
     LockedSource, PreparedFile, RemoteError, RemoteSelector, RepositoryVisibility, ResolvedSource,
-    SearchResult, SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
+    SearchResponse, SearchResult, SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
 };
 
 const ROOT_DOMAIN: &[u8] = b"skilld-trusted-key-v1\0";
@@ -331,9 +331,10 @@ fn search_uses_only_the_v1_skilld_route_and_retries_a_bounded_failure() {
     ]));
     let remote = search_remote(http.clone());
 
-    let results = remote.search("vue testing", 20).unwrap();
+    let response = remote.search("vue testing", 20).unwrap();
 
-    assert_eq!(results[0].name, "vue-testing");
+    assert_eq!(response.items[0].name, "vue-testing");
+    assert_eq!(response.total, 1);
     let requests = http.requests.lock().unwrap();
     assert_eq!(requests.len(), 2);
     assert!(requests.iter().all(|request| {
@@ -759,11 +760,10 @@ impl FakeProvider {
 }
 
 impl RemoteProvider for FakeProvider {
-    fn search(&self, _query: &str, _limit: u8) -> Result<Vec<SearchResult>, RemoteError> {
+    fn search(&self, _query: &str, _limit: u8) -> Result<SearchResponse, RemoteError> {
         skilld_core::parse_search_response(include_bytes!(
             "../../../contracts/fixtures/v1/skill-search.json"
         ))
-        .map(|response| response.items)
     }
 
     fn prepare(

--- a/crates/skilld-core/src/lib.rs
+++ b/crates/skilld-core/src/lib.rs
@@ -1,6 +1,7 @@
 mod lock;
 mod remote;
 mod target;
+mod update;
 
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -19,6 +20,10 @@ pub use remote::{
 use serde::{Deserialize, Serialize};
 pub use target::{
     AGENT_TARGETS, AgentTarget, AgentTargetId, GlobalTargetPath, TargetSelection, select_target_ids,
+};
+pub use update::{
+    CommitSha, NotTrackedReason, UpdateCheckV1, UpdateFailure, UpdateLatestCommit,
+    UpdateModelError, UpdatePlan, UpdatePlanItem, UpdateRelation, classify_update_comparison,
 };
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -48,7 +53,8 @@ impl InstallMode {
     }
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
 pub struct SkillName(String);
 
 impl SkillName {
@@ -88,6 +94,20 @@ impl SkillName {
 impl fmt::Display for SkillName {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str(&self.0)
+    }
+}
+
+impl TryFrom<String> for SkillName {
+    type Error = DomainError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<SkillName> for String {
+    fn from(value: SkillName) -> Self {
+        value.0
     }
 }
 

--- a/crates/skilld-core/src/update.rs
+++ b/crates/skilld-core/src/update.rs
@@ -1,0 +1,247 @@
+use std::fmt;
+use std::num::NonZeroU64;
+
+use serde::{Deserialize, Deserializer, Serialize};
+
+use crate::SkillName;
+
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
+#[serde(try_from = "String", into = "String")]
+pub struct CommitSha(String);
+
+impl CommitSha {
+    pub fn parse(value: impl Into<String>) -> Result<Self, UpdateModelError> {
+        let value = value.into();
+        let valid = value.len() == 40
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+        valid
+            .then_some(Self(value.clone()))
+            .ok_or(UpdateModelError::InvalidCommitSha(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl TryFrom<String> for CommitSha {
+    type Error = UpdateModelError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl From<CommitSha> for String {
+    fn from(value: CommitSha) -> Self {
+        value.0
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct UpdateFailure {
+    pub code: String,
+    pub message: String,
+}
+
+impl UpdateFailure {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    deny_unknown_fields,
+    tag = "_tag",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum UpdateLatestCommit {
+    Known { commit_sha: CommitSha },
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum NotTrackedReason {
+    Local,
+    Bundled,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    deny_unknown_fields,
+    tag = "_tag",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum UpdateRelation {
+    Current {
+        commit_sha: CommitSha,
+    },
+    Available {
+        locked_commit_sha: CommitSha,
+        latest_commit_sha: CommitSha,
+        ahead_by: NonZeroU64,
+    },
+    Behind {
+        locked_commit_sha: CommitSha,
+        latest_commit_sha: CommitSha,
+        behind_by: NonZeroU64,
+    },
+    Diverged {
+        locked_commit_sha: CommitSha,
+        latest_commit_sha: CommitSha,
+        ahead_by: NonZeroU64,
+        behind_by: NonZeroU64,
+    },
+    Pinned {
+        commit_sha: CommitSha,
+    },
+    NotTracked {
+        reason: NotTrackedReason,
+    },
+    Unavailable {
+        locked_commit_sha: CommitSha,
+        latest_commit: UpdateLatestCommit,
+        failure: UpdateFailure,
+    },
+}
+
+pub fn classify_update_comparison(
+    locked_commit_sha: CommitSha,
+    latest_commit_sha: CommitSha,
+    ahead_by: u64,
+    behind_by: u64,
+) -> Result<UpdateRelation, UpdateModelError> {
+    match (locked_commit_sha == latest_commit_sha, ahead_by, behind_by) {
+        (true, 0, 0) => Ok(UpdateRelation::Current {
+            commit_sha: locked_commit_sha,
+        }),
+        (false, ahead_by, 0) if ahead_by > 0 => Ok(UpdateRelation::Available {
+            locked_commit_sha,
+            latest_commit_sha,
+            ahead_by: NonZeroU64::new(ahead_by).expect("ahead count is non-zero"),
+        }),
+        (false, 0, behind_by) if behind_by > 0 => Ok(UpdateRelation::Behind {
+            locked_commit_sha,
+            latest_commit_sha,
+            behind_by: NonZeroU64::new(behind_by).expect("behind count is non-zero"),
+        }),
+        (false, ahead_by, behind_by) if ahead_by > 0 && behind_by > 0 => {
+            Ok(UpdateRelation::Diverged {
+                locked_commit_sha,
+                latest_commit_sha,
+                ahead_by: NonZeroU64::new(ahead_by).expect("ahead count is non-zero"),
+                behind_by: NonZeroU64::new(behind_by).expect("behind count is non-zero"),
+            })
+        }
+        _ => Err(UpdateModelError::InvalidComparison),
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct UpdatePlanItem {
+    name: SkillName,
+    relation: UpdateRelation,
+}
+
+impl UpdatePlanItem {
+    pub fn new(name: SkillName, relation: UpdateRelation) -> Self {
+        Self { name, relation }
+    }
+
+    pub const fn name(&self) -> &SkillName {
+        &self.name
+    }
+
+    pub const fn relation(&self) -> &UpdateRelation {
+        &self.relation
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UpdatePlan {
+    items: Vec<UpdatePlanItem>,
+}
+
+impl UpdatePlan {
+    pub fn new(mut items: Vec<UpdatePlanItem>) -> Result<Self, UpdateModelError> {
+        items.sort_by(|left, right| left.name.cmp(&right.name));
+        if let Some(duplicate) = items
+            .windows(2)
+            .find(|pair| pair[0].name == pair[1].name)
+            .map(|pair| pair[0].name.to_string())
+        {
+            return Err(UpdateModelError::DuplicateSkill(duplicate));
+        }
+        Ok(Self { items })
+    }
+
+    pub fn items(&self) -> &[UpdatePlanItem] {
+        &self.items
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct UpdateCheckV1 {
+    items: Vec<UpdatePlanItem>,
+}
+
+impl UpdateCheckV1 {
+    pub fn new(plan: UpdatePlan) -> Self {
+        Self { items: plan.items }
+    }
+
+    pub fn items(&self) -> &[UpdatePlanItem] {
+        &self.items
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct UpdateCheckV1Wire {
+    items: Vec<UpdatePlanItem>,
+}
+
+impl<'de> Deserialize<'de> for UpdateCheckV1 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = UpdateCheckV1Wire::deserialize(deserializer)?;
+        UpdatePlan::new(wire.items)
+            .map(Self::new)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UpdateModelError {
+    DuplicateSkill(String),
+    InvalidCommitSha(String),
+    InvalidComparison,
+}
+
+impl fmt::Display for UpdateModelError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicateSkill(name) => {
+                write!(formatter, "duplicate Skill in update plan: {name}")
+            }
+            Self::InvalidCommitSha(_) => formatter.write_str("invalid Git commit in update plan"),
+            Self::InvalidComparison => formatter.write_str("invalid Git update comparison"),
+        }
+    }
+}
+
+impl std::error::Error for UpdateModelError {}

--- a/crates/skilld-core/tests/update.rs
+++ b/crates/skilld-core/tests/update.rs
@@ -1,0 +1,122 @@
+use std::num::NonZeroU64;
+
+use skilld_core::{
+    CommitSha, SkillName, UpdateCheckV1, UpdateLatestCommit, UpdateModelError, UpdatePlan,
+    UpdatePlanItem, UpdateRelation, classify_update_comparison,
+};
+
+fn sha(value: char) -> CommitSha {
+    CommitSha::parse(value.to_string().repeat(40)).unwrap()
+}
+
+#[test]
+fn comparison_counts_classify_every_git_relation() {
+    let locked = sha('1');
+    let latest = sha('2');
+
+    assert_eq!(
+        classify_update_comparison(locked.clone(), locked.clone(), 0, 0).unwrap(),
+        UpdateRelation::Current {
+            commit_sha: locked.clone(),
+        }
+    );
+    assert_eq!(
+        classify_update_comparison(locked.clone(), latest.clone(), 3, 0).unwrap(),
+        UpdateRelation::Available {
+            locked_commit_sha: locked.clone(),
+            latest_commit_sha: latest.clone(),
+            ahead_by: NonZeroU64::new(3).unwrap(),
+        }
+    );
+    assert_eq!(
+        classify_update_comparison(locked.clone(), latest.clone(), 0, 2).unwrap(),
+        UpdateRelation::Behind {
+            locked_commit_sha: locked.clone(),
+            latest_commit_sha: latest.clone(),
+            behind_by: NonZeroU64::new(2).unwrap(),
+        }
+    );
+    assert_eq!(
+        classify_update_comparison(locked.clone(), latest.clone(), 4, 2).unwrap(),
+        UpdateRelation::Diverged {
+            locked_commit_sha: locked,
+            latest_commit_sha: latest,
+            ahead_by: NonZeroU64::new(4).unwrap(),
+            behind_by: NonZeroU64::new(2).unwrap(),
+        }
+    );
+}
+
+#[test]
+fn impossible_comparison_counts_are_rejected() {
+    assert_eq!(
+        classify_update_comparison(sha('1'), sha('2'), 0, 0),
+        Err(UpdateModelError::InvalidComparison)
+    );
+    assert_eq!(
+        classify_update_comparison(sha('1'), sha('1'), 1, 0),
+        Err(UpdateModelError::InvalidComparison)
+    );
+}
+
+#[test]
+fn update_plan_sorts_skills_and_rejects_duplicates() {
+    let first = UpdatePlanItem::new(
+        SkillName::parse("zeta").unwrap(),
+        UpdateRelation::Pinned {
+            commit_sha: sha('1'),
+        },
+    );
+    let second = UpdatePlanItem::new(
+        SkillName::parse("alpha").unwrap(),
+        UpdateRelation::Current {
+            commit_sha: sha('2'),
+        },
+    );
+    let plan = UpdatePlan::new(vec![first, second]).unwrap();
+
+    assert_eq!(
+        plan.items()
+            .iter()
+            .map(|item| item.name().as_str())
+            .collect::<Vec<_>>(),
+        ["alpha", "zeta"]
+    );
+    assert_eq!(
+        UpdatePlan::new(vec![
+            UpdatePlanItem::new(
+                SkillName::parse("alpha").unwrap(),
+                UpdateRelation::Pinned {
+                    commit_sha: sha('1'),
+                },
+            ),
+            UpdatePlanItem::new(
+                SkillName::parse("alpha").unwrap(),
+                UpdateRelation::Current {
+                    commit_sha: sha('2'),
+                },
+            ),
+        ]),
+        Err(UpdateModelError::DuplicateSkill("alpha".to_owned()))
+    );
+}
+
+#[test]
+fn v1_check_fixture_covers_the_published_relations() {
+    let bytes = include_bytes!("../../../tests/fixtures/v3-rust/v1/update-check.json");
+    let fixture: serde_json::Value = serde_json::from_slice(bytes).unwrap();
+    let check: UpdateCheckV1 = serde_json::from_value(fixture["data"].clone()).unwrap();
+
+    assert_eq!(fixture["schemaVersion"], 1);
+    assert_eq!(fixture["_tag"], "Success");
+    assert_eq!(fixture["command"], "update");
+    assert_eq!(check.items().len(), 7);
+    assert!(matches!(
+        check.items()[6].relation(),
+        UpdateRelation::Unavailable {
+            latest_commit: UpdateLatestCommit::Known { .. },
+            ..
+        }
+    ));
+    assert_eq!(serde_json::to_value(check).unwrap(), fixture["data"]);
+}

--- a/crates/skilld-native/Cargo.toml
+++ b/crates/skilld-native/Cargo.toml
@@ -24,6 +24,11 @@ skilld-core.workspace = true
 
 tempfile.workspace = true
 
+terminal_size.workspace = true
+
 ureq = { version = "=3.1.4", default-features = false, features = [ "rustls" ] }
 
 url.workspace = true
+
+[target.'cfg(unix)'.dev-dependencies]
+nix = { version = "0.29.0", features = [ "term" ] }

--- a/crates/skilld-native/src/main.rs
+++ b/crates/skilld-native/src/main.rs
@@ -10,11 +10,15 @@ use std::sync::Arc;
 use embedded_skill::EmbeddedSkilld;
 use native_auth::NativeAccount;
 use skilld_command::{
-    DetectionEnvironment, LocalHost, NativeRemoteConfig, OutputContext, SkilldRemote, TargetRoots,
-    run_stdio_probe, run_with_output,
+    CommandError, DetectionEnvironment, Host, LocalHost, NativeRemoteConfig, OutputContext,
+    SkilldRemote, TargetRoots, run_stdio_probe, run_with_output,
 };
-use skilld_core::TrustedRootPin;
+use skilld_core::{
+    InstallScope, InstallSource, SearchResponse, SearchResult, SourceProvider, SourceRequest,
+    SourceSelector, TrustedRootPin,
+};
 use skilld_native::NativeHttpAdapter;
+use terminal_size::Width;
 
 fn main() -> ExitCode {
     if env::var_os("SKILLD_PROBE_STDIO").as_deref() == Some(std::ffi::OsStr::new("1")) {
@@ -23,6 +27,9 @@ fn main() -> ExitCode {
         let mut stderr = std::io::stderr().lock();
         let result = run_stdio_probe(&mut stdin, &mut stdout, &mut stderr);
         return ExitCode::from(result.exit_code);
+    }
+    if env::var_os("SKILLD_PROBE_SEARCH_OUTPUT").as_deref() == Some(std::ffi::OsStr::new("1")) {
+        return run_search_output_probe();
     }
 
     let project_root = match env::current_dir() {
@@ -50,7 +57,7 @@ fn main() -> ExitCode {
     let mut stderr = std::io::stderr().lock();
     let output = OutputContext::auto(
         stdout.is_terminal(),
-        detection.detects_agent(),
+        active_agent_detected(),
         environment_enabled("CI"),
         environment_present("NO_COLOR"),
         env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
@@ -58,6 +65,64 @@ fn main() -> ExitCode {
     );
     let result = run_with_output(env::args_os(), &host, output, &mut stdout, &mut stderr);
     ExitCode::from(result.exit_code)
+}
+
+fn run_search_output_probe() -> ExitCode {
+    let mut stdout = std::io::stdout().lock();
+    let mut stderr = std::io::stderr().lock();
+    let output = OutputContext::auto(
+        stdout.is_terminal(),
+        active_agent_detected(),
+        environment_enabled("CI"),
+        environment_present("NO_COLOR"),
+        env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
+        terminal_width(),
+    );
+    let mut args = vec!["skilld", "search", "output"];
+    if env::args_os().any(|argument| argument == "--json") {
+        args.push("--json");
+    }
+    if env::args_os().any(|argument| argument == "--plain") {
+        args.push("--plain");
+    }
+    let result = run_with_output(args, &SearchOutputProbe, output, &mut stdout, &mut stderr);
+    ExitCode::from(result.exit_code)
+}
+
+struct SearchOutputProbe;
+
+impl Host for SearchOutputProbe {
+    fn list(&self, _scope: InstallScope) -> Result<Vec<String>, CommandError> {
+        unreachable!("list is outside the search output probe")
+    }
+
+    fn install(
+        &self,
+        _source: InstallSource,
+        _scope: InstallScope,
+    ) -> Result<String, CommandError> {
+        unreachable!("install is outside the search output probe")
+    }
+
+    fn search(&self, _query: &str) -> Result<SearchResponse, CommandError> {
+        Ok(SearchResponse {
+            items: vec![SearchResult {
+                name: "output-probe".to_owned(),
+                description: Some("Checks native terminal output.".to_owned()),
+                source: SourceRequest {
+                    provider: SourceProvider::Github,
+                    owner: "skilld-dev".to_owned(),
+                    repository: "skilld".to_owned(),
+                    selector: SourceSelector::NamedSkill {
+                        name: "output-probe".to_owned(),
+                    },
+                    r#ref: None,
+                },
+                stargazer_count: 1,
+            }],
+            total: 1,
+        })
+    }
 }
 
 fn native_remote_config() -> NativeRemoteConfig {
@@ -116,6 +181,29 @@ fn detection_environment() -> DetectionEnvironment {
     )
 }
 
+fn active_agent_detected() -> bool {
+    const SIGNALS: [&str; 17] = [
+        "CLAUDE_CODE",
+        "CLAUDECODE",
+        "CLAUDE_CODE_ENTRYPOINT",
+        "CURSOR_SESSION",
+        "CURSOR_TRACE_ID",
+        "WINDSURF_SESSION",
+        "CLINE_TASK_ID",
+        "CLINE_ACTIVE",
+        "COPILOT_RUN_APP",
+        "GEMINI_CLI",
+        "GOOSE_SESSION",
+        "AGENT_SESSION_ID",
+        "AMP_SESSION",
+        "OPENCODE_SESSION",
+        "OPENCODE_SESSION_ID",
+        "ROO_SESSION",
+        "ANTIGRAVITY_CLI_ALIAS",
+    ];
+    SIGNALS.iter().any(|name| environment_enabled(name))
+}
+
 fn global_root() -> PathBuf {
     if let Some(path) = env::var_os("SKILLD_DATA_DIR") {
         return PathBuf::from(path);
@@ -140,8 +228,14 @@ fn environment_present(name: &str) -> bool {
 }
 
 fn terminal_width() -> u16 {
-    env::var("COLUMNS")
-        .ok()
-        .and_then(|value| value.parse().ok())
+    terminal_size::terminal_size_of(std::io::stdout())
+        .map(|(Width(width), _)| width)
+        .filter(|width| (20..=240).contains(width))
+        .or_else(|| {
+            env::var("COLUMNS")
+                .ok()
+                .and_then(|value| value.parse().ok())
+                .filter(|width| (20..=240).contains(width))
+        })
         .unwrap_or(80)
 }

--- a/crates/skilld-native/src/main.rs
+++ b/crates/skilld-native/src/main.rs
@@ -2,6 +2,7 @@ mod embedded_skill;
 mod native_auth;
 
 use std::env;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -9,8 +10,8 @@ use std::sync::Arc;
 use embedded_skill::EmbeddedSkilld;
 use native_auth::NativeAccount;
 use skilld_command::{
-    DetectionEnvironment, LocalHost, NativeRemoteConfig, SkilldRemote, TargetRoots, run,
-    run_stdio_probe,
+    DetectionEnvironment, LocalHost, NativeRemoteConfig, OutputContext, SkilldRemote, TargetRoots,
+    run_stdio_probe, run_with_output,
 };
 use skilld_core::TrustedRootPin;
 use skilld_native::NativeHttpAdapter;
@@ -32,10 +33,11 @@ fn main() -> ExitCode {
         }
     };
     let global_root = global_root();
+    let detection = detection_environment();
     let account = Arc::new(NativeAccount::new());
     let host = LocalHost::new(project_root, global_root)
         .with_target_roots(target_roots())
-        .with_detection_environment(detection_environment())
+        .with_detection_environment(detection.clone())
         .with_bundled_provider(Arc::new(EmbeddedSkilld::new()))
         .with_account_provider(account.clone())
         .with_remote_provider(Arc::new(SkilldRemote::new(
@@ -46,7 +48,15 @@ fn main() -> ExitCode {
 
     let mut stdout = std::io::stdout().lock();
     let mut stderr = std::io::stderr().lock();
-    let result = run(env::args_os(), &host, &mut stdout, &mut stderr);
+    let output = OutputContext::auto(
+        stdout.is_terminal(),
+        detection.detects_agent(),
+        environment_enabled("CI"),
+        environment_present("NO_COLOR"),
+        env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
+        terminal_width(),
+    );
+    let result = run_with_output(env::args_os(), &host, output, &mut stdout, &mut stderr);
     ExitCode::from(result.exit_code)
 }
 
@@ -117,4 +127,21 @@ fn global_root() -> PathBuf {
         return PathBuf::from(path).join(".skilld");
     }
     PathBuf::from(".skilld")
+}
+
+fn environment_enabled(name: &str) -> bool {
+    env::var(name).is_ok_and(|value| {
+        !value.is_empty() && value != "0" && !value.eq_ignore_ascii_case("false")
+    })
+}
+
+fn environment_present(name: &str) -> bool {
+    env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+fn terminal_width() -> u16 {
+    env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(80)
 }

--- a/crates/skilld-native/src/native_auth.rs
+++ b/crates/skilld-native/src/native_auth.rs
@@ -203,10 +203,7 @@ fn command_auth_error(error: AuthError) -> CommandError {
         AuthErrorKind::UnsupportedCapability => "UNSUPPORTED_HOST",
         _ => "SERVICE_UNAVAILABLE",
     };
-    CommandError {
-        code,
-        message: error.message().to_owned(),
-    }
+    CommandError::operation(code, error.message())
 }
 
 fn remote_auth_error(error: AuthError) -> RemoteError {

--- a/crates/skilld-native/tests/cli.rs
+++ b/crates/skilld-native/tests/cli.rs
@@ -1,6 +1,36 @@
 use std::fs;
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::io::Read;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
+use std::process::Stdio;
 use std::process::{Command, Output};
+
+#[cfg(unix)]
+use nix::pty::{Winsize, openpty};
+
+const DETECTION_SIGNALS: [&str; 18] = [
+    "CLAUDE_CODE",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CONFIG_DIR",
+    "CURSOR_SESSION",
+    "CURSOR_TRACE_ID",
+    "WINDSURF_SESSION",
+    "CLINE_TASK_ID",
+    "CLINE_ACTIVE",
+    "COPILOT_RUN_APP",
+    "GEMINI_CLI",
+    "GOOSE_SESSION",
+    "AGENT_SESSION_ID",
+    "AMP_SESSION",
+    "OPENCODE_SESSION",
+    "OPENCODE_SESSION_ID",
+    "ROO_SESSION",
+    "ANTIGRAVITY_CLI_ALIAS",
+];
 
 fn binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_skilld"))
@@ -11,26 +41,6 @@ fn fixture() -> PathBuf {
 }
 
 fn run(project: &Path, data: &Path, home: &Path, args: &[&str]) -> Output {
-    const SIGNALS: [&str; 18] = [
-        "CLAUDE_CODE",
-        "CLAUDECODE",
-        "CLAUDE_CODE_ENTRYPOINT",
-        "CLAUDE_CONFIG_DIR",
-        "CURSOR_SESSION",
-        "CURSOR_TRACE_ID",
-        "WINDSURF_SESSION",
-        "CLINE_TASK_ID",
-        "CLINE_ACTIVE",
-        "COPILOT_RUN_APP",
-        "GEMINI_CLI",
-        "GOOSE_SESSION",
-        "AGENT_SESSION_ID",
-        "AMP_SESSION",
-        "OPENCODE_SESSION",
-        "OPENCODE_SESSION_ID",
-        "ROO_SESSION",
-        "ANTIGRAVITY_CLI_ALIAS",
-    ];
     let mut command = Command::new(binary());
     command
         .current_dir(project)
@@ -38,10 +48,70 @@ fn run(project: &Path, data: &Path, home: &Path, args: &[&str]) -> Output {
         .env("HOME", home)
         .env("XDG_CONFIG_HOME", home.join(".config"))
         .args(args);
-    for signal in SIGNALS {
+    for signal in DETECTION_SIGNALS {
         command.env_remove(signal);
     }
     command.output().unwrap()
+}
+
+#[cfg(unix)]
+fn run_output_probe_in_pty(signal: (&str, &str), width: u16) -> String {
+    let pair = openpty(
+        Some(&Winsize {
+            ws_row: 24,
+            ws_col: width,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        }),
+        None,
+    )
+    .unwrap();
+    let mut master = File::from(pair.master);
+    let slave = File::from(pair.slave);
+    let slave_stdout = slave.try_clone().unwrap();
+    let slave_stderr = slave.try_clone().unwrap();
+    let mut command = Command::new(binary());
+    for name in DETECTION_SIGNALS {
+        command.env_remove(name);
+    }
+    let mut child = command
+        .env_remove("CI")
+        .env_remove("COLUMNS")
+        .env("NO_COLOR", "1")
+        .env("TERM", "xterm-256color")
+        .env("SKILLD_PROBE_SEARCH_OUTPUT", "1")
+        .env(signal.0, signal.1)
+        .stdin(Stdio::from(slave))
+        .stdout(Stdio::from(slave_stdout))
+        .stderr(Stdio::from(slave_stderr))
+        .spawn()
+        .unwrap();
+    drop(command);
+
+    let status = child.wait().unwrap();
+    let mut output = String::new();
+    let _ = master.read_to_string(&mut output);
+    assert!(status.success());
+    output.replace("\r\n", "\n")
+}
+
+#[cfg(unix)]
+#[test]
+fn active_agent_signal_uses_plain_output_in_a_terminal() {
+    let output = run_output_probe_in_pty(("AGENT_SESSION_ID", "test-session"), 40);
+
+    assert!(output.contains("output-probe\tskilld:skilld-dev/skilld/output-probe\t1\t"));
+    assert!(!output.contains("Skill search"));
+}
+
+#[cfg(unix)]
+#[test]
+fn config_directory_alone_keeps_human_output_in_a_terminal() {
+    let output = run_output_probe_in_pty(("CLAUDE_CONFIG_DIR", "/tmp/claude-config"), 40);
+
+    assert!(output.contains("Skill search output"));
+    assert!(output.contains("Install: skilld install"));
+    assert!(output.lines().all(|line| line.chars().count() <= 40));
 }
 
 #[test]
@@ -286,7 +356,7 @@ fn native_auth_status_surfaces_an_unavailable_os_credential_store() {
         .output()
         .unwrap();
 
-    assert_eq!(output.status.code(), Some(2));
+    assert_eq!(output.status.code(), Some(1));
     assert_eq!(
         String::from_utf8(output.stderr).unwrap(),
         "SERVICE_UNAVAILABLE: The OS keychain operation failed.\n"

--- a/crates/skilld-native/tests/http.rs
+++ b/crates/skilld-native/tests/http.rs
@@ -33,8 +33,9 @@ fn native_http_adapter_reaches_the_v1_skill_search_route() {
     .with_endpoint(&format!("http://{address}"))
     .unwrap();
 
-    let results = remote.search("testing", 20).unwrap();
+    let response = remote.search("testing", 20).unwrap();
 
-    assert_eq!(results[0].name, "vue-testing");
+    assert_eq!(response.items[0].name, "vue-testing");
+    assert_eq!(response.total, 1);
     server.join().unwrap();
 }

--- a/crates/skilld-wasi/src/lib.rs
+++ b/crates/skilld-wasi/src/lib.rs
@@ -1,7 +1,9 @@
 use std::env;
 use std::path::PathBuf;
 
-use skilld_command::{CommandError, Host, LocalHost, run, run_stdio_probe};
+use skilld_command::{
+    CommandError, Host, LocalHost, OutputContext, run_stdio_probe, run_with_output,
+};
 use skilld_core::{InstallScope, InstallSource};
 
 wit_bindgen::generate!({
@@ -37,7 +39,13 @@ impl Guest for SkilldComponent {
         let host = WasiHost { local };
         let mut stdout = std::io::stdout().lock();
         let mut stderr = std::io::stderr().lock();
-        let result = run(env::args_os(), &host, &mut stdout, &mut stderr);
+        let result = run_with_output(
+            env::args_os(),
+            &host,
+            OutputContext::Plain,
+            &mut stdout,
+            &mut stderr,
+        );
         result.exit_code.into()
     }
 }

--- a/docs/migrate-v2-to-v3.md
+++ b/docs/migrate-v2-to-v3.md
@@ -111,7 +111,7 @@ It cannot restore a v2 lockfile.
 | v2 command | v3 replacement |
 | --- | --- |
 | `skilld add <source>` | Run `skilld search`, then `skilld install <selector>` |
-| `skilld update [name]` | `skilld upgrade [name]` |
+| `skilld update [name]` | `skilld update [name]` |
 | `skilld info` | `skilld list`, then `skilld view <name>` |
 | `skilld login` | `skilld auth login` |
 | `skilld whoami` | `skilld auth status` |

--- a/skills/skilld/SKILL.md
+++ b/skills/skilld/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skilld
-description: Search, view, install, upgrade, verify, and remove Skills with skilld CLI, including private repository access.
+description: Search, view, install, update, verify, and remove Skills with skilld CLI, including private repository access.
 ---
 
 # Use skilld CLI
@@ -64,11 +64,18 @@ Use `view` to show one Skill's path, source status, and Agent targets.
 ## Maintain installed Skills
 
 ```sh
-skilld upgrade <skill>
+skilld update <skill>
+skilld update --check --json
 skilld verify <skill>
 skilld remove <skill>
 ```
 
-Use `upgrade` to install a newer Artifact.
+Use `update --check --json` to inspect update relations without changing files.
+Read each `data.items[].relation._tag` before changing files.
+Use `update <skill>` only when the relation is `available`.
+Treat `current`, `pinned`, and `notTracked` as no action.
+If the relation is `behind` or `diverged`, ask before changing files.
+If the relation is `unavailable`, report `failure.code` and `failure.message`.
+Treat `unavailable` as unknown. Do not infer a newer commit.
 Use `verify` to check the installed bytes and source status.
 Use `remove` only when the request names the Skill to remove.

--- a/skills/skilld/SKILL.md
+++ b/skills/skilld/SKILL.md
@@ -12,11 +12,18 @@ Use skilld CLI to search for and install Skills.
 Run a focused search:
 
 ```sh
-skilld search <query>
+skilld search <query> --json
 ```
 
-Read the result names and descriptions before choosing.
+Read `data.items` before choosing a Skill.
+Use each item's `selector` for install.
 Refine the query when several Skills cover different tasks.
+
+Always use `--json` when an Agent runs Skill search.
+Check the exit code before reading stdout.
+If search fails, read the tagged JSON error from stderr.
+Use `--plain` only when another command needs stable text.
+Never parse formatted terminal output.
 
 ## Install a Skill
 

--- a/tests/fixtures/v3-rust/v1/update-check.json
+++ b/tests/fixtures/v3-rust/v1/update-check.json
@@ -1,0 +1,74 @@
+{
+  "schemaVersion": 1,
+  "_tag": "Success",
+  "command": "update",
+  "data": {
+    "items": [
+    {
+      "name": "available-skill",
+      "relation": {
+        "_tag": "available",
+        "lockedCommitSha": "1111111111111111111111111111111111111111",
+        "latestCommitSha": "2222222222222222222222222222222222222222",
+        "aheadBy": 3
+      }
+    },
+    {
+      "name": "behind-skill",
+      "relation": {
+        "_tag": "behind",
+        "lockedCommitSha": "2222222222222222222222222222222222222222",
+        "latestCommitSha": "1111111111111111111111111111111111111111",
+        "behindBy": 2
+      }
+    },
+    {
+      "name": "current-skill",
+      "relation": {
+        "_tag": "current",
+        "commitSha": "1111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "name": "diverged-skill",
+      "relation": {
+        "_tag": "diverged",
+        "lockedCommitSha": "1111111111111111111111111111111111111111",
+        "latestCommitSha": "2222222222222222222222222222222222222222",
+        "aheadBy": 4,
+        "behindBy": 2
+      }
+    },
+    {
+      "name": "local-skill",
+      "relation": {
+        "_tag": "notTracked",
+        "reason": "local"
+      }
+    },
+    {
+      "name": "pinned-skill",
+      "relation": {
+        "_tag": "pinned",
+        "commitSha": "1111111111111111111111111111111111111111"
+      }
+    },
+    {
+      "name": "unavailable-skill",
+      "relation": {
+        "_tag": "unavailable",
+        "lockedCommitSha": "1111111111111111111111111111111111111111",
+        "latestCommit": {
+          "_tag": "known",
+          "commitSha": "2222222222222222222222222222222222222222"
+        },
+        "failure": {
+          "code": "COMPARISON_UNAVAILABLE",
+          "message": "Git comparison is unavailable."
+        }
+      }
+    }
+    ]
+  },
+  "notices": []
+}


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`skilld search` sent the same raw output to people and automation. Human terminals now get readable, width-aware results. Agents, pipes, and CI get plain records, with `--json` as the versioned contract.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
