### PR TITLE
feat(update): add remote comparison plans

### DIFF
--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -14,20 +14,22 @@ use std::sync::Arc;
 use clap::{CommandFactory, Parser, Subcommand, error::ErrorKind};
 pub use config::{ConfigStore, LocalConfig};
 pub use local_store::{
-    AllowTransaction, LocalStore, ResolvedTarget, SkillView, StoreError, TargetInstall,
-    TransactionGate,
+    AllowTransaction, LocalStore, PreparedStoreUpdate, ResolvedTarget, SkillView, StoreError,
+    TargetInstall, TransactionGate,
 };
 pub use output::OutputContext;
 pub use remote::{
     Cancellation, HeaderValue, HttpAdapter, HttpHeader, HttpMethod, HttpRequest, HttpResponse,
-    NativeRemoteConfig, NeverCancelled, NoTokenProvider, PreparedRemoteSkill, RemoteProvider,
-    RemoteSourceState, SecretValue, SkilldRemote, Sleeper, ThreadSleeper, TokenProvider,
+    NativeRemoteConfig, NeverCancelled, NoTokenProvider, PreparedRemoteSkill,
+    RemoteComparisonAccess, RemoteComparisonOutcome, RemoteComparisonRelation, RemoteLatestCommit,
+    RemoteProvider, RemoteSourceState, RemoteUpdateComparison, RemoteUpdateResult, SecretValue,
+    SkilldRemote, Sleeper, ThreadSleeper, TokenProvider,
 };
 use skilld_core::{
-    AGENT_TARGETS, AgentTargetId, CommitSha, DomainError, GlobalTargetPath, InstallMode,
-    InstallRequest, InstallScope, InstallSource, LockedSource, NotTrackedReason, SourceRef,
-    UpdateCheckV1, UpdateFailure, UpdateLatestCommit, UpdateModelError, UpdatePlan, UpdatePlanItem,
-    UpdateRelation, VERSION, select_target_ids,
+    AGENT_TARGETS, AgentTargetId, CommitHistory, CommitSha, DomainError, GlobalTargetPath,
+    InstallMode, InstallRequest, InstallScope, InstallSource, LockedSource, NotTrackedReason,
+    SourceRef, UpdateFailure, UpdateLatestCommit, UpdateModelError, UpdatePlan, UpdatePlanItem,
+    UpdatePlanV1, UpdateRelation, UpdateRetryAfter, VERSION, select_target_ids,
 };
 
 use output::{
@@ -168,7 +170,7 @@ pub trait Host {
         ))
     }
 
-    fn update_check(&self, _name: Option<&str>) -> Result<UpdateCheckV1, CommandError> {
+    fn update_check(&self, _name: Option<&str>) -> Result<UpdatePlanV1, CommandError> {
         Err(CommandError::unsupported_host(
             "Skill update checks are unavailable on this host",
         ))
@@ -313,7 +315,7 @@ pub struct CommandResult {
 enum CommandOutput {
     Lines(Vec<String>),
     Search(SearchOutcome),
-    UpdateCheck(UpdateCheckV1),
+    UpdateCheck(UpdatePlanV1),
 }
 
 pub fn run<I, T, H, O, E>(args: I, host: &H, stdout: &mut O, stderr: &mut E) -> CommandResult
@@ -434,7 +436,16 @@ where
             }
         },
         Ok(CommandOutput::UpdateCheck(outcome)) => match render_update_check(&outcome, mode) {
-            Ok(bytes) => write_success(&bytes, mode, stdout, stderr),
+            Ok(bytes) => {
+                let exit_code = if outcome.is_incomplete() {
+                    2
+                } else if outcome.has_changes() {
+                    1
+                } else {
+                    0
+                };
+                write_success_with_exit(&bytes, mode, stdout, stderr, exit_code)
+            }
             Err(error) => {
                 if stderr.write_all(&render_error(&error, mode)).is_err() {
                     return CommandResult {
@@ -497,8 +508,18 @@ fn write_success<O: Write, E: Write>(
     stdout: &mut O,
     stderr: &mut E,
 ) -> CommandResult {
+    write_success_with_exit(bytes, mode, stdout, stderr, 0)
+}
+
+fn write_success_with_exit<O: Write, E: Write>(
+    bytes: &[u8],
+    mode: OutputMode,
+    stdout: &mut O,
+    stderr: &mut E,
+    exit_code: u8,
+) -> CommandResult {
     match stdout.write_all(bytes) {
-        Ok(()) => CommandResult { exit_code: 0 },
+        Ok(()) => CommandResult { exit_code },
         Err(error) if error.kind() == std::io::ErrorKind::BrokenPipe => {
             CommandResult { exit_code: 0 }
         }
@@ -939,144 +960,6 @@ impl LocalHost {
         })
     }
 
-    fn update_relation(
-        &self,
-        skill: &skilld_core::LockedSkill,
-    ) -> Result<UpdateRelation, CommandError> {
-        let (source, locked_commit_sha) = match &skill.source {
-            LockedSource::Local { .. } => {
-                return Ok(UpdateRelation::NotTracked {
-                    reason: NotTrackedReason::Local,
-                });
-            }
-            LockedSource::BundledSkilld => {
-                return Ok(UpdateRelation::NotTracked {
-                    reason: NotTrackedReason::Bundled,
-                });
-            }
-            LockedSource::Remote {
-                source, commit_sha, ..
-            } => (
-                source,
-                CommitSha::parse(commit_sha.clone()).map_err(update_model_error)?,
-            ),
-        };
-
-        let selector = match skilld_core::RemoteSelector::parse(source) {
-            Ok(selector) => selector,
-            Err(error) => {
-                return Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Unknown,
-                    error.code,
-                    error.message,
-                ));
-            }
-        };
-        if let Some(SourceRef::Commit { value }) = &selector.source().r#ref {
-            let pinned_commit_sha = match CommitSha::parse(value.clone()) {
-                Ok(commit_sha) => commit_sha,
-                Err(error) => {
-                    return Ok(unavailable_update(
-                        locked_commit_sha,
-                        UpdateLatestCommit::Unknown,
-                        "INVALID_SOURCE",
-                        error.to_string(),
-                    ));
-                }
-            };
-            if pinned_commit_sha != locked_commit_sha {
-                return Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Known {
-                        commit_sha: pinned_commit_sha,
-                    },
-                    "INVALID_LOCKFILE",
-                    "the locked commit differs from its source selector",
-                ));
-            }
-            return Ok(UpdateRelation::Pinned {
-                commit_sha: locked_commit_sha,
-            });
-        }
-
-        let artifact_id = match &skill.source_status {
-            skilld_core::SourceStatus::Verified { artifact_id, .. } => artifact_id,
-            skilld_core::SourceStatus::Unverified { .. } => {
-                return Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Unknown,
-                    "UNVERIFIED_SOURCE",
-                    "run an explicit --direct install to update this Skill",
-                ));
-            }
-            skilld_core::SourceStatus::Local { .. } => {
-                return Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Unknown,
-                    "INVALID_LOCKFILE",
-                    "the remote Skill has a local source status",
-                ));
-            }
-        };
-        let provider = match self.remote_provider() {
-            Ok(provider) => provider,
-            Err(error) => {
-                return Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Unknown,
-                    error.code,
-                    error.message,
-                ));
-            }
-        };
-        let state = match provider.source_state(&selector, artifact_id, locked_commit_sha.as_str())
-        {
-            Ok(state) => state,
-            Err(error) => {
-                return Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Unknown,
-                    error.code,
-                    error.message,
-                ));
-            }
-        };
-        match state {
-            RemoteSourceState::Current => Ok(UpdateRelation::Current {
-                commit_sha: locked_commit_sha,
-            }),
-            RemoteSourceState::Stale {
-                current_commit_sha, ..
-            } => {
-                let latest_commit_sha = match CommitSha::parse(current_commit_sha) {
-                    Ok(commit_sha) => commit_sha,
-                    Err(error) => {
-                        return Ok(unavailable_update(
-                            locked_commit_sha,
-                            UpdateLatestCommit::Unknown,
-                            "INVALID_RESPONSE",
-                            error.to_string(),
-                        ));
-                    }
-                };
-                if latest_commit_sha == locked_commit_sha {
-                    return Ok(UpdateRelation::Current {
-                        commit_sha: locked_commit_sha,
-                    });
-                }
-                Ok(unavailable_update(
-                    locked_commit_sha,
-                    UpdateLatestCommit::Known {
-                        commit_sha: latest_commit_sha,
-                    },
-                    "COMPARISON_UNAVAILABLE",
-                    "skilld.dev does not provide Git comparison data",
-                ))
-            }
-        }
-    }
-
     fn install_remote(
         &self,
         source: &str,
@@ -1361,12 +1244,12 @@ impl Host for LocalHost {
         let known = self.known_targets(scope)?;
         let store = self.store(scope);
         let names = selected_names(&store, &known, requested)?;
-        let mut updated = Vec::new();
+        let mut selected = Vec::new();
         for name in names {
             let skill_name =
                 skilld_core::SkillName::parse(name.clone()).map_err(CommandError::domain)?;
             let view = store
-                .view(&skill_name, &known)
+                .verify_content(&skill_name, &known)
                 .map_err(CommandError::store)?;
             let LockedSource::Remote { source, .. } = &view.skill.source else {
                 continue;
@@ -1382,9 +1265,13 @@ impl Host for LocalHost {
             }
             let selector =
                 skilld_core::RemoteSelector::parse(source).map_err(CommandError::remote)?;
-            let prepared = self
-                .remote_provider()?
-                .prepare(&selector, false)
+            let provider = self.remote_provider()?;
+            let expected_commit = provider
+                .latest_commit(&selector, false)
+                .map_err(CommandError::remote)?
+                .commit_sha;
+            let prepared = provider
+                .prepare_exact(&selector, &expected_commit, false)
                 .map_err(CommandError::remote)?;
             let staged = materialize_remote(&prepared.files)?;
             let staged_name =
@@ -1415,36 +1302,301 @@ impl Host for LocalHost {
                         })
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            store
-                .install_from_with_status(
-                    staged.path(),
-                    prepared.locked_source,
-                    prepared.source_status,
-                    &targets,
-                    &known,
-                )
-                .map_err(CommandError::store)?;
-            updated.push(format!("Updated Skill {name}."));
+            selected.push(PreparedUpdateSelection {
+                name,
+                staged,
+                prepared,
+                targets,
+            });
         }
-        Ok(updated)
+        let updates = selected
+            .iter()
+            .map(|selection| PreparedStoreUpdate {
+                source: selection.staged.path().to_owned(),
+                locked_source: selection.prepared.locked_source.clone(),
+                source_status: Some(selection.prepared.source_status.clone()),
+                targets: selection.targets.clone(),
+            })
+            .collect();
+        store
+            .apply_update_batch(updates, &known)
+            .map_err(CommandError::store)?;
+        Ok(selected
+            .into_iter()
+            .map(|selection| format!("Updated Skill {}.", selection.name))
+            .collect())
     }
 
-    fn update_check(&self, requested: Option<&str>) -> Result<UpdateCheckV1, CommandError> {
+    fn update_check(&self, requested: Option<&str>) -> Result<UpdatePlanV1, CommandError> {
         let scope = InstallScope::Project;
         let known = self.known_targets(scope)?;
         let store = self.store(scope);
         let names = selected_names(&store, &known, requested)?;
         let mut items = Vec::with_capacity(names.len());
+        let mut pending = Vec::new();
         for name in names {
             let skill_name = skilld_core::SkillName::parse(name).map_err(CommandError::domain)?;
             let view = store
-                .view(&skill_name, &known)
+                .verify_content(&skill_name, &known)
                 .map_err(CommandError::store)?;
-            let relation = self.update_relation(&view.skill)?;
-            items.push(UpdatePlanItem::new(skill_name, relation));
+            let (source, locked_commit_sha) = match &view.skill.source {
+                LockedSource::Local { .. } => {
+                    items.push(UpdatePlanItem::new(
+                        skill_name,
+                        UpdateRelation::NotTracked {
+                            reason: NotTrackedReason::Local,
+                        },
+                    ));
+                    continue;
+                }
+                LockedSource::BundledSkilld => {
+                    items.push(UpdatePlanItem::new(
+                        skill_name,
+                        UpdateRelation::NotTracked {
+                            reason: NotTrackedReason::Bundled,
+                        },
+                    ));
+                    continue;
+                }
+                LockedSource::Remote {
+                    source, commit_sha, ..
+                } => (
+                    source,
+                    CommitSha::parse(commit_sha.clone()).map_err(update_model_error)?,
+                ),
+            };
+            let selector = match skilld_core::RemoteSelector::parse(source) {
+                Ok(selector) => selector,
+                Err(error) => {
+                    items.push(UpdatePlanItem::new(
+                        skill_name,
+                        unavailable_update(
+                            locked_commit_sha,
+                            UpdateLatestCommit::Unknown,
+                            error.code,
+                            error.message,
+                        ),
+                    ));
+                    continue;
+                }
+            };
+            if let Some(SourceRef::Commit { value }) = &selector.source().r#ref {
+                let pinned = CommitSha::parse(value.clone()).map_err(update_model_error)?;
+                let relation = if pinned == locked_commit_sha {
+                    UpdateRelation::Pinned {
+                        commit_sha: locked_commit_sha,
+                    }
+                } else {
+                    unavailable_update(
+                        locked_commit_sha,
+                        UpdateLatestCommit::Known { commit_sha: pinned },
+                        "INVALID_LOCKFILE",
+                        "The locked commit differs from its source selector",
+                    )
+                };
+                items.push(UpdatePlanItem::new(skill_name, relation));
+                continue;
+            }
+            let direct = match &view.skill.source_status {
+                skilld_core::SourceStatus::Verified { .. } => false,
+                skilld_core::SourceStatus::Unverified { .. } => true,
+                skilld_core::SourceStatus::Local { .. } => {
+                    items.push(UpdatePlanItem::new(
+                        skill_name,
+                        unavailable_update(
+                            locked_commit_sha,
+                            UpdateLatestCommit::Unknown,
+                            "INVALID_LOCKFILE",
+                            "A remote Skill has a local source status",
+                        ),
+                    ));
+                    continue;
+                }
+            };
+            let latest = match self.remote_provider().and_then(|provider| {
+                provider
+                    .latest_commit(&selector, direct)
+                    .map_err(CommandError::remote)
+            }) {
+                Ok(latest) => latest,
+                Err(error) => {
+                    items.push(UpdatePlanItem::new(
+                        skill_name,
+                        unavailable_update(
+                            locked_commit_sha,
+                            UpdateLatestCommit::Unknown,
+                            error.code,
+                            error.message,
+                        ),
+                    ));
+                    continue;
+                }
+            };
+            if latest.commit_sha == locked_commit_sha {
+                items.push(UpdatePlanItem::new(
+                    skill_name,
+                    UpdateRelation::Current {
+                        commit_sha: locked_commit_sha,
+                    },
+                ));
+                continue;
+            }
+            let comparison = RemoteUpdateComparison::new(
+                skill_name.as_str(),
+                &selector.source().owner,
+                &selector.source().repository,
+                locked_commit_sha.clone(),
+                latest.commit_sha.clone(),
+                latest.access,
+            )
+            .map_err(CommandError::remote)?;
+            pending.push(PendingUpdateComparison {
+                name: skill_name,
+                locked_commit_sha,
+                latest_commit_sha: latest.commit_sha,
+                comparison,
+            });
+        }
+        if !pending.is_empty() {
+            let comparisons = pending
+                .iter()
+                .map(|pending| pending.comparison.clone())
+                .collect::<Vec<_>>();
+            let results = self
+                .remote_provider()?
+                .compare_updates(&comparisons)
+                .map_err(CommandError::remote)?;
+            if results.len() != pending.len() {
+                return Err(CommandError::service(
+                    "Update comparison results were incomplete",
+                ));
+            }
+            for (pending, result) in pending.into_iter().zip(results) {
+                if pending.comparison.id != result.id {
+                    return Err(CommandError::service(
+                        "Update comparison results changed order",
+                    ));
+                }
+                items.push(update_plan_item(pending, result.outcome));
+            }
         }
         let plan = UpdatePlan::new(items).map_err(update_model_error)?;
-        Ok(UpdateCheckV1::new(plan))
+        Ok(UpdatePlanV1::new(plan))
+    }
+}
+
+struct PendingUpdateComparison {
+    name: skilld_core::SkillName,
+    locked_commit_sha: CommitSha,
+    latest_commit_sha: CommitSha,
+    comparison: RemoteUpdateComparison,
+}
+
+struct PreparedUpdateSelection {
+    name: String,
+    staged: StagedRemote,
+    prepared: PreparedRemoteSkill,
+    targets: Vec<TargetInstall>,
+}
+
+fn update_plan_item(
+    pending: PendingUpdateComparison,
+    outcome: RemoteComparisonOutcome,
+) -> UpdatePlanItem {
+    let unavailable = |code: &'static str, message: String| {
+        UpdatePlanItem::new(
+            pending.name.clone(),
+            unavailable_update(
+                pending.locked_commit_sha.clone(),
+                UpdateLatestCommit::Known {
+                    commit_sha: pending.latest_commit_sha.clone(),
+                },
+                code,
+                message,
+            ),
+        )
+    };
+    match outcome {
+        RemoteComparisonOutcome::Ready {
+            relation,
+            commits,
+            total,
+            truncated,
+            compare_url,
+        } => {
+            let relation = match relation {
+                RemoteComparisonRelation::Identical
+                    if pending.locked_commit_sha == pending.latest_commit_sha =>
+                {
+                    UpdateRelation::Current {
+                        commit_sha: pending.locked_commit_sha.clone(),
+                    }
+                }
+                RemoteComparisonRelation::Ahead if total > 0 => UpdateRelation::Available {
+                    locked_commit_sha: pending.locked_commit_sha.clone(),
+                    latest_commit_sha: pending.latest_commit_sha.clone(),
+                },
+                RemoteComparisonRelation::Behind => UpdateRelation::Behind {
+                    locked_commit_sha: pending.locked_commit_sha.clone(),
+                    latest_commit_sha: pending.latest_commit_sha.clone(),
+                },
+                RemoteComparisonRelation::Diverged => UpdateRelation::Diverged {
+                    locked_commit_sha: pending.locked_commit_sha.clone(),
+                    latest_commit_sha: pending.latest_commit_sha.clone(),
+                },
+                RemoteComparisonRelation::Identical | RemoteComparisonRelation::Ahead => {
+                    return unavailable(
+                        "INVALID_RESPONSE",
+                        "GitHub returned an impossible update relation".to_owned(),
+                    );
+                }
+            };
+            match CommitHistory::compared(commits, total, truncated, compare_url) {
+                Ok(history) => UpdatePlanItem::with_history(pending.name, relation, history),
+                Err(error) => unavailable("INVALID_RESPONSE", error.to_string()),
+            }
+        }
+        RemoteComparisonOutcome::NotFound => unavailable(
+            "SOURCE_NOT_FOUND",
+            "The Repository or commit is unavailable".to_owned(),
+        ),
+        RemoteComparisonOutcome::InvalidComparison => unavailable(
+            "COMMIT_NOT_FOUND",
+            "GitHub could not compare the installed commit".to_owned(),
+        ),
+        RemoteComparisonOutcome::RateLimited {
+            retry_after_seconds,
+            reset_at,
+        } => {
+            let retry_after = match (retry_after_seconds, reset_at) {
+                (Some(seconds), Some(reset_at)) => {
+                    UpdateRetryAfter::SecondsAndReset { seconds, reset_at }
+                }
+                (Some(seconds), None) => UpdateRetryAfter::Seconds { seconds },
+                (None, Some(reset_at)) => UpdateRetryAfter::Reset { reset_at },
+                (None, None) => UpdateRetryAfter::Unknown,
+            };
+            let failure =
+                UpdateFailure::rate_limited("GitHub rate limited the update check.", retry_after);
+            UpdatePlanItem::new(
+                pending.name,
+                UpdateRelation::Unavailable {
+                    locked_commit_sha: pending.locked_commit_sha,
+                    latest_commit: UpdateLatestCommit::Known {
+                        commit_sha: pending.latest_commit_sha,
+                    },
+                    failure,
+                },
+            )
+        }
+        RemoteComparisonOutcome::ProviderFailure { status } => unavailable(
+            "SERVICE_UNAVAILABLE",
+            status.map_or_else(
+                || "GitHub comparison failed".to_owned(),
+                |status| format!("GitHub comparison returned HTTP {status}"),
+            ),
+        ),
+        RemoteComparisonOutcome::RequestFailure { code, message } => unavailable(code, message),
     }
 }
 

--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -29,7 +29,8 @@ use skilld_core::{
     AGENT_TARGETS, AgentTargetId, CommitHistory, CommitSha, DomainError, GlobalTargetPath,
     InstallMode, InstallRequest, InstallScope, InstallSource, LockedSource, NotTrackedReason,
     SourceRef, UpdateFailure, UpdateLatestCommit, UpdateModelError, UpdatePlan, UpdatePlanItem,
-    UpdatePlanV1, UpdateRelation, UpdateRetryAfter, VERSION, select_target_ids,
+    UpdatePlanV1, UpdateRelation, UpdateRetryAfter, VERSION, classify_update_comparison,
+    select_target_ids,
 };
 
 use output::{
@@ -1244,7 +1245,8 @@ impl Host for LocalHost {
         let known = self.known_targets(scope)?;
         let store = self.store(scope);
         let names = selected_names(&store, &known, requested)?;
-        let mut selected = Vec::new();
+        let provider = self.remote_provider()?;
+        let mut pending = Vec::new();
         for name in names {
             let skill_name =
                 skilld_core::SkillName::parse(name.clone()).map_err(CommandError::domain)?;
@@ -1265,24 +1267,112 @@ impl Host for LocalHost {
             }
             let selector =
                 skilld_core::RemoteSelector::parse(source).map_err(CommandError::remote)?;
-            let provider = self.remote_provider()?;
-            let expected_commit = provider
+            if matches!(selector.source().r#ref, Some(SourceRef::Commit { .. })) {
+                continue;
+            }
+            let latest_commit = provider
                 .latest_commit(&selector, false)
-                .map_err(CommandError::remote)?
-                .commit_sha;
+                .map_err(CommandError::remote)?;
+            let LockedSource::Remote { commit_sha, .. } = &view.skill.source else {
+                unreachable!("the update candidate has a remote source")
+            };
+            let locked_commit_sha =
+                CommitSha::parse(commit_sha.clone()).map_err(update_model_error)?;
+            if latest_commit.commit_sha == locked_commit_sha {
+                continue;
+            }
+            let comparison = RemoteUpdateComparison::new(
+                skill_name.as_str(),
+                &selector.source().owner,
+                &selector.source().repository,
+                locked_commit_sha,
+                latest_commit.commit_sha.clone(),
+                latest_commit.access,
+            )
+            .map_err(CommandError::remote)?;
+            pending.push(PendingUpdateApply {
+                name,
+                skill_name,
+                view,
+                selector,
+                expected_commit: latest_commit.commit_sha,
+                comparison,
+            });
+        }
+        if pending.is_empty() {
+            return Ok(vec![]);
+        }
+        let comparisons = pending
+            .iter()
+            .map(|pending| pending.comparison.clone())
+            .collect::<Vec<_>>();
+        let results = provider
+            .compare_updates(&comparisons)
+            .map_err(CommandError::remote)?;
+        if results.len() != pending.len() {
+            return Err(CommandError::service(
+                "Update comparison results were incomplete",
+            ));
+        }
+        let mut selected = Vec::new();
+        for (pending, result) in pending.into_iter().zip(results) {
+            if pending.comparison.id != result.id {
+                return Err(CommandError::service(
+                    "Update comparison results changed order",
+                ));
+            }
+            match result.outcome {
+                RemoteComparisonOutcome::Ready {
+                    relation: RemoteComparisonRelation::Ahead,
+                    total,
+                    ..
+                } if total > 0 => {}
+                RemoteComparisonOutcome::Ready {
+                    relation: RemoteComparisonRelation::Behind,
+                    ..
+                } => {
+                    return Err(CommandError::operation(
+                        "UPDATE_CONFIRMATION_REQUIRED",
+                        format!(
+                            "Skill {} needs interactive confirmation because its source moved behind",
+                            pending.name
+                        ),
+                    ));
+                }
+                RemoteComparisonOutcome::Ready {
+                    relation: RemoteComparisonRelation::Diverged,
+                    ..
+                } => {
+                    return Err(CommandError::operation(
+                        "UPDATE_CONFIRMATION_REQUIRED",
+                        format!(
+                            "Skill {} needs interactive confirmation because its source diverged",
+                            pending.name
+                        ),
+                    ));
+                }
+                RemoteComparisonOutcome::Ready { .. } => {
+                    return Err(CommandError::operation(
+                        "INVALID_RESPONSE",
+                        "GitHub returned an impossible update relation",
+                    ));
+                }
+                outcome => return Err(update_apply_failure(&pending.name, outcome)),
+            }
             let prepared = provider
-                .prepare_exact(&selector, &expected_commit, false)
+                .prepare_exact(&pending.selector, &pending.expected_commit, false)
                 .map_err(CommandError::remote)?;
             let staged = materialize_remote(&prepared.files)?;
             let staged_name =
                 skilld_core::SkillName::from_source(staged.path()).map_err(CommandError::domain)?;
-            if staged_name != skill_name {
+            if staged_name != pending.skill_name {
                 return Err(CommandError::operation(
                     "SOURCE_MISMATCH",
-                    format!("the updated Skill name changed from {name}"),
+                    format!("the updated Skill name changed from {}", pending.name),
                 ));
             }
-            let targets = view
+            let targets = pending
+                .view
                 .skill
                 .targets
                 .iter()
@@ -1303,10 +1393,12 @@ impl Host for LocalHost {
                 })
                 .collect::<Result<Vec<_>, _>>()?;
             selected.push(PreparedUpdateSelection {
-                name,
+                name: pending.name,
                 staged,
                 prepared,
                 targets,
+                expected_transaction_id: pending.view.transaction_id,
+                expected_skill: pending.view.skill,
             });
         }
         let updates = selected
@@ -1316,6 +1408,8 @@ impl Host for LocalHost {
                 locked_source: selection.prepared.locked_source.clone(),
                 source_status: Some(selection.prepared.source_status.clone()),
                 targets: selection.targets.clone(),
+                expected_transaction_id: selection.expected_transaction_id.clone(),
+                expected_skill: selection.expected_skill.clone(),
             })
             .collect();
         store
@@ -1492,11 +1586,22 @@ struct PendingUpdateComparison {
     comparison: RemoteUpdateComparison,
 }
 
+struct PendingUpdateApply {
+    name: String,
+    skill_name: skilld_core::SkillName,
+    view: SkillView,
+    selector: skilld_core::RemoteSelector,
+    expected_commit: CommitSha,
+    comparison: RemoteUpdateComparison,
+}
+
 struct PreparedUpdateSelection {
     name: String,
     staged: StagedRemote,
     prepared: PreparedRemoteSkill,
     targets: Vec<TargetInstall>,
+    expected_transaction_id: String,
+    expected_skill: skilld_core::LockedSkill,
 }
 
 fn update_plan_item(
@@ -1519,40 +1624,48 @@ fn update_plan_item(
     match outcome {
         RemoteComparisonOutcome::Ready {
             relation,
+            ahead_by,
+            behind_by,
             commits,
             total,
             truncated,
             compare_url,
         } => {
-            let relation = match relation {
-                RemoteComparisonRelation::Identical
-                    if pending.locked_commit_sha == pending.latest_commit_sha =>
-                {
-                    UpdateRelation::Current {
-                        commit_sha: pending.locked_commit_sha.clone(),
-                    }
-                }
-                RemoteComparisonRelation::Ahead if total > 0 => UpdateRelation::Available {
-                    locked_commit_sha: pending.locked_commit_sha.clone(),
-                    latest_commit_sha: pending.latest_commit_sha.clone(),
-                },
-                RemoteComparisonRelation::Behind => UpdateRelation::Behind {
-                    locked_commit_sha: pending.locked_commit_sha.clone(),
-                    latest_commit_sha: pending.latest_commit_sha.clone(),
-                },
-                RemoteComparisonRelation::Diverged => UpdateRelation::Diverged {
-                    locked_commit_sha: pending.locked_commit_sha.clone(),
-                    latest_commit_sha: pending.latest_commit_sha.clone(),
-                },
-                RemoteComparisonRelation::Identical | RemoteComparisonRelation::Ahead => {
-                    return unavailable(
-                        "INVALID_RESPONSE",
-                        "GitHub returned an impossible update relation".to_owned(),
-                    );
-                }
+            let Ok(classified) = classify_update_comparison(
+                pending.locked_commit_sha.clone(),
+                pending.latest_commit_sha.clone(),
+                ahead_by,
+                behind_by,
+            ) else {
+                return unavailable(
+                    "INVALID_RESPONSE",
+                    "GitHub returned impossible update counts".to_owned(),
+                );
             };
+            let relation_matches = matches!(
+                (&relation, &classified),
+                (
+                    RemoteComparisonRelation::Identical,
+                    UpdateRelation::Current { .. }
+                ) | (
+                    RemoteComparisonRelation::Ahead,
+                    UpdateRelation::Available { .. }
+                ) | (
+                    RemoteComparisonRelation::Behind,
+                    UpdateRelation::Behind { .. }
+                ) | (
+                    RemoteComparisonRelation::Diverged,
+                    UpdateRelation::Diverged { .. }
+                )
+            );
+            if !relation_matches {
+                return unavailable(
+                    "INVALID_RESPONSE",
+                    "GitHub returned an impossible update relation".to_owned(),
+                );
+            }
             match CommitHistory::compared(commits, total, truncated, compare_url) {
-                Ok(history) => UpdatePlanItem::with_history(pending.name, relation, history),
+                Ok(history) => UpdatePlanItem::with_history(pending.name, classified, history),
                 Err(error) => unavailable("INVALID_RESPONSE", error.to_string()),
             }
         }
@@ -1597,6 +1710,45 @@ fn update_plan_item(
             ),
         ),
         RemoteComparisonOutcome::RequestFailure { code, message } => unavailable(code, message),
+    }
+}
+
+fn update_apply_failure(name: &str, outcome: RemoteComparisonOutcome) -> CommandError {
+    match outcome {
+        RemoteComparisonOutcome::NotFound => CommandError::operation(
+            "SOURCE_NOT_FOUND",
+            format!("The Repository or commit for Skill {name} is unavailable"),
+        ),
+        RemoteComparisonOutcome::InvalidComparison => CommandError::operation(
+            "COMMIT_NOT_FOUND",
+            format!("GitHub could not compare the installed commit for Skill {name}"),
+        ),
+        RemoteComparisonOutcome::RateLimited {
+            retry_after_seconds,
+            ..
+        } => CommandError::operation(
+            "RATE_LIMITED",
+            retry_after_seconds.map_or_else(
+                || "GitHub rate limited the Skill update".to_owned(),
+                |seconds| {
+                    format!("GitHub rate limited the Skill update. Retry after {seconds} seconds")
+                },
+            ),
+        ),
+        RemoteComparisonOutcome::ProviderFailure { status } => CommandError::operation(
+            "SERVICE_UNAVAILABLE",
+            status.map_or_else(
+                || "GitHub comparison failed".to_owned(),
+                |status| format!("GitHub comparison returned HTTP {status}"),
+            ),
+        ),
+        RemoteComparisonOutcome::RequestFailure { code, message } => {
+            CommandError::operation(code, message)
+        }
+        RemoteComparisonOutcome::Ready { .. } => CommandError::operation(
+            "INVALID_RESPONSE",
+            "GitHub returned an impossible update relation",
+        ),
     }
 }
 

--- a/crates/skilld-command/src/local_store.rs
+++ b/crates/skilld-command/src/local_store.rs
@@ -62,6 +62,8 @@ pub struct PreparedStoreUpdate {
     pub locked_source: LockedSource,
     pub source_status: Option<SourceStatus>,
     pub targets: Vec<TargetInstall>,
+    pub expected_transaction_id: String,
+    pub expected_skill: LockedSkill,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -69,6 +71,7 @@ pub struct SkillView {
     pub name: String,
     pub canonical_path: PathBuf,
     pub skill: LockedSkill,
+    pub transaction_id: String,
 }
 
 #[derive(Debug)]
@@ -80,6 +83,7 @@ pub enum StoreError {
     InvalidSource(String),
     InvalidTargetPath(PathBuf),
     NotFound(String),
+    StalePlan(String),
     Unsupported(String),
 }
 
@@ -93,6 +97,7 @@ impl StoreError {
             Self::InvalidSource(_) => "INVALID_SOURCE",
             Self::InvalidTargetPath(_) => "INVALID_TARGET",
             Self::NotFound(_) => "SKILL_NOT_FOUND",
+            Self::StalePlan(_) => "PLAN_STALE",
             Self::Unsupported(_) => "UNSUPPORTED_HOST",
         }
     }
@@ -107,6 +112,7 @@ impl fmt::Display for StoreError {
             | Self::InvalidLockfile(message)
             | Self::InvalidSource(message)
             | Self::NotFound(message)
+            | Self::StalePlan(message)
             | Self::Unsupported(message) => formatter.write_str(message),
             Self::InvalidTargetPath(path) => {
                 write!(
@@ -180,6 +186,7 @@ impl LocalStore {
             name: name.to_string(),
             canonical_path: self.root.join(name.as_str()),
             skill,
+            transaction_id: document.transaction_id,
         })
     }
 
@@ -207,6 +214,7 @@ impl LocalStore {
             name: name.to_string(),
             canonical_path: self.root.join(name.as_str()),
             skill,
+            transaction_id: document.transaction_id,
         })
     }
 
@@ -445,28 +453,50 @@ impl LocalStore {
                 locked_source: update.locked_source,
                 source_status,
                 targets: update.targets,
+                expected_transaction_id: update.expected_transaction_id,
+                expected_skill: update.expected_skill,
             });
+        }
+        let expected_transaction_id = validated[0].expected_transaction_id.clone();
+        if validated
+            .iter()
+            .any(|update| update.expected_transaction_id != expected_transaction_id)
+        {
+            return Err(stale_update_plan());
         }
 
         self.prepare_root()?;
         let _lock = acquire_store_lock(&self.root)?;
         self.recover_locked(known_targets)?;
         let old_lock = self.read_lock()?;
+        if old_lock.transaction_id != expected_transaction_id {
+            return Err(stale_update_plan());
+        }
         let mut prepared = Vec::with_capacity(validated.len());
         for update in validated {
-            let old_skill = old_lock.skills.get(update.name.as_str());
-            self.verify_managed_state(&update.name, old_skill, known_targets)?;
+            let Some(old_skill) = old_lock.skills.get(update.name.as_str()) else {
+                return Err(stale_update_plan());
+            };
+            if old_skill != &update.expected_skill {
+                return Err(stale_update_plan());
+            }
+            self.verify_managed_state(&update.name, Some(old_skill), known_targets)?;
             let selected_targets = unique_target_installs(&update.targets);
             self.validate_target_changes(
                 &update.name,
-                old_skill,
+                Some(old_skill),
                 &selected_targets,
                 known_targets,
             )?;
             let canonical = self.root.join(update.name.as_str());
             prepared.push(BatchStoreUpdate {
                 canonical_had_existing: path_exists(&canonical)?,
-                changes: target_changes(&update.name, old_skill, &selected_targets, known_targets)?,
+                changes: target_changes(
+                    &update.name,
+                    Some(old_skill),
+                    &selected_targets,
+                    known_targets,
+                )?,
                 canonical,
                 update,
             });
@@ -996,6 +1026,8 @@ struct ValidatedStoreUpdate {
     locked_source: LockedSource,
     source_status: SourceStatus,
     targets: Vec<TargetInstall>,
+    expected_transaction_id: String,
+    expected_skill: LockedSkill,
 }
 
 #[derive(Clone, Debug)]
@@ -1577,6 +1609,10 @@ fn fs_error(error: io::Error) -> StoreError {
     } else {
         StoreError::Filesystem(error.to_string())
     }
+}
+
+fn stale_update_plan() -> StoreError {
+    StoreError::StalePlan("The Skill store changed while the update was preparing".to_owned())
 }
 
 fn normalize_path(path: &Path) -> PathBuf {

--- a/crates/skilld-command/src/local_store.rs
+++ b/crates/skilld-command/src/local_store.rs
@@ -15,6 +15,7 @@ use skilld_core::{
 };
 
 const JOURNAL_NAME: &str = ".skilld-transaction";
+#[cfg(not(target_os = "wasi"))]
 const LOCK_NAME: &str = ".skilld-store-lock";
 const LOCKFILE_NAME: &str = "skilld-lock.yaml";
 static TRANSACTION_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -55,6 +56,14 @@ pub struct TargetInstall {
     pub mode: InstallMode,
 }
 
+#[derive(Clone, Debug)]
+pub struct PreparedStoreUpdate {
+    pub source: PathBuf,
+    pub locked_source: LockedSource,
+    pub source_status: Option<SourceStatus>,
+    pub targets: Vec<TargetInstall>,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SkillView {
     pub name: String,
@@ -64,6 +73,7 @@ pub struct SkillView {
 
 #[derive(Debug)]
 pub enum StoreError {
+    AtomicUpdateUnavailable(String),
     CommittedCleanupPending(String),
     Conflict(String),
     Filesystem(String),
@@ -77,6 +87,7 @@ pub enum StoreError {
 impl StoreError {
     pub const fn code(&self) -> &'static str {
         match self {
+            Self::AtomicUpdateUnavailable(_) => "ATOMIC_UPDATE_UNAVAILABLE",
             Self::CommittedCleanupPending(_) => "COMMITTED_CLEANUP_PENDING",
             Self::Conflict(_) => "TARGET_CONFLICT",
             Self::Filesystem(_) => "SERVICE_UNAVAILABLE",
@@ -92,7 +103,8 @@ impl StoreError {
 impl fmt::Display for StoreError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::CommittedCleanupPending(message)
+            Self::AtomicUpdateUnavailable(message)
+            | Self::CommittedCleanupPending(message)
             | Self::Conflict(message)
             | Self::Filesystem(message)
             | Self::InvalidLockfile(message)
@@ -383,6 +395,37 @@ impl LocalStore {
         self.cleanup_committed(&journal, known_targets)
             .map_err(|error| StoreError::CommittedCleanupPending(error.to_string()))?;
         Ok(name)
+    }
+
+    pub fn apply_update_batch(
+        &self,
+        mut updates: Vec<PreparedStoreUpdate>,
+        known_targets: &[ResolvedTarget],
+    ) -> Result<Vec<SkillName>, StoreError> {
+        if updates.len() > 1 {
+            return Err(StoreError::AtomicUpdateUnavailable(
+                "Update one Skill at a time. Multi-Skill updates are unavailable.".to_owned(),
+            ));
+        }
+        let Some(update) = updates.pop() else {
+            return Ok(vec![]);
+        };
+        let name = match update.source_status {
+            Some(source_status) => self.install_from_with_status(
+                &update.source,
+                update.locked_source,
+                source_status,
+                &update.targets,
+                known_targets,
+            )?,
+            None => self.install_from(
+                &update.source,
+                update.locked_source,
+                &update.targets,
+                known_targets,
+            )?,
+        };
+        Ok(vec![name])
     }
 
     pub fn remove(

--- a/crates/skilld-command/src/local_store.rs
+++ b/crates/skilld-command/src/local_store.rs
@@ -73,7 +73,6 @@ pub struct SkillView {
 
 #[derive(Debug)]
 pub enum StoreError {
-    AtomicUpdateUnavailable(String),
     CommittedCleanupPending(String),
     Conflict(String),
     Filesystem(String),
@@ -87,7 +86,6 @@ pub enum StoreError {
 impl StoreError {
     pub const fn code(&self) -> &'static str {
         match self {
-            Self::AtomicUpdateUnavailable(_) => "ATOMIC_UPDATE_UNAVAILABLE",
             Self::CommittedCleanupPending(_) => "COMMITTED_CLEANUP_PENDING",
             Self::Conflict(_) => "TARGET_CONFLICT",
             Self::Filesystem(_) => "SERVICE_UNAVAILABLE",
@@ -103,8 +101,7 @@ impl StoreError {
 impl fmt::Display for StoreError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::AtomicUpdateUnavailable(message)
-            | Self::CommittedCleanupPending(message)
+            Self::CommittedCleanupPending(message)
             | Self::Conflict(message)
             | Self::Filesystem(message)
             | Self::InvalidLockfile(message)
@@ -300,17 +297,19 @@ impl LocalStore {
         let journal = Journal {
             version: 1,
             transaction_id: transaction.clone(),
-            operation: JournalOperation::Install,
-            skill: name.to_string(),
-            canonical_had_existing,
-            targets: changes
-                .iter()
-                .map(|change| JournalTarget {
-                    agent: change.agent,
-                    had_existing: change.had_existing,
-                    promote: change.install.is_some(),
-                })
-                .collect(),
+            skills: vec![JournalSkill {
+                operation: JournalOperation::Install,
+                skill: name.to_string(),
+                canonical_had_existing,
+                targets: changes
+                    .iter()
+                    .map(|change| JournalTarget {
+                        agent: change.agent,
+                        had_existing: change.had_existing,
+                        promote: change.install.is_some(),
+                    })
+                    .collect(),
+            }],
         };
         self.write_journal(&journal)?;
 
@@ -399,33 +398,181 @@ impl LocalStore {
 
     pub fn apply_update_batch(
         &self,
-        mut updates: Vec<PreparedStoreUpdate>,
+        updates: Vec<PreparedStoreUpdate>,
         known_targets: &[ResolvedTarget],
     ) -> Result<Vec<SkillName>, StoreError> {
-        if updates.len() > 1 {
-            return Err(StoreError::AtomicUpdateUnavailable(
-                "Update one Skill at a time. Multi-Skill updates are unavailable.".to_owned(),
-            ));
-        }
-        let Some(update) = updates.pop() else {
+        self.apply_update_batch_with_gate(updates, known_targets, &AllowTransaction)
+    }
+
+    pub fn apply_update_batch_with_gate<G: TransactionGate>(
+        &self,
+        updates: Vec<PreparedStoreUpdate>,
+        known_targets: &[ResolvedTarget],
+        gate: &G,
+    ) -> Result<Vec<SkillName>, StoreError> {
+        ensure_write_capability()?;
+        if updates.is_empty() {
             return Ok(vec![]);
-        };
-        let name = match update.source_status {
-            Some(source_status) => self.install_from_with_status(
-                &update.source,
-                update.locked_source,
+        }
+
+        let mut names = BTreeSet::new();
+        let mut validated = Vec::with_capacity(updates.len());
+        for update in updates {
+            let source = absolute_normalized(&update.source).map_err(fs_error)?;
+            validate_skill_source(&source)?;
+            let digest = hash_skill_tree(&source)?;
+            let source = resolve_path(&source).map_err(fs_error)?;
+            let name = SkillName::from_source(&source)
+                .map_err(|error| StoreError::InvalidSource(error.to_string()))?;
+            if !names.insert(name.clone()) {
+                return Err(StoreError::InvalidSource(format!(
+                    "Skill {name} appears more than once in the update"
+                )));
+            }
+            self.reject_overlap(&source)?;
+            let source_status = update.source_status.unwrap_or_else(|| SourceStatus::Local {
+                content_sha256: digest.clone(),
+            });
+            if source_digest(&source_status) != digest {
+                return Err(StoreError::InvalidSource(
+                    "the updated Skill does not match its source status".to_owned(),
+                ));
+            }
+            validated.push(ValidatedStoreUpdate {
+                name,
+                source,
+                digest,
+                locked_source: update.locked_source,
                 source_status,
-                &update.targets,
+                targets: update.targets,
+            });
+        }
+
+        self.prepare_root()?;
+        let _lock = acquire_store_lock(&self.root)?;
+        self.recover_locked(known_targets)?;
+        let old_lock = self.read_lock()?;
+        let mut prepared = Vec::with_capacity(validated.len());
+        for update in validated {
+            let old_skill = old_lock.skills.get(update.name.as_str());
+            self.verify_managed_state(&update.name, old_skill, known_targets)?;
+            let selected_targets = unique_target_installs(&update.targets);
+            self.validate_target_changes(
+                &update.name,
+                old_skill,
+                &selected_targets,
                 known_targets,
-            )?,
-            None => self.install_from(
-                &update.source,
-                update.locked_source,
-                &update.targets,
-                known_targets,
-            )?,
+            )?;
+            let canonical = self.root.join(update.name.as_str());
+            prepared.push(BatchStoreUpdate {
+                canonical_had_existing: path_exists(&canonical)?,
+                changes: target_changes(&update.name, old_skill, &selected_targets, known_targets)?,
+                canonical,
+                update,
+            });
+        }
+
+        let transaction = transaction_id();
+        let journal = Journal {
+            version: 1,
+            transaction_id: transaction.clone(),
+            skills: prepared
+                .iter()
+                .map(|prepared| JournalSkill {
+                    operation: JournalOperation::Install,
+                    skill: prepared.update.name.to_string(),
+                    canonical_had_existing: prepared.canonical_had_existing,
+                    targets: prepared
+                        .changes
+                        .iter()
+                        .map(|change| JournalTarget {
+                            agent: change.agent,
+                            had_existing: change.had_existing,
+                            promote: change.install.is_some(),
+                        })
+                        .collect(),
+                })
+                .collect(),
         };
-        Ok(vec![name])
+        self.write_journal(&journal)?;
+
+        let commit_result = (|| -> Result<(), StoreError> {
+            for prepared in &prepared {
+                let canonical_stage = stage_path(&prepared.canonical, &transaction)?;
+                copy_tree(&prepared.update.source, &canonical_stage)?;
+                for change in &prepared.changes {
+                    if let Some(install) = &change.install {
+                        stage_target(
+                            install,
+                            &prepared.canonical,
+                            &canonical_stage,
+                            &transaction,
+                            &prepared.update.digest,
+                        )?;
+                    }
+                }
+                if hash_skill_tree(&canonical_stage)? != prepared.update.digest {
+                    return Err(StoreError::InvalidSource(
+                        "the local Skill changed while copying".to_owned(),
+                    ));
+                }
+            }
+
+            for prepared in &prepared {
+                let canonical_backup = backup_path(&prepared.canonical, &transaction)?;
+                if prepared.canonical_had_existing {
+                    fs::rename(&prepared.canonical, canonical_backup).map_err(fs_error)?;
+                }
+                fs::rename(
+                    stage_path(&prepared.canonical, &transaction)?,
+                    &prepared.canonical,
+                )
+                .map_err(fs_error)?;
+                for change in &prepared.changes {
+                    let destination = change.target.destination(&prepared.update.name);
+                    if change.had_existing {
+                        fs::rename(&destination, backup_path(&destination, &transaction)?)
+                            .map_err(fs_error)?;
+                    }
+                    if change.install.is_some() {
+                        fs::rename(stage_path(&destination, &transaction)?, &destination)
+                            .map_err(fs_error)?;
+                    }
+                }
+            }
+
+            gate.before_lock_commit(&self.lockfile_path())?;
+            let mut new_lock = old_lock;
+            new_lock.transaction_id.clone_from(&transaction);
+            for prepared in &prepared {
+                new_lock.skills.insert(
+                    prepared.update.name.to_string(),
+                    LockedSkill {
+                        source: prepared.update.locked_source.clone(),
+                        source_status: prepared.update.source_status.clone(),
+                        targets: prepared
+                            .update
+                            .targets
+                            .iter()
+                            .map(|target| LockedTarget {
+                                agent: target.target.agent,
+                                mode: target.mode,
+                            })
+                            .collect(),
+                    },
+                );
+            }
+            self.write_lock_atomic(&new_lock, &transaction)
+        })();
+        if let Err(error) = commit_result {
+            return self.rollback_error(error, known_targets);
+        }
+        self.cleanup_committed(&journal, known_targets)
+            .map_err(|error| StoreError::CommittedCleanupPending(error.to_string()))?;
+        Ok(prepared
+            .into_iter()
+            .map(|prepared| prepared.update.name)
+            .collect())
     }
 
     pub fn remove(
@@ -463,10 +610,12 @@ impl LocalStore {
         let journal = Journal {
             version: 1,
             transaction_id: transaction.clone(),
-            operation: JournalOperation::Remove,
-            skill: name.to_string(),
-            canonical_had_existing,
-            targets: journal_targets,
+            skills: vec![JournalSkill {
+                operation: JournalOperation::Remove,
+                skill: name.to_string(),
+                canonical_had_existing,
+                targets: journal_targets,
+            }],
         };
         self.write_journal(&journal)?;
         if canonical_had_existing {
@@ -705,13 +854,24 @@ impl LocalStore {
         let journal: Journal =
             serde_json::from_slice(&fs::read(path.join("state.json")).map_err(fs_error)?)
                 .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
-        if journal.version != 1 || !valid_transaction_id(&journal.transaction_id) {
+        if journal.version != 1
+            || !valid_transaction_id(&journal.transaction_id)
+            || journal.skills.is_empty()
+        {
             return Err(StoreError::InvalidLockfile(
                 "invalid Skill transaction journal".to_owned(),
             ));
         }
-        SkillName::parse(journal.skill.clone())
-            .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
+        let mut names = BTreeSet::new();
+        for skill in &journal.skills {
+            let name = SkillName::parse(skill.skill.clone())
+                .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
+            if !names.insert(name) {
+                return Err(StoreError::InvalidLockfile(
+                    "the Skill transaction journal contains duplicate Skills".to_owned(),
+                ));
+            }
+        }
         Ok(Some(journal))
     }
 
@@ -759,24 +919,26 @@ impl LocalStore {
         journal: &Journal,
         known_targets: &[ResolvedTarget],
     ) -> Result<(), StoreError> {
-        let name = SkillName::parse(journal.skill.clone())
-            .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
-        let canonical = self.root.join(name.as_str());
-        restore_path(
-            &canonical,
-            &stage_path(&canonical, &journal.transaction_id)?,
-            &backup_path(&canonical, &journal.transaction_id)?,
-            journal.canonical_had_existing,
-        )?;
-        for target in &journal.targets {
-            let resolved = find_target(known_targets, target.agent)?;
-            let destination = resolved.destination(&name);
+        for skill in &journal.skills {
+            let name = SkillName::parse(skill.skill.clone())
+                .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
+            let canonical = self.root.join(name.as_str());
             restore_path(
-                &destination,
-                &stage_path(&destination, &journal.transaction_id)?,
-                &backup_path(&destination, &journal.transaction_id)?,
-                target.had_existing,
+                &canonical,
+                &stage_path(&canonical, &journal.transaction_id)?,
+                &backup_path(&canonical, &journal.transaction_id)?,
+                skill.canonical_had_existing,
             )?;
+            for target in &skill.targets {
+                let resolved = find_target(known_targets, target.agent)?;
+                let destination = resolved.destination(&name);
+                restore_path(
+                    &destination,
+                    &stage_path(&destination, &journal.transaction_id)?,
+                    &backup_path(&destination, &journal.transaction_id)?,
+                    target.had_existing,
+                )?;
+            }
         }
         restore_lockfile(&self.root, &journal.transaction_id)?;
         remove_path(&self.root.join(JOURNAL_NAME)).map_err(fs_error)
@@ -787,16 +949,20 @@ impl LocalStore {
         journal: &Journal,
         known_targets: &[ResolvedTarget],
     ) -> Result<(), StoreError> {
-        let name = SkillName::parse(journal.skill.clone())
-            .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
-        let canonical = self.root.join(name.as_str());
-        remove_path(&stage_path(&canonical, &journal.transaction_id)?).map_err(fs_error)?;
-        remove_path(&backup_path(&canonical, &journal.transaction_id)?).map_err(fs_error)?;
-        for target in &journal.targets {
-            let resolved = find_target(known_targets, target.agent)?;
-            let destination = resolved.destination(&name);
-            remove_path(&stage_path(&destination, &journal.transaction_id)?).map_err(fs_error)?;
-            remove_path(&backup_path(&destination, &journal.transaction_id)?).map_err(fs_error)?;
+        for skill in &journal.skills {
+            let name = SkillName::parse(skill.skill.clone())
+                .map_err(|error| StoreError::InvalidLockfile(error.to_string()))?;
+            let canonical = self.root.join(name.as_str());
+            remove_path(&stage_path(&canonical, &journal.transaction_id)?).map_err(fs_error)?;
+            remove_path(&backup_path(&canonical, &journal.transaction_id)?).map_err(fs_error)?;
+            for target in &skill.targets {
+                let resolved = find_target(known_targets, target.agent)?;
+                let destination = resolved.destination(&name);
+                remove_path(&stage_path(&destination, &journal.transaction_id)?)
+                    .map_err(fs_error)?;
+                remove_path(&backup_path(&destination, &journal.transaction_id)?)
+                    .map_err(fs_error)?;
+            }
         }
         remove_path(
             &self
@@ -822,11 +988,35 @@ struct TargetChange {
     install: Option<TargetInstall>,
 }
 
+#[derive(Clone, Debug)]
+struct ValidatedStoreUpdate {
+    name: SkillName,
+    source: PathBuf,
+    digest: String,
+    locked_source: LockedSource,
+    source_status: SourceStatus,
+    targets: Vec<TargetInstall>,
+}
+
+#[derive(Clone, Debug)]
+struct BatchStoreUpdate {
+    update: ValidatedStoreUpdate,
+    canonical: PathBuf,
+    canonical_had_existing: bool,
+    changes: Vec<TargetChange>,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 struct Journal {
     version: u8,
     transaction_id: String,
+    skills: Vec<JournalSkill>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct JournalSkill {
     operation: JournalOperation,
     skill: String,
     canonical_had_existing: bool,

--- a/crates/skilld-command/src/output.rs
+++ b/crates/skilld-command/src/output.rs
@@ -1,6 +1,6 @@
 use clap::error::ErrorKind;
 use serde::Serialize;
-use skilld_core::UpdateCheckV1;
+use skilld_core::UpdatePlanV1;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::{CommandError, CommandErrorKind};
@@ -106,7 +106,7 @@ pub(crate) fn render_display(kind: ErrorKind, path: &str, text: &str) -> Vec<u8>
 }
 
 pub(crate) fn render_update_check(
-    outcome: &UpdateCheckV1,
+    outcome: &UpdatePlanV1,
     mode: OutputMode,
 ) -> Result<Vec<u8>, CommandError> {
     if mode != OutputMode::JsonV1 {

--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -1,17 +1,20 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::sync::Arc;
+#[cfg(not(target_os = "wasi"))]
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 use skilld_core::{
-    ArtifactAttestation, LockedSource, PreparedFile, RemoteError, RemoteSelector,
-    RepositoryVisibility, SearchResponse, SourceRef, SourceRequest, SourceSelector, SourceStatus,
-    TrustedRoot, TrustedRootPin, VerifiedTrustedRoot, parse_search_response,
-    prepare_unverified_files, verify_artifact, verify_attestation, verify_trusted_root,
+    ArtifactAttestation, CommitAuthor, CommitSha, CommitSummary, LockedSource, PreparedFile,
+    RemoteError, RemoteSelector, RepositoryVisibility, SearchResponse, SourceRef, SourceRequest,
+    SourceSelector, SourceStatus, TrustedRoot, TrustedRootPin, VerifiedTrustedRoot,
+    parse_search_response, prepare_unverified_files, verify_artifact, verify_attestation,
+    verify_trusted_root,
 };
 use url::Url;
 
@@ -22,6 +25,14 @@ const DIRECT_BLOB_LIMIT: usize = 12 * 1024 * 1024;
 const MAX_REDIRECTS: usize = 3;
 const MAX_RETRIES: usize = 2;
 const MAX_POLLS: usize = 120;
+const MAX_UPDATE_COMPARISONS: usize = 500;
+const UPDATE_SERVICE_BATCH: usize = 50;
+#[cfg(not(target_os = "wasi"))]
+const UPDATE_CONCURRENCY: usize = 4;
+const UPDATE_COMMITS_PER_PAGE: usize = 100;
+const MAX_UPDATE_COMMITS: usize = 500;
+const GITHUB_API_VERSION: &str = "2026-03-10";
+const MAX_SAFE_INTEGER: u64 = 9_007_199_254_740_991;
 const RESOLUTION_TIMEOUT_MS: u64 = 60 * 1_000;
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -240,6 +251,89 @@ pub struct PreparedRemoteSkill {
     pub source_status: SourceStatus,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RemoteComparisonAccess {
+    PublicGithub,
+    Hosted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteUpdateComparison {
+    pub id: String,
+    pub owner: String,
+    pub repository: String,
+    pub base_sha: CommitSha,
+    pub head_sha: CommitSha,
+    pub access: RemoteComparisonAccess,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteLatestCommit {
+    pub commit_sha: CommitSha,
+    pub access: RemoteComparisonAccess,
+}
+
+impl RemoteUpdateComparison {
+    pub fn new(
+        id: impl Into<String>,
+        owner: impl Into<String>,
+        repository: impl Into<String>,
+        base_sha: CommitSha,
+        head_sha: CommitSha,
+        access: RemoteComparisonAccess,
+    ) -> Result<Self, RemoteError> {
+        let comparison = Self {
+            id: id.into(),
+            owner: owner.into(),
+            repository: repository.into(),
+            base_sha,
+            head_sha,
+            access,
+        };
+        validate_update_comparison(&comparison)?;
+        Ok(comparison)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RemoteComparisonRelation {
+    Ahead,
+    Behind,
+    Diverged,
+    Identical,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RemoteComparisonOutcome {
+    Ready {
+        relation: RemoteComparisonRelation,
+        commits: Vec<CommitSummary>,
+        total: u64,
+        truncated: bool,
+        compare_url: String,
+    },
+    NotFound,
+    InvalidComparison,
+    RateLimited {
+        retry_after_seconds: Option<u64>,
+        reset_at: Option<String>,
+    },
+    ProviderFailure {
+        status: Option<u16>,
+    },
+    RequestFailure {
+        code: &'static str,
+        message: String,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RemoteUpdateResult {
+    pub id: String,
+    pub outcome: RemoteComparisonOutcome,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RemoteSourceState {
     Current,
@@ -258,12 +352,283 @@ pub trait RemoteProvider: Send + Sync {
         direct: bool,
     ) -> Result<PreparedRemoteSkill, RemoteError>;
 
+    fn prepare_exact(
+        &self,
+        selector: &RemoteSelector,
+        expected_commit: &CommitSha,
+        direct: bool,
+    ) -> Result<PreparedRemoteSkill, RemoteError>;
+
     fn source_state(
         &self,
         selector: &RemoteSelector,
         artifact_id: &str,
         commit_sha: &str,
     ) -> Result<RemoteSourceState, RemoteError>;
+
+    fn latest_commit(
+        &self,
+        selector: &RemoteSelector,
+        direct: bool,
+    ) -> Result<RemoteLatestCommit, RemoteError>;
+
+    fn compare_updates(
+        &self,
+        comparisons: &[RemoteUpdateComparison],
+    ) -> Result<Vec<RemoteUpdateResult>, RemoteError>;
+}
+
+#[derive(Clone)]
+enum UpdateComparisonTask {
+    Public {
+        index: usize,
+        input: RemoteUpdateComparison,
+    },
+    Hosted {
+        inputs: Vec<(usize, RemoteUpdateComparison)>,
+    },
+}
+
+impl UpdateComparisonTask {
+    fn indexed_inputs(&self) -> Vec<(usize, &RemoteUpdateComparison)> {
+        match self {
+            Self::Public { index, input } => vec![(*index, input)],
+            Self::Hosted { inputs } => inputs
+                .iter()
+                .map(|(index, input)| (*index, input))
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ComparisonPageReady {
+    relation: RemoteComparisonRelation,
+    commits: Vec<CommitSummary>,
+    total: u64,
+    page: usize,
+}
+
+enum ComparisonPage {
+    Ready(ComparisonPageReady),
+    NotFound,
+    InvalidComparison,
+    RateLimited {
+        retry_after_seconds: Option<u64>,
+        reset_at: Option<String>,
+    },
+    ProviderFailure {
+        status: Option<u16>,
+    },
+}
+
+impl ComparisonPage {
+    fn into_outcome(self) -> RemoteComparisonOutcome {
+        match self {
+            Self::Ready(_) => unreachable!("ready pages are handled before conversion"),
+            Self::NotFound => RemoteComparisonOutcome::NotFound,
+            Self::InvalidComparison => RemoteComparisonOutcome::InvalidComparison,
+            Self::RateLimited {
+                retry_after_seconds,
+                reset_at,
+            } => RemoteComparisonOutcome::RateLimited {
+                retry_after_seconds,
+                reset_at,
+            },
+            Self::ProviderFailure { status } => RemoteComparisonOutcome::ProviderFailure { status },
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HostedComparisonsRequest<'a> {
+    comparisons: Vec<HostedComparison<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HostedComparison<'a> {
+    id: &'a str,
+    owner: &'a str,
+    repository: &'a str,
+    base_sha: &'a str,
+    head_sha: &'a str,
+}
+
+impl<'a> From<&'a RemoteUpdateComparison> for HostedComparison<'a> {
+    fn from(input: &'a RemoteUpdateComparison) -> Self {
+        Self {
+            id: &input.id,
+            owner: &input.owner,
+            repository: &input.repository,
+            base_sha: input.base_sha.as_str(),
+            head_sha: input.head_sha.as_str(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HostedComparisonsResponse {
+    results: Vec<HostedComparisonResult>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, tag = "_tag", rename_all = "snake_case")]
+enum HostedComparisonResult {
+    Ready {
+        id: String,
+        owner: String,
+        repository: String,
+        #[serde(rename = "baseSha")]
+        base_sha: String,
+        #[serde(rename = "headSha")]
+        head_sha: String,
+        relation: RemoteComparisonRelation,
+        commits: Vec<HostedCommit>,
+        total: u64,
+        truncated: bool,
+        #[serde(rename = "compareUrl")]
+        compare_url: String,
+    },
+    NotFound {
+        id: String,
+        owner: String,
+        repository: String,
+        #[serde(rename = "baseSha")]
+        base_sha: String,
+        #[serde(rename = "headSha")]
+        head_sha: String,
+    },
+    InvalidComparison {
+        id: String,
+        owner: String,
+        repository: String,
+        #[serde(rename = "baseSha")]
+        base_sha: String,
+        #[serde(rename = "headSha")]
+        head_sha: String,
+    },
+    RateLimited {
+        id: String,
+        owner: String,
+        repository: String,
+        #[serde(rename = "baseSha")]
+        base_sha: String,
+        #[serde(rename = "headSha")]
+        head_sha: String,
+        #[serde(rename = "retryAfterSeconds")]
+        retry_after_seconds: Option<u64>,
+        #[serde(rename = "resetAt")]
+        reset_at: Option<String>,
+    },
+    ProviderFailure {
+        id: String,
+        owner: String,
+        repository: String,
+        #[serde(rename = "baseSha")]
+        base_sha: String,
+        #[serde(rename = "headSha")]
+        head_sha: String,
+        status: Option<u16>,
+    },
+}
+
+impl HostedComparisonResult {
+    fn identity(&self) -> (&str, &str, &str, &str, &str) {
+        match self {
+            Self::Ready {
+                id,
+                owner,
+                repository,
+                base_sha,
+                head_sha,
+                ..
+            }
+            | Self::NotFound {
+                id,
+                owner,
+                repository,
+                base_sha,
+                head_sha,
+            }
+            | Self::InvalidComparison {
+                id,
+                owner,
+                repository,
+                base_sha,
+                head_sha,
+            }
+            | Self::RateLimited {
+                id,
+                owner,
+                repository,
+                base_sha,
+                head_sha,
+                ..
+            }
+            | Self::ProviderFailure {
+                id,
+                owner,
+                repository,
+                base_sha,
+                head_sha,
+                ..
+            } => (id, owner, repository, base_sha, head_sha),
+        }
+    }
+
+    fn id(&self) -> &str {
+        self.identity().0
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+struct HostedCommit {
+    sha: String,
+    subject: String,
+    timestamp: String,
+    author: HostedCommitAuthor,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HostedCommitAuthor {
+    name: String,
+    login: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GithubComparisonWire {
+    status: RemoteComparisonRelation,
+    total_commits: u64,
+    commits: Vec<GithubComparisonCommit>,
+}
+
+#[derive(Deserialize)]
+struct GithubComparisonCommit {
+    sha: String,
+    commit: GithubCommitDetails,
+    author: Option<GithubCommitAuthor>,
+}
+
+#[derive(Deserialize)]
+struct GithubCommitDetails {
+    message: String,
+    author: GithubGitAuthor,
+}
+
+#[derive(Deserialize)]
+struct GithubGitAuthor {
+    name: String,
+    date: String,
+}
+
+#[derive(Deserialize)]
+struct GithubCommitAuthor {
+    login: String,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -664,10 +1029,7 @@ impl SkilldRemote {
         let request = HttpRequest {
             method: HttpMethod::Get,
             url: url.to_owned(),
-            headers: vec![HttpHeader {
-                name: "accept".to_owned(),
-                value: HeaderValue::Public("application/vnd.github+json".to_owned()),
-            }],
+            headers: github_headers(),
             body: vec![],
             response_limit: limit,
         };
@@ -675,7 +1037,10 @@ impl SkilldRemote {
         parse_json(&response.body)
     }
 
-    fn direct(&self, selector: &RemoteSelector) -> Result<PreparedRemoteSkill, RemoteError> {
+    fn direct_commit(
+        &self,
+        selector: &RemoteSelector,
+    ) -> Result<(String, String, GithubCommit), RemoteError> {
         if !selector.is_explicit_github() {
             return Err(RemoteError::new(
                 "DIRECT_SOURCE_REQUIRED",
@@ -698,7 +1063,7 @@ impl SkilldRemote {
         if repository.private {
             return Err(RemoteError::new(
                 "DIRECT_PRIVATE_UNSUPPORTED",
-                "--direct cannot install from a private Repository",
+                "--direct cannot use a private Repository",
             ));
         }
         let reference = source.r#ref.as_ref().map_or_else(
@@ -714,6 +1079,218 @@ impl SkilldRemote {
         if !valid_sha(&commit.sha) || !valid_sha(&commit.commit.tree.sha) {
             return Err(invalid_github());
         }
+        Ok((repository_url, skill_path.clone(), commit))
+    }
+
+    fn public_comparison(
+        &self,
+        input: &RemoteUpdateComparison,
+    ) -> Result<RemoteComparisonOutcome, RemoteError> {
+        let first = self.github_comparison_page(input, 1)?;
+        let ComparisonPage::Ready(first) = first else {
+            return Ok(first.into_outcome());
+        };
+        let relation = first.relation;
+        let total = first.total;
+        let first_included_index = total.saturating_sub(MAX_UPDATE_COMMITS as u64);
+        let first_included_page =
+            usize::try_from(first_included_index / UPDATE_COMMITS_PER_PAGE as u64 + 1)
+                .map_err(|_| invalid_update_response())?;
+        let first_page_offset =
+            usize::try_from(first_included_index % UPDATE_COMMITS_PER_PAGE as u64)
+                .map_err(|_| invalid_update_response())?;
+        let last_included_page =
+            usize::try_from(total.div_ceil(UPDATE_COMMITS_PER_PAGE as u64).max(1))
+                .map_err(|_| invalid_update_response())?;
+        let mut commits = Vec::new();
+        for page in first_included_page..=last_included_page {
+            let page = if page == 1 {
+                ComparisonPage::Ready(first.clone())
+            } else {
+                self.github_comparison_page(input, page)?
+            };
+            let ComparisonPage::Ready(page) = page else {
+                return Ok(page.into_outcome());
+            };
+            if page.relation != relation || page.total != total {
+                return Err(invalid_update_response());
+            }
+            let offset = if page.page == first_included_page {
+                first_page_offset
+            } else {
+                0
+            };
+            commits.extend(page.commits.into_iter().skip(offset));
+        }
+        if commits.len() > MAX_UPDATE_COMMITS {
+            commits.drain(..commits.len() - MAX_UPDATE_COMMITS);
+        }
+        let compare_url = github_compare_url(input);
+        Ok(RemoteComparisonOutcome::Ready {
+            relation,
+            truncated: u64::try_from(commits.len()).unwrap_or(u64::MAX) < total,
+            commits,
+            total,
+            compare_url,
+        })
+    }
+
+    fn github_comparison_page(
+        &self,
+        input: &RemoteUpdateComparison,
+        page: usize,
+    ) -> Result<ComparisonPage, RemoteError> {
+        let url = format!(
+            "https://api.github.com/repos/{}/{}/compare/{}...{}?per_page={UPDATE_COMMITS_PER_PAGE}&page={page}",
+            path_segment(&input.owner),
+            path_segment(&input.repository),
+            input.base_sha.as_str(),
+            input.head_sha.as_str(),
+        );
+        let request = HttpRequest {
+            method: HttpMethod::Get,
+            url,
+            headers: github_headers(),
+            body: vec![],
+            response_limit: JSON_LIMIT,
+        };
+        let response = self.execute_comparison_request(request, AllowedOrigin::Github)?;
+        if is_rate_limited(&response) {
+            return Ok(ComparisonPage::RateLimited {
+                retry_after_seconds: bounded_retry_after(&response),
+                reset_at: None,
+            });
+        }
+        if response.status == 404 {
+            return Ok(ComparisonPage::NotFound);
+        }
+        if matches!(response.status, 409 | 422) {
+            return Ok(ComparisonPage::InvalidComparison);
+        }
+        if !(200..300).contains(&response.status) {
+            return Ok(ComparisonPage::ProviderFailure {
+                status: Some(response.status),
+            });
+        }
+        let wire: GithubComparisonWire = parse_json(&response.body)?;
+        if wire.commits.len() > UPDATE_COMMITS_PER_PAGE || wire.total_commits > MAX_SAFE_INTEGER {
+            return Err(invalid_update_response());
+        }
+        let commits = wire
+            .commits
+            .into_iter()
+            .map(|commit| present_commit(input, commit))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(ComparisonPage::Ready(ComparisonPageReady {
+            relation: wire.status,
+            total: wire.total_commits,
+            commits,
+            page,
+        }))
+    }
+
+    fn hosted_comparisons(
+        &self,
+        inputs: &[RemoteUpdateComparison],
+    ) -> Result<Vec<RemoteUpdateResult>, RemoteError> {
+        let mut headers = self.authenticated_headers()?;
+        if !headers.iter().any(|header| header.name == "authorization") {
+            return Err(RemoteError::new(
+                "AUTH_REQUIRED",
+                "Hosted update checks need an account",
+            ));
+        }
+        headers.extend(json_headers());
+        let body = serde_json::to_vec(&HostedComparisonsRequest {
+            comparisons: inputs.iter().map(HostedComparison::from).collect(),
+        })
+        .map_err(|_| {
+            RemoteError::new("INVALID_SOURCE", "Update comparisons could not be encoded")
+        })?;
+        let request = HttpRequest {
+            method: HttpMethod::Post,
+            url: self.service_url("/api/v1/update-plans")?.into(),
+            headers,
+            body,
+            response_limit: JSON_LIMIT,
+        };
+        let response = self.execute(request, AllowedOrigin::Service(self.endpoint.clone()))?;
+        let wire: HostedComparisonsResponse = parse_json(&response.body)?;
+        if wire.results.len() != inputs.len() || wire.results.len() > UPDATE_SERVICE_BATCH {
+            return Err(invalid_update_response());
+        }
+        let mut by_id = wire
+            .results
+            .into_iter()
+            .map(|result| {
+                let id = result.id().to_owned();
+                let input = inputs
+                    .iter()
+                    .find(|input| input.id == id)
+                    .ok_or_else(invalid_update_response)?;
+                validate_hosted_identity(input, &result)?;
+                let outcome = present_hosted_outcome(input, result)?;
+                Ok((id, outcome))
+            })
+            .collect::<Result<BTreeMap<_, _>, RemoteError>>()?;
+        if by_id.len() != inputs.len() {
+            return Err(invalid_update_response());
+        }
+        inputs
+            .iter()
+            .map(|input| {
+                by_id
+                    .remove(&input.id)
+                    .map(|outcome| RemoteUpdateResult {
+                        id: input.id.clone(),
+                        outcome,
+                    })
+                    .ok_or_else(invalid_update_response)
+            })
+            .collect()
+    }
+
+    fn execute_comparison_request(
+        &self,
+        request: HttpRequest,
+        allowed: AllowedOrigin,
+    ) -> Result<HttpResponse, RemoteError> {
+        validate_request_url(&request.url, &allowed)?;
+        let mut attempts = 0;
+        loop {
+            if self.cancellation.is_cancelled() {
+                return Err(cancelled());
+            }
+            match self
+                .adapter
+                .send(&request, self.cancellation.as_ref(), None)
+            {
+                Ok(response) => {
+                    if response.body.len() > request.response_limit {
+                        return Err(RemoteError::new(
+                            "RESPONSE_TOO_LARGE",
+                            "A comparison response exceeded its limit",
+                        ));
+                    }
+                    if matches!(response.status, 301 | 302 | 303 | 307 | 308) {
+                        return Err(RemoteError::new(
+                            "REDIRECT_REJECTED",
+                            "A comparison response used a redirect",
+                        ));
+                    }
+                    return Ok(response);
+                }
+                Err(error) if error.code == "HTTP_TRANSPORT" && attempts < MAX_RETRIES => {
+                    attempts += 1;
+                    self.sleep(Duration::from_millis(100 * attempts as u64), None)?;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn direct(&self, selector: &RemoteSelector) -> Result<PreparedRemoteSkill, RemoteError> {
+        let (repository_url, skill_path, commit) = self.direct_commit(selector)?;
         let tree_url = format!(
             "{repository_url}/git/trees/{}?recursive=1",
             path_segment(&commit.commit.tree.sha)
@@ -774,7 +1351,7 @@ impl SkilldRemote {
             locked_source: LockedSource::Remote {
                 source: selector.canonical(),
                 commit_sha: commit.sha,
-                skill_path: skill_path.clone(),
+                skill_path,
             },
             source_status: SourceStatus::Unverified {
                 content_sha256: installed_sha256.clone(),
@@ -848,6 +1425,40 @@ impl RemoteProvider for SkilldRemote {
         })
     }
 
+    fn prepare_exact(
+        &self,
+        selector: &RemoteSelector,
+        expected_commit: &CommitSha,
+        direct: bool,
+    ) -> Result<PreparedRemoteSkill, RemoteError> {
+        let mut source = selector.source().clone();
+        source.r#ref = Some(SourceRef::Commit {
+            value: expected_commit.as_str().to_owned(),
+        });
+        let exact = match selector {
+            RemoteSelector::Skilld(_) => RemoteSelector::Skilld(source),
+            RemoteSelector::Github(_) => RemoteSelector::Github(source),
+        };
+        let mut prepared = self.prepare(&exact, direct)?;
+        let LockedSource::Remote {
+            source, commit_sha, ..
+        } = &mut prepared.locked_source
+        else {
+            return Err(RemoteError::new(
+                "SOURCE_MISMATCH",
+                "The prepared update has no remote source",
+            ));
+        };
+        if commit_sha != expected_commit.as_str() {
+            return Err(RemoteError::new(
+                "SOURCE_MISMATCH",
+                "The prepared update changed its exact commit",
+            ));
+        }
+        *source = selector.canonical();
+        Ok(prepared)
+    }
+
     fn source_state(
         &self,
         selector: &RemoteSelector,
@@ -868,6 +1479,439 @@ impl RemoteProvider for SkilldRemote {
             })
         }
     }
+
+    fn latest_commit(
+        &self,
+        selector: &RemoteSelector,
+        direct: bool,
+    ) -> Result<RemoteLatestCommit, RemoteError> {
+        if direct {
+            let commit_sha = self.direct_commit(selector).and_then(|(_, _, commit)| {
+                CommitSha::parse(commit.sha).map_err(|_| invalid_github())
+            })?;
+            return Ok(RemoteLatestCommit {
+                commit_sha,
+                access: RemoteComparisonAccess::PublicGithub,
+            });
+        }
+        let descriptor = self.resolve(selector.source())?;
+        let root = self.verified_root()?;
+        verify_attestation(&descriptor.attestation, &root)?;
+        let access = match descriptor.visibility {
+            RepositoryVisibility::Public => RemoteComparisonAccess::PublicGithub,
+            RepositoryVisibility::Private => RemoteComparisonAccess::Hosted,
+        };
+        let commit_sha = CommitSha::parse(descriptor.attestation.source.commit_sha)
+            .map_err(|_| invalid_update_response())?;
+        Ok(RemoteLatestCommit { commit_sha, access })
+    }
+
+    fn compare_updates(
+        &self,
+        comparisons: &[RemoteUpdateComparison],
+    ) -> Result<Vec<RemoteUpdateResult>, RemoteError> {
+        if comparisons.is_empty() || comparisons.len() > MAX_UPDATE_COMPARISONS {
+            return Err(RemoteError::new(
+                "INVALID_UPDATE_COMPARISON",
+                "Update checks need from 1 to 500 comparisons",
+            ));
+        }
+        let mut identifiers = BTreeSet::new();
+        for comparison in comparisons {
+            validate_update_comparison(comparison)?;
+            if !identifiers.insert(comparison.id.as_str()) {
+                return Err(RemoteError::new(
+                    "INVALID_UPDATE_COMPARISON",
+                    "Update comparison identifiers must be unique",
+                ));
+            }
+        }
+        let mut tasks = comparisons
+            .iter()
+            .enumerate()
+            .filter(|(_, input)| input.access == RemoteComparisonAccess::PublicGithub)
+            .map(|(index, input)| UpdateComparisonTask::Public {
+                index,
+                input: input.clone(),
+            })
+            .collect::<Vec<_>>();
+        let hosted = comparisons
+            .iter()
+            .enumerate()
+            .filter(|(_, input)| input.access == RemoteComparisonAccess::Hosted)
+            .map(|(index, input)| (index, input.clone()))
+            .collect::<Vec<_>>();
+        tasks.extend(hosted.chunks(UPDATE_SERVICE_BATCH).map(|chunk| {
+            UpdateComparisonTask::Hosted {
+                inputs: chunk.to_vec(),
+            }
+        }));
+        let mut indexed = run_update_comparison_tasks(self, &tasks);
+        indexed.sort_by_key(|(index, _)| *index);
+        if indexed.len() != comparisons.len()
+            || indexed
+                .iter()
+                .enumerate()
+                .any(|(expected, (actual, _))| expected != *actual)
+        {
+            return Err(RemoteError::new(
+                "INVALID_RESPONSE",
+                "Update comparison results were incomplete",
+            ));
+        }
+        Ok(indexed.into_iter().map(|(_, result)| result).collect())
+    }
+}
+
+fn run_update_comparison_tasks(
+    remote: &SkilldRemote,
+    tasks: &[UpdateComparisonTask],
+) -> Vec<(usize, RemoteUpdateResult)> {
+    #[cfg(target_os = "wasi")]
+    {
+        return tasks
+            .iter()
+            .flat_map(|task| execute_update_comparison_task(remote, task))
+            .collect();
+    }
+    #[cfg(not(target_os = "wasi"))]
+    {
+        let next = AtomicU64::new(0);
+        let results = Mutex::new(Vec::new());
+        std::thread::scope(|scope| {
+            for _ in 0..UPDATE_CONCURRENCY.min(tasks.len()) {
+                scope.spawn(|| {
+                    loop {
+                        let index = usize::try_from(next.fetch_add(1, Ordering::Relaxed))
+                            .unwrap_or(usize::MAX);
+                        let Some(task) = tasks.get(index) else {
+                            break;
+                        };
+                        results
+                            .lock()
+                            .expect("comparison result lock is available")
+                            .extend(execute_update_comparison_task(remote, task));
+                    }
+                });
+            }
+        });
+        results
+            .into_inner()
+            .expect("comparison result lock is available")
+    }
+}
+
+fn execute_update_comparison_task(
+    remote: &SkilldRemote,
+    task: &UpdateComparisonTask,
+) -> Vec<(usize, RemoteUpdateResult)> {
+    let outcome = match task {
+        UpdateComparisonTask::Public { index, input } => {
+            remote.public_comparison(input).map(|outcome| {
+                vec![(
+                    *index,
+                    RemoteUpdateResult {
+                        id: input.id.clone(),
+                        outcome,
+                    },
+                )]
+            })
+        }
+        UpdateComparisonTask::Hosted { inputs } => remote
+            .hosted_comparisons(
+                &inputs
+                    .iter()
+                    .map(|(_, input)| input.clone())
+                    .collect::<Vec<_>>(),
+            )
+            .map(|results| {
+                inputs
+                    .iter()
+                    .zip(results)
+                    .map(|((index, _), result)| (*index, result))
+                    .collect()
+            }),
+    };
+    outcome.unwrap_or_else(|error| {
+        task.indexed_inputs()
+            .into_iter()
+            .map(|(index, input)| {
+                (
+                    index,
+                    RemoteUpdateResult {
+                        id: input.id.clone(),
+                        outcome: RemoteComparisonOutcome::RequestFailure {
+                            code: error.code,
+                            message: error.message.clone(),
+                        },
+                    },
+                )
+            })
+            .collect()
+    })
+}
+
+fn validate_update_comparison(input: &RemoteUpdateComparison) -> Result<(), RemoteError> {
+    let valid_id = !input.id.is_empty()
+        && input.id.len() <= 200
+        && input.id.bytes().all(|byte| {
+            byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'/' | b'@' | b':')
+        });
+    let valid_owner = !input.owner.is_empty()
+        && input.owner.len() <= 39
+        && input
+            .owner
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-');
+    let valid_repository = !input.repository.is_empty()
+        && input.repository.len() <= 100
+        && !matches!(input.repository.as_str(), "." | "..")
+        && !input.repository.ends_with(".git")
+        && input
+            .repository
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if valid_id && valid_owner && valid_repository {
+        Ok(())
+    } else {
+        Err(RemoteError::new(
+            "INVALID_UPDATE_COMPARISON",
+            "An update comparison identity is invalid",
+        ))
+    }
+}
+
+fn validate_hosted_identity(
+    input: &RemoteUpdateComparison,
+    result: &HostedComparisonResult,
+) -> Result<(), RemoteError> {
+    let (id, owner, repository, base_sha, head_sha) = result.identity();
+    if id == input.id
+        && owner.eq_ignore_ascii_case(&input.owner)
+        && repository.eq_ignore_ascii_case(&input.repository)
+        && base_sha == input.base_sha.as_str()
+        && head_sha == input.head_sha.as_str()
+    {
+        Ok(())
+    } else {
+        Err(invalid_update_response())
+    }
+}
+
+fn present_hosted_outcome(
+    input: &RemoteUpdateComparison,
+    result: HostedComparisonResult,
+) -> Result<RemoteComparisonOutcome, RemoteError> {
+    match result {
+        HostedComparisonResult::Ready {
+            relation,
+            commits,
+            total,
+            truncated,
+            compare_url,
+            ..
+        } => {
+            if commits.len() > MAX_UPDATE_COMMITS
+                || total > MAX_SAFE_INTEGER
+                || u64::try_from(commits.len()).unwrap_or(u64::MAX) > total
+                || truncated != (u64::try_from(commits.len()).unwrap_or(u64::MAX) < total)
+                || compare_url != github_compare_url(input)
+            {
+                return Err(invalid_update_response());
+            }
+            Ok(RemoteComparisonOutcome::Ready {
+                relation,
+                commits: commits
+                    .into_iter()
+                    .map(|commit| present_hosted_commit(input, commit))
+                    .collect::<Result<_, _>>()?,
+                total,
+                truncated,
+                compare_url,
+            })
+        }
+        HostedComparisonResult::NotFound { .. } => Ok(RemoteComparisonOutcome::NotFound),
+        HostedComparisonResult::InvalidComparison { .. } => {
+            Ok(RemoteComparisonOutcome::InvalidComparison)
+        }
+        HostedComparisonResult::RateLimited {
+            retry_after_seconds,
+            reset_at,
+            ..
+        } => {
+            if retry_after_seconds.is_some_and(|seconds| seconds > 604_800)
+                || reset_at
+                    .as_deref()
+                    .is_some_and(|value| value.len() > 64 || value.chars().any(is_unsafe_terminal))
+            {
+                return Err(invalid_update_response());
+            }
+            Ok(RemoteComparisonOutcome::RateLimited {
+                retry_after_seconds,
+                reset_at,
+            })
+        }
+        HostedComparisonResult::ProviderFailure { status, .. } => {
+            if status.is_some_and(|status| !(100..=599).contains(&status)) {
+                return Err(invalid_update_response());
+            }
+            Ok(RemoteComparisonOutcome::ProviderFailure { status })
+        }
+    }
+}
+
+fn present_hosted_commit(
+    input: &RemoteUpdateComparison,
+    commit: HostedCommit,
+) -> Result<CommitSummary, RemoteError> {
+    if commit.subject.is_empty()
+        || commit.subject.chars().count() > 500
+        || commit.author.name.is_empty()
+        || commit.author.name.chars().count() > 200
+        || commit
+            .author
+            .login
+            .as_deref()
+            .is_some_and(|login| login.is_empty() || login.chars().count() > 100)
+        || !valid_timestamp(&commit.timestamp)
+    {
+        return Err(invalid_update_response());
+    }
+    let sha = CommitSha::parse(commit.sha).map_err(|_| invalid_update_response())?;
+    Ok(CommitSummary {
+        url: github_commit_url(input, sha.as_str()),
+        sha,
+        subject: sanitize_line(&commit.subject, 500, "No commit subject"),
+        author: CommitAuthor {
+            name: sanitize_line(&commit.author.name, 200, "Unknown"),
+            login: commit.author.login,
+        },
+        timestamp: commit.timestamp,
+    })
+}
+
+fn present_commit(
+    input: &RemoteUpdateComparison,
+    commit: GithubComparisonCommit,
+) -> Result<CommitSummary, RemoteError> {
+    let sha = CommitSha::parse(commit.sha).map_err(|_| invalid_update_response())?;
+    if !valid_timestamp(&commit.commit.author.date)
+        || commit
+            .author
+            .as_ref()
+            .is_some_and(|author| author.login.is_empty() || author.login.chars().count() > 100)
+    {
+        return Err(invalid_update_response());
+    }
+    Ok(CommitSummary {
+        url: github_commit_url(input, sha.as_str()),
+        sha,
+        subject: sanitize_line(&commit.commit.message, 500, "No commit subject"),
+        author: CommitAuthor {
+            name: sanitize_line(
+                &commit.commit.author.name,
+                200,
+                commit
+                    .author
+                    .as_ref()
+                    .map_or("Unknown", |author| author.login.as_str()),
+            ),
+            login: commit.author.map(|author| author.login),
+        },
+        timestamp: commit.commit.author.date,
+    })
+}
+
+fn sanitize_line(value: &str, maximum: usize, fallback: &str) -> String {
+    let line = value.split(['\r', '\n']).next().unwrap_or_default();
+    let sanitized = line
+        .chars()
+        .map(|character| {
+            if is_unsafe_terminal(character) {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    let value = if sanitized.is_empty() {
+        fallback
+    } else {
+        &sanitized
+    };
+    value.chars().take(maximum).collect()
+}
+
+fn is_unsafe_terminal(character: char) -> bool {
+    let code = u32::from(character);
+    character.is_control() || matches!(code, 0x200E | 0x200F | 0x202A..=0x202E | 0x2066..=0x2069)
+}
+
+fn valid_timestamp(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 64
+        && value.contains('T')
+        && value.ends_with('Z')
+        && !value.chars().any(is_unsafe_terminal)
+}
+
+fn github_headers() -> Vec<HttpHeader> {
+    vec![
+        HttpHeader {
+            name: "accept".to_owned(),
+            value: HeaderValue::Public("application/vnd.github+json".to_owned()),
+        },
+        HttpHeader {
+            name: "user-agent".to_owned(),
+            value: HeaderValue::Public("skilld".to_owned()),
+        },
+        HttpHeader {
+            name: "x-github-api-version".to_owned(),
+            value: HeaderValue::Public(GITHUB_API_VERSION.to_owned()),
+        },
+    ]
+}
+
+fn github_compare_url(input: &RemoteUpdateComparison) -> String {
+    format!(
+        "https://github.com/{}/{}/compare/{}...{}",
+        path_segment(&input.owner),
+        path_segment(&input.repository),
+        input.base_sha.as_str(),
+        input.head_sha.as_str(),
+    )
+}
+
+fn github_commit_url(input: &RemoteUpdateComparison, sha: &str) -> String {
+    format!(
+        "https://github.com/{}/{}/commit/{sha}",
+        path_segment(&input.owner),
+        path_segment(&input.repository),
+    )
+}
+
+fn is_rate_limited(response: &HttpResponse) -> bool {
+    response.status == 429
+        || (response.status == 403
+            && (response.header("x-ratelimit-remaining") == Some("0")
+                || response.header("retry-after").is_some()))
+}
+
+fn bounded_retry_after(response: &HttpResponse) -> Option<u64> {
+    response
+        .header("retry-after")
+        .and_then(|value| value.parse().ok())
+        .map(|seconds: u64| seconds.min(604_800))
+}
+
+fn invalid_update_response() -> RemoteError {
+    RemoteError::new(
+        "INVALID_RESPONSE",
+        "A comparison response violated its contract",
+    )
 }
 
 #[derive(Clone)]

--- a/crates/skilld-command/src/remote.rs
+++ b/crates/skilld-command/src/remote.rs
@@ -19,6 +19,7 @@ use skilld_core::{
 use url::Url;
 
 const JSON_LIMIT: usize = 8 * 1024 * 1024;
+const UPDATE_RESPONSE_LIMIT: usize = 64 * 1024 * 1024;
 const SEARCH_LIMIT: usize = 1024 * 1024;
 const ARTIFACT_LIMIT: usize = 64 * 1024 * 1024;
 const DIRECT_BLOB_LIMIT: usize = 12 * 1024 * 1024;
@@ -308,6 +309,8 @@ pub enum RemoteComparisonRelation {
 pub enum RemoteComparisonOutcome {
     Ready {
         relation: RemoteComparisonRelation,
+        ahead_by: u64,
+        behind_by: u64,
         commits: Vec<CommitSummary>,
         total: u64,
         truncated: bool,
@@ -404,6 +407,8 @@ impl UpdateComparisonTask {
 #[derive(Clone)]
 struct ComparisonPageReady {
     relation: RemoteComparisonRelation,
+    ahead_by: u64,
+    behind_by: u64,
     commits: Vec<CommitSummary>,
     total: u64,
     page: usize,
@@ -486,6 +491,10 @@ enum HostedComparisonResult {
         #[serde(rename = "headSha")]
         head_sha: String,
         relation: RemoteComparisonRelation,
+        #[serde(rename = "aheadBy")]
+        ahead_by: u64,
+        #[serde(rename = "behindBy")]
+        behind_by: u64,
         commits: Vec<HostedCommit>,
         total: u64,
         truncated: bool,
@@ -603,6 +612,8 @@ struct HostedCommitAuthor {
 #[derive(Deserialize)]
 struct GithubComparisonWire {
     status: RemoteComparisonRelation,
+    ahead_by: u64,
+    behind_by: u64,
     total_commits: u64,
     commits: Vec<GithubComparisonCommit>,
 }
@@ -1091,6 +1102,8 @@ impl SkilldRemote {
             return Ok(first.into_outcome());
         };
         let relation = first.relation;
+        let ahead_by = first.ahead_by;
+        let behind_by = first.behind_by;
         let total = first.total;
         let first_included_index = total.saturating_sub(MAX_UPDATE_COMMITS as u64);
         let first_included_page =
@@ -1112,7 +1125,11 @@ impl SkilldRemote {
             let ComparisonPage::Ready(page) = page else {
                 return Ok(page.into_outcome());
             };
-            if page.relation != relation || page.total != total {
+            if page.relation != relation
+                || page.ahead_by != ahead_by
+                || page.behind_by != behind_by
+                || page.total != total
+            {
                 return Err(invalid_update_response());
             }
             let offset = if page.page == first_included_page {
@@ -1125,9 +1142,21 @@ impl SkilldRemote {
         if commits.len() > MAX_UPDATE_COMMITS {
             commits.drain(..commits.len() - MAX_UPDATE_COMMITS);
         }
+        let expected_count = usize::try_from(total.min(MAX_UPDATE_COMMITS as u64))
+            .map_err(|_| invalid_update_response())?;
+        let unique_count = commits
+            .iter()
+            .map(|commit| commit.sha.as_str())
+            .collect::<BTreeSet<_>>()
+            .len();
+        if commits.len() != expected_count || unique_count != commits.len() {
+            return Err(invalid_update_response());
+        }
         let compare_url = github_compare_url(input);
         Ok(RemoteComparisonOutcome::Ready {
             relation,
+            ahead_by,
+            behind_by,
             truncated: u64::try_from(commits.len()).unwrap_or(u64::MAX) < total,
             commits,
             total,
@@ -1157,7 +1186,7 @@ impl SkilldRemote {
         let response = self.execute_comparison_request(request, AllowedOrigin::Github)?;
         if is_rate_limited(&response) {
             return Ok(ComparisonPage::RateLimited {
-                retry_after_seconds: bounded_retry_after(&response),
+                retry_after_seconds: bounded_rate_limit_wait(&response),
                 reset_at: None,
             });
         }
@@ -1173,7 +1202,18 @@ impl SkilldRemote {
             });
         }
         let wire: GithubComparisonWire = parse_json(&response.body)?;
-        if wire.commits.len() > UPDATE_COMMITS_PER_PAGE || wire.total_commits > MAX_SAFE_INTEGER {
+        if wire.commits.len() > UPDATE_COMMITS_PER_PAGE
+            || wire.total_commits > MAX_SAFE_INTEGER
+            || wire.ahead_by > MAX_SAFE_INTEGER
+            || wire.behind_by > MAX_SAFE_INTEGER
+            || wire.total_commits != wire.ahead_by
+            || !comparison_counts_match(
+                wire.status,
+                input.base_sha == input.head_sha,
+                wire.ahead_by,
+                wire.behind_by,
+            )
+        {
             return Err(invalid_update_response());
         }
         let commits = wire
@@ -1183,6 +1223,8 @@ impl SkilldRemote {
             .collect::<Result<Vec<_>, _>>()?;
         Ok(ComparisonPage::Ready(ComparisonPageReady {
             relation: wire.status,
+            ahead_by: wire.ahead_by,
+            behind_by: wire.behind_by,
             total: wire.total_commits,
             commits,
             page,
@@ -1212,27 +1254,48 @@ impl SkilldRemote {
             url: self.service_url("/api/v1/update-plans")?.into(),
             headers,
             body,
-            response_limit: JSON_LIMIT,
+            response_limit: UPDATE_RESPONSE_LIMIT,
         };
-        let response = self.execute(request, AllowedOrigin::Service(self.endpoint.clone()))?;
+        let response = self
+            .execute_comparison_request(request, AllowedOrigin::Service(self.endpoint.clone()))?;
+        if is_rate_limited(&response) {
+            let retry_after_seconds = bounded_rate_limit_wait(&response);
+            return Ok(inputs
+                .iter()
+                .map(|input| RemoteUpdateResult {
+                    id: input.id.clone(),
+                    outcome: RemoteComparisonOutcome::RateLimited {
+                        retry_after_seconds,
+                        reset_at: None,
+                    },
+                })
+                .collect());
+        }
+        if !(200..300).contains(&response.status) {
+            return Err(problem_error(&response));
+        }
         let wire: HostedComparisonsResponse = parse_json(&response.body)?;
         if wire.results.len() != inputs.len() || wire.results.len() > UPDATE_SERVICE_BATCH {
             return Err(invalid_update_response());
         }
-        let mut by_id = wire
-            .results
-            .into_iter()
-            .map(|result| {
-                let id = result.id().to_owned();
-                let input = inputs
-                    .iter()
-                    .find(|input| input.id == id)
-                    .ok_or_else(invalid_update_response)?;
-                validate_hosted_identity(input, &result)?;
-                let outcome = present_hosted_outcome(input, result)?;
-                Ok((id, outcome))
-            })
-            .collect::<Result<BTreeMap<_, _>, RemoteError>>()?;
+        let mut by_id = BTreeMap::new();
+        for result in wire.results {
+            let id = result.id().to_owned();
+            if by_id.contains_key(&id) {
+                return Err(invalid_update_response());
+            }
+            let input = inputs
+                .iter()
+                .find(|input| input.id == id)
+                .ok_or_else(invalid_update_response)?;
+            let outcome = validate_hosted_identity(input, &result)
+                .and_then(|()| present_hosted_outcome(input, result))
+                .unwrap_or_else(|error| RemoteComparisonOutcome::RequestFailure {
+                    code: error.code,
+                    message: error.message,
+                });
+            by_id.insert(id, outcome);
+        }
         if by_id.len() != inputs.len() {
             return Err(invalid_update_response());
         }
@@ -1705,6 +1768,8 @@ fn present_hosted_outcome(
     match result {
         HostedComparisonResult::Ready {
             relation,
+            ahead_by,
+            behind_by,
             commits,
             total,
             truncated,
@@ -1713,6 +1778,15 @@ fn present_hosted_outcome(
         } => {
             if commits.len() > MAX_UPDATE_COMMITS
                 || total > MAX_SAFE_INTEGER
+                || ahead_by > MAX_SAFE_INTEGER
+                || behind_by > MAX_SAFE_INTEGER
+                || total != ahead_by
+                || !comparison_counts_match(
+                    relation,
+                    input.base_sha == input.head_sha,
+                    ahead_by,
+                    behind_by,
+                )
                 || u64::try_from(commits.len()).unwrap_or(u64::MAX) > total
                 || truncated != (u64::try_from(commits.len()).unwrap_or(u64::MAX) < total)
                 || compare_url != github_compare_url(input)
@@ -1721,6 +1795,8 @@ fn present_hosted_outcome(
             }
             Ok(RemoteComparisonOutcome::Ready {
                 relation,
+                ahead_by,
+                behind_by,
                 commits: commits
                     .into_iter()
                     .map(|commit| present_hosted_commit(input, commit))
@@ -1900,11 +1976,34 @@ fn is_rate_limited(response: &HttpResponse) -> bool {
                 || response.header("retry-after").is_some()))
 }
 
-fn bounded_retry_after(response: &HttpResponse) -> Option<u64> {
-    response
+fn comparison_counts_match(
+    relation: RemoteComparisonRelation,
+    same_commit: bool,
+    ahead_by: u64,
+    behind_by: u64,
+) -> bool {
+    matches!(
+        (relation, same_commit, ahead_by, behind_by),
+        (RemoteComparisonRelation::Identical, true, 0, 0)
+            | (RemoteComparisonRelation::Ahead, false, 1.., 0)
+            | (RemoteComparisonRelation::Behind, false, 0, 1..)
+            | (RemoteComparisonRelation::Diverged, false, 1.., 1..)
+    )
+}
+
+fn bounded_rate_limit_wait(response: &HttpResponse) -> Option<u64> {
+    let retry_after = response
         .header("retry-after")
         .and_then(|value| value.parse().ok())
-        .map(|seconds: u64| seconds.min(604_800))
+        .map(|seconds: u64| seconds.min(604_800));
+    retry_after.or_else(|| {
+        let reset = response.header("x-ratelimit-reset")?.parse::<u64>().ok()?;
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Some(reset.saturating_sub(now).min(604_800)).filter(|seconds| *seconds > 0)
+    })
 }
 
 fn invalid_update_response() -> RemoteError {

--- a/crates/skilld-command/tests/local_store.rs
+++ b/crates/skilld-command/tests/local_store.rs
@@ -26,7 +26,67 @@ fn named_source(root: &Path, parent: &str, name: &str, content: &str) -> PathBuf
 }
 
 #[test]
-fn unsupported_multi_skill_batch_writes_nothing() {
+fn multi_skill_batch_commits_every_skill() {
+    let temporary = tempfile::tempdir().unwrap();
+    let alpha = named_source(temporary.path(), "old-alpha", "alpha", "old alpha");
+    let beta = named_source(temporary.path(), "old-beta", "beta", "old beta");
+    let new_alpha = named_source(temporary.path(), "new-alpha", "alpha", "new alpha");
+    let new_beta = named_source(temporary.path(), "new-beta", "beta", "new beta");
+    let store = LocalStore::new(temporary.path().join("project/.skills"));
+    let target = resolved(
+        AgentTargetId::Codex,
+        temporary.path().join("project/.agents/skills"),
+    );
+    let install = TargetInstall {
+        target: target.clone(),
+        mode: InstallMode::Copy,
+    };
+    for source in [&alpha, &beta] {
+        store
+            .install_from(
+                source,
+                local_source(source),
+                std::slice::from_ref(&install),
+                std::slice::from_ref(&target),
+            )
+            .unwrap();
+    }
+    let updated = store
+        .apply_update_batch(
+            vec![
+                PreparedStoreUpdate {
+                    source: new_alpha,
+                    locked_source: local_source(&alpha),
+                    source_status: None,
+                    targets: vec![install.clone()],
+                },
+                PreparedStoreUpdate {
+                    source: new_beta,
+                    locked_source: local_source(&beta),
+                    source_status: None,
+                    targets: vec![install],
+                },
+            ],
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+
+    assert_eq!(
+        updated.iter().map(SkillName::as_str).collect::<Vec<_>>(),
+        ["alpha", "beta"]
+    );
+    assert_eq!(
+        fs::read_to_string(store.root().join("alpha/SKILL.md")).unwrap(),
+        "---\nname: alpha\ndescription: Test fixture.\n---\n\nnew alpha\n"
+    );
+    assert_eq!(
+        fs::read_to_string(target.root.join("beta/SKILL.md")).unwrap(),
+        "---\nname: beta\ndescription: Test fixture.\n---\n\nnew beta\n"
+    );
+}
+
+#[test]
+fn multi_skill_batch_rolls_every_skill_back_when_the_lock_write_fails() {
     let temporary = tempfile::tempdir().unwrap();
     let alpha = named_source(temporary.path(), "old-alpha", "alpha", "old alpha");
     let beta = named_source(temporary.path(), "old-beta", "beta", "old beta");
@@ -54,7 +114,7 @@ fn unsupported_multi_skill_batch_writes_nothing() {
     let before_lock = fs::read(store.root().join("skilld-lock.yaml")).unwrap();
 
     let error = store
-        .apply_update_batch(
+        .apply_update_batch_with_gate(
             vec![
                 PreparedStoreUpdate {
                     source: new_alpha,
@@ -70,18 +130,23 @@ fn unsupported_multi_skill_batch_writes_nothing() {
                 },
             ],
             std::slice::from_ref(&target),
+            &RejectLockCommit,
         )
         .unwrap_err();
 
-    assert_eq!(error.code(), "ATOMIC_UPDATE_UNAVAILABLE");
-    assert_eq!(
-        fs::read_to_string(store.root().join("alpha/SKILL.md")).unwrap(),
-        "---\nname: alpha\ndescription: Test fixture.\n---\n\nold alpha\n"
-    );
-    assert_eq!(
-        fs::read_to_string(target.root.join("beta/SKILL.md")).unwrap(),
-        "---\nname: beta\ndescription: Test fixture.\n---\n\nold beta\n"
-    );
+    assert_eq!(error.to_string(), "injected lock failure");
+    for name in ["alpha", "beta"] {
+        let expected =
+            format!("---\nname: {name}\ndescription: Test fixture.\n---\n\nold {name}\n");
+        assert_eq!(
+            fs::read_to_string(store.root().join(name).join("SKILL.md")).unwrap(),
+            expected
+        );
+        assert_eq!(
+            fs::read_to_string(target.root.join(name).join("SKILL.md")).unwrap(),
+            expected
+        );
+    }
     assert_eq!(
         fs::read(store.root().join("skilld-lock.yaml")).unwrap(),
         before_lock

--- a/crates/skilld-command/tests/local_store.rs
+++ b/crates/skilld-command/tests/local_store.rs
@@ -4,15 +4,88 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
-use skilld_command::{LocalStore, ResolvedTarget, StoreError, TargetInstall, TransactionGate};
+use skilld_command::{
+    LocalStore, PreparedStoreUpdate, ResolvedTarget, StoreError, TargetInstall, TransactionGate,
+};
 use skilld_core::{AgentTargetId, InstallMode, LockedSource, SkillName};
 
 fn source(root: &Path, parent: &str, content: &str) -> PathBuf {
-    let path = root.join(parent).join("example");
+    named_source(root, parent, "example", content)
+}
+
+fn named_source(root: &Path, parent: &str, name: &str, content: &str) -> PathBuf {
+    let path = root.join(parent).join(name);
     fs::create_dir_all(path.join("references")).unwrap();
-    fs::write(path.join("SKILL.md"), skill_text(content)).unwrap();
+    fs::write(
+        path.join("SKILL.md"),
+        format!("---\nname: {name}\ndescription: Test fixture.\n---\n\n{content}\n"),
+    )
+    .unwrap();
     fs::write(path.join("references/check.md"), "check").unwrap();
     path
+}
+
+#[test]
+fn unsupported_multi_skill_batch_writes_nothing() {
+    let temporary = tempfile::tempdir().unwrap();
+    let alpha = named_source(temporary.path(), "old-alpha", "alpha", "old alpha");
+    let beta = named_source(temporary.path(), "old-beta", "beta", "old beta");
+    let new_alpha = named_source(temporary.path(), "new-alpha", "alpha", "new alpha");
+    let new_beta = named_source(temporary.path(), "new-beta", "beta", "new beta");
+    let store = LocalStore::new(temporary.path().join("project/.skills"));
+    let target = resolved(
+        AgentTargetId::Codex,
+        temporary.path().join("project/.agents/skills"),
+    );
+    let install = TargetInstall {
+        target: target.clone(),
+        mode: InstallMode::Copy,
+    };
+    for source in [&alpha, &beta] {
+        store
+            .install_from(
+                source,
+                local_source(source),
+                std::slice::from_ref(&install),
+                std::slice::from_ref(&target),
+            )
+            .unwrap();
+    }
+    let before_lock = fs::read(store.root().join("skilld-lock.yaml")).unwrap();
+
+    let error = store
+        .apply_update_batch(
+            vec![
+                PreparedStoreUpdate {
+                    source: new_alpha,
+                    locked_source: local_source(&alpha),
+                    source_status: None,
+                    targets: vec![install.clone()],
+                },
+                PreparedStoreUpdate {
+                    source: new_beta,
+                    locked_source: local_source(&beta),
+                    source_status: None,
+                    targets: vec![install],
+                },
+            ],
+            std::slice::from_ref(&target),
+        )
+        .unwrap_err();
+
+    assert_eq!(error.code(), "ATOMIC_UPDATE_UNAVAILABLE");
+    assert_eq!(
+        fs::read_to_string(store.root().join("alpha/SKILL.md")).unwrap(),
+        "---\nname: alpha\ndescription: Test fixture.\n---\n\nold alpha\n"
+    );
+    assert_eq!(
+        fs::read_to_string(target.root.join("beta/SKILL.md")).unwrap(),
+        "---\nname: beta\ndescription: Test fixture.\n---\n\nold beta\n"
+    );
+    assert_eq!(
+        fs::read(store.root().join("skilld-lock.yaml")).unwrap(),
+        before_lock
+    );
 }
 
 fn skill_text(content: &str) -> String {

--- a/crates/skilld-command/tests/local_store.rs
+++ b/crates/skilld-command/tests/local_store.rs
@@ -51,6 +51,18 @@ fn multi_skill_batch_commits_every_skill() {
             )
             .unwrap();
     }
+    let alpha_view = store
+        .view(
+            &SkillName::parse("alpha").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    let beta_view = store
+        .view(
+            &SkillName::parse("beta").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
     let updated = store
         .apply_update_batch(
             vec![
@@ -59,12 +71,16 @@ fn multi_skill_batch_commits_every_skill() {
                     locked_source: local_source(&alpha),
                     source_status: None,
                     targets: vec![install.clone()],
+                    expected_transaction_id: alpha_view.transaction_id,
+                    expected_skill: alpha_view.skill,
                 },
                 PreparedStoreUpdate {
                     source: new_beta,
                     locked_source: local_source(&beta),
                     source_status: None,
                     targets: vec![install],
+                    expected_transaction_id: beta_view.transaction_id,
+                    expected_skill: beta_view.skill,
                 },
             ],
             std::slice::from_ref(&target),
@@ -111,6 +127,18 @@ fn multi_skill_batch_rolls_every_skill_back_when_the_lock_write_fails() {
             )
             .unwrap();
     }
+    let alpha_view = store
+        .view(
+            &SkillName::parse("alpha").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    let beta_view = store
+        .view(
+            &SkillName::parse("beta").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
     let before_lock = fs::read(store.root().join("skilld-lock.yaml")).unwrap();
 
     let error = store
@@ -121,12 +149,16 @@ fn multi_skill_batch_rolls_every_skill_back_when_the_lock_write_fails() {
                     locked_source: local_source(&alpha),
                     source_status: None,
                     targets: vec![install.clone()],
+                    expected_transaction_id: alpha_view.transaction_id,
+                    expected_skill: alpha_view.skill,
                 },
                 PreparedStoreUpdate {
                     source: new_beta,
                     locked_source: local_source(&beta),
                     source_status: None,
                     targets: vec![install],
+                    expected_transaction_id: beta_view.transaction_id,
+                    expected_skill: beta_view.skill,
                 },
             ],
             std::slice::from_ref(&target),
@@ -150,6 +182,235 @@ fn multi_skill_batch_rolls_every_skill_back_when_the_lock_write_fails() {
     assert_eq!(
         fs::read(store.root().join("skilld-lock.yaml")).unwrap(),
         before_lock
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn multi_skill_batch_rolls_symlink_targets_back_when_the_lock_write_fails() {
+    let temporary = tempfile::tempdir().unwrap();
+    let alpha = named_source(temporary.path(), "old-alpha", "alpha", "old alpha");
+    let beta = named_source(temporary.path(), "old-beta", "beta", "old beta");
+    let new_alpha = named_source(temporary.path(), "new-alpha", "alpha", "new alpha");
+    let new_beta = named_source(temporary.path(), "new-beta", "beta", "new beta");
+    let store = LocalStore::new(temporary.path().join("project/.skills"));
+    let target = resolved(
+        AgentTargetId::Cursor,
+        temporary.path().join("project/.cursor/skills"),
+    );
+    let install = TargetInstall {
+        target: target.clone(),
+        mode: InstallMode::Symlink,
+    };
+    for source in [&alpha, &beta] {
+        store
+            .install_from(
+                source,
+                local_source(source),
+                std::slice::from_ref(&install),
+                std::slice::from_ref(&target),
+            )
+            .unwrap();
+    }
+    let alpha_view = store
+        .view(
+            &SkillName::parse("alpha").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    let beta_view = store
+        .view(
+            &SkillName::parse("beta").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+
+    store
+        .apply_update_batch_with_gate(
+            vec![
+                PreparedStoreUpdate {
+                    source: new_alpha,
+                    locked_source: local_source(&alpha),
+                    source_status: None,
+                    targets: vec![install.clone()],
+                    expected_transaction_id: alpha_view.transaction_id,
+                    expected_skill: alpha_view.skill,
+                },
+                PreparedStoreUpdate {
+                    source: new_beta,
+                    locked_source: local_source(&beta),
+                    source_status: None,
+                    targets: vec![install],
+                    expected_transaction_id: beta_view.transaction_id,
+                    expected_skill: beta_view.skill,
+                },
+            ],
+            std::slice::from_ref(&target),
+            &RejectLockCommit,
+        )
+        .unwrap_err();
+
+    for name in ["alpha", "beta"] {
+        let destination = target.root.join(name);
+        assert!(
+            fs::symlink_metadata(&destination)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            fs::read_to_string(destination.join("SKILL.md")).unwrap(),
+            format!("---\nname: {name}\ndescription: Test fixture.\n---\n\nold {name}\n")
+        );
+    }
+}
+
+struct PanicBeforeCommit;
+
+impl TransactionGate for PanicBeforeCommit {
+    fn before_lock_commit(&self, _lockfile: &Path) -> Result<(), StoreError> {
+        panic!("simulated process interruption");
+    }
+}
+
+#[test]
+fn next_store_access_recovers_an_interrupted_multi_skill_batch() {
+    let temporary = tempfile::tempdir().unwrap();
+    let alpha = named_source(temporary.path(), "old-alpha", "alpha", "old alpha");
+    let beta = named_source(temporary.path(), "old-beta", "beta", "old beta");
+    let new_alpha = named_source(temporary.path(), "new-alpha", "alpha", "new alpha");
+    let new_beta = named_source(temporary.path(), "new-beta", "beta", "new beta");
+    let store = LocalStore::new(temporary.path().join("project/.skills"));
+    let target = resolved(
+        AgentTargetId::Codex,
+        temporary.path().join("project/.agents/skills"),
+    );
+    let install = TargetInstall {
+        target: target.clone(),
+        mode: InstallMode::Copy,
+    };
+    for source in [&alpha, &beta] {
+        store
+            .install_from(
+                source,
+                local_source(source),
+                std::slice::from_ref(&install),
+                std::slice::from_ref(&target),
+            )
+            .unwrap();
+    }
+    let alpha_view = store
+        .view(
+            &SkillName::parse("alpha").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    let beta_view = store
+        .view(
+            &SkillName::parse("beta").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    let interrupted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        store.apply_update_batch_with_gate(
+            vec![
+                PreparedStoreUpdate {
+                    source: new_alpha,
+                    locked_source: local_source(&alpha),
+                    source_status: None,
+                    targets: vec![install.clone()],
+                    expected_transaction_id: alpha_view.transaction_id,
+                    expected_skill: alpha_view.skill,
+                },
+                PreparedStoreUpdate {
+                    source: new_beta,
+                    locked_source: local_source(&beta),
+                    source_status: None,
+                    targets: vec![install],
+                    expected_transaction_id: beta_view.transaction_id,
+                    expected_skill: beta_view.skill,
+                },
+            ],
+            std::slice::from_ref(&target),
+            &PanicBeforeCommit,
+        )
+    }));
+    assert!(interrupted.is_err());
+
+    assert_eq!(
+        store.list(std::slice::from_ref(&target)).unwrap(),
+        ["alpha", "beta"]
+    );
+    for name in ["alpha", "beta"] {
+        let expected =
+            format!("---\nname: {name}\ndescription: Test fixture.\n---\n\nold {name}\n");
+        assert_eq!(
+            fs::read_to_string(store.root().join(name).join("SKILL.md")).unwrap(),
+            expected
+        );
+        assert_eq!(
+            fs::read_to_string(target.root.join(name).join("SKILL.md")).unwrap(),
+            expected
+        );
+    }
+}
+
+#[test]
+fn multi_skill_batch_rejects_a_stale_store_snapshot() {
+    let temporary = tempfile::tempdir().unwrap();
+    let old_alpha = named_source(temporary.path(), "old-alpha", "alpha", "old alpha");
+    let new_alpha = named_source(temporary.path(), "new-alpha", "alpha", "new alpha");
+    let gamma = named_source(temporary.path(), "gamma-source", "gamma", "gamma");
+    let store = LocalStore::new(temporary.path().join("project/.skills"));
+    let target = resolved(
+        AgentTargetId::Codex,
+        temporary.path().join("project/.agents/skills"),
+    );
+    let install = TargetInstall {
+        target: target.clone(),
+        mode: InstallMode::Copy,
+    };
+    store
+        .install_from(
+            &old_alpha,
+            local_source(&old_alpha),
+            std::slice::from_ref(&install),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    let snapshot = store
+        .view(
+            &SkillName::parse("alpha").unwrap(),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+    store
+        .install_from(
+            &gamma,
+            local_source(&gamma),
+            std::slice::from_ref(&install),
+            std::slice::from_ref(&target),
+        )
+        .unwrap();
+
+    let error = store
+        .apply_update_batch(
+            vec![PreparedStoreUpdate {
+                source: new_alpha,
+                locked_source: local_source(&old_alpha),
+                source_status: None,
+                targets: vec![install],
+                expected_transaction_id: snapshot.transaction_id,
+                expected_skill: snapshot.skill,
+            }],
+            std::slice::from_ref(&target),
+        )
+        .unwrap_err();
+
+    assert_eq!(error.code(), "PLAN_STALE");
+    assert_eq!(
+        fs::read_to_string(store.root().join("alpha/SKILL.md")).unwrap(),
+        "---\nname: alpha\ndescription: Test fixture.\n---\n\nold alpha\n"
     );
 }
 

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fs;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -10,15 +10,16 @@ use serde_json::json;
 use sha2::{Digest, Sha256};
 use skilld_command::{
     Cancellation, HeaderValue, Host, HttpAdapter, HttpRequest, HttpResponse, LocalHost,
-    NativeRemoteConfig, NoTokenProvider, PreparedRemoteSkill, RemoteProvider, RemoteSourceState,
-    SecretValue, SkilldRemote, Sleeper, TokenProvider, run,
+    NativeRemoteConfig, NoTokenProvider, PreparedRemoteSkill, RemoteComparisonAccess,
+    RemoteComparisonOutcome, RemoteComparisonRelation, RemoteProvider, RemoteSourceState,
+    RemoteUpdateComparison, SecretValue, SkilldRemote, Sleeper, TokenProvider, run,
 };
 use skilld_core::{
     AgentTargetId, ArtifactAttestation, ArtifactFile, AttestationSignature, CheckOutcome,
-    CheckResult, InstallMode, InstallRequest, InstallScope, InstallSource, LockedSource,
-    PreparedFile, RemoteError, RemoteSelector, RepositoryVisibility, ResolvedSource,
-    SearchResponse, SignatureAlgorithm, SourceProvider, SourceStatus, TrustedRootPin,
-    UpdateCheckV1, UpdateLatestCommit, UpdateRelation,
+    CheckResult, CommitAuthor, CommitSha, CommitSummary, InstallMode, InstallRequest, InstallScope,
+    InstallSource, LockedSource, PreparedFile, RemoteError, RemoteSelector, RepositoryVisibility,
+    ResolvedSource, SearchResponse, SignatureAlgorithm, SourceProvider, SourceStatus,
+    TrustedRootPin, UpdatePlanV1, UpdateRelation,
 };
 
 const ROOT_DOMAIN: &[u8] = b"skilld-trusted-key-v1\0";
@@ -60,6 +61,59 @@ impl HttpAdapter for FakeHttp {
                     "the fake response queue is empty",
                 ))
             })
+    }
+}
+
+#[derive(Default)]
+struct UpdatePlansHttp {
+    requests: Mutex<Vec<HttpRequest>>,
+    active: AtomicUsize,
+    maximum_concurrency: AtomicUsize,
+}
+
+impl HttpAdapter for UpdatePlansHttp {
+    fn send(
+        &self,
+        request: &HttpRequest,
+        _cancellation: &dyn Cancellation,
+        _timeout: Option<Duration>,
+    ) -> Result<HttpResponse, RemoteError> {
+        let active = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+        self.maximum_concurrency.fetch_max(active, Ordering::SeqCst);
+        std::thread::sleep(Duration::from_millis(5));
+        self.requests.lock().unwrap().push(request.clone());
+        let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+        let results = body["comparisons"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|comparison| {
+                json!({
+                    "_tag": "ready",
+                    "id": comparison["id"],
+                    "owner": comparison["owner"],
+                    "repository": comparison["repository"],
+                    "baseSha": comparison["baseSha"],
+                    "headSha": comparison["headSha"],
+                    "relation": "identical",
+                    "commits": [],
+                    "total": 0,
+                    "truncated": false,
+                    "compareUrl": format!(
+                        "https://github.com/{}/{}/compare/{}...{}",
+                        comparison["owner"].as_str().unwrap(),
+                        comparison["repository"].as_str().unwrap(),
+                        comparison["baseSha"].as_str().unwrap(),
+                        comparison["headSha"].as_str().unwrap(),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        self.active.fetch_sub(1, Ordering::SeqCst);
+        Ok(response(
+            200,
+            serde_json::to_vec(&json!({ "results": results })).unwrap(),
+        ))
     }
 }
 
@@ -341,6 +395,281 @@ fn search_uses_only_the_v1_skilld_route_and_retries_a_bounded_failure() {
     assert!(requests.iter().all(|request| {
         request.url == "http://127.0.0.1:8787/api/v1/skills?q=vue+testing&limit=20"
     }));
+}
+
+#[test]
+fn public_comparison_uses_anonymous_github_and_keeps_full_commit_details() {
+    let base = CommitSha::parse("1".repeat(40)).unwrap();
+    let head = CommitSha::parse("2".repeat(40)).unwrap();
+    let commit = "3".repeat(40);
+    let http = Arc::new(FakeHttp::with([response(
+        200,
+        serde_json::to_vec(&json!({
+            "status": "ahead",
+            "total_commits": 1,
+            "commits": [{
+                "sha": commit,
+                "commit": {
+                    "message": "Add grill timers\u{1b}[31m\nHidden body",
+                    "author": {
+                        "name": "Ada Lovelace",
+                        "date": "2026-08-21T00:00:00Z"
+                    }
+                },
+                "author": { "login": "ada" }
+            }]
+        }))
+        .unwrap(),
+    )]));
+    let remote = search_remote(http.clone());
+    let comparison = RemoteUpdateComparison::new(
+        "grill",
+        "acme",
+        "skills",
+        base,
+        head,
+        RemoteComparisonAccess::PublicGithub,
+    )
+    .unwrap();
+
+    let results = remote.compare_updates(&[comparison]).unwrap();
+
+    assert_eq!(results.len(), 1);
+    let RemoteComparisonOutcome::Ready {
+        relation,
+        commits,
+        total,
+        truncated,
+        compare_url,
+    } = &results[0].outcome
+    else {
+        panic!("expected a ready comparison")
+    };
+    assert_eq!(*relation, RemoteComparisonRelation::Ahead);
+    assert_eq!((*total, *truncated), (1, false));
+    assert_eq!(
+        commits[0].sha.as_str(),
+        "3333333333333333333333333333333333333333"
+    );
+    assert_eq!(commits[0].subject, "Add grill timers [31m");
+    assert_eq!(commits[0].author.name, "Ada Lovelace");
+    assert_eq!(commits[0].author.login.as_deref(), Some("ada"));
+    assert_eq!(
+        commits[0].url,
+        "https://github.com/acme/skills/commit/3333333333333333333333333333333333333333"
+    );
+    assert_eq!(
+        compare_url,
+        "https://github.com/acme/skills/compare/1111111111111111111111111111111111111111...2222222222222222222222222222222222222222"
+    );
+    let request = &http.requests.lock().unwrap()[0];
+    assert!(
+        request
+            .url
+            .starts_with("https://api.github.com/repos/acme/skills/compare/")
+    );
+    assert!(
+        request
+            .headers
+            .iter()
+            .all(|header| header.name != "authorization")
+    );
+    assert!(request.headers.iter().any(|header| {
+        header.name == "x-github-api-version" && header.value.expose() == "2026-03-10"
+    }));
+}
+
+#[test]
+fn public_comparison_keeps_the_newest_five_hundred_commits() {
+    let responses = (0..6).map(|page| {
+        let start = page * 100 + 1;
+        let count = if page == 5 { 50 } else { 100 };
+        response(
+            200,
+            serde_json::to_vec(&json!({
+                "status": "ahead",
+                "total_commits": 550,
+                "commits": (start..start + count).map(|number| json!({
+                    "sha": format!("{number:040x}"),
+                    "commit": {
+                        "message": format!("Commit {number}"),
+                        "author": {
+                            "name": "Ada Lovelace",
+                            "date": "2026-08-21T00:00:00Z"
+                        }
+                    },
+                    "author": { "login": "ada" }
+                })).collect::<Vec<_>>()
+            }))
+            .unwrap(),
+        )
+    });
+    let http = Arc::new(FakeHttp::with(responses));
+    let remote = search_remote(http.clone());
+    let comparison = RemoteUpdateComparison::new(
+        "grill",
+        "acme",
+        "skills",
+        CommitSha::parse("1".repeat(40)).unwrap(),
+        CommitSha::parse("2".repeat(40)).unwrap(),
+        RemoteComparisonAccess::PublicGithub,
+    )
+    .unwrap();
+
+    let results = remote.compare_updates(&[comparison]).unwrap();
+
+    let RemoteComparisonOutcome::Ready {
+        commits,
+        total,
+        truncated,
+        ..
+    } = &results[0].outcome
+    else {
+        panic!("expected a ready comparison")
+    };
+    assert_eq!(commits.len(), 500);
+    assert_eq!(commits[0].sha.as_str(), format!("{:040x}", 51));
+    assert_eq!(commits[499].sha.as_str(), format!("{:040x}", 550));
+    assert_eq!((*total, *truncated), (550, true));
+    assert_eq!(http.requests.lock().unwrap().len(), 6);
+}
+
+#[test]
+fn hosted_comparisons_are_authenticated_and_chunked_at_fifty() {
+    let http = Arc::new(UpdatePlansHttp::default());
+    let remote = SkilldRemote::new(
+        http.clone(),
+        Arc::new(FixedToken),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap()
+    .with_sleeper(Arc::new(NoSleep));
+    let comparisons = (0..51)
+        .map(|index| {
+            RemoteUpdateComparison::new(
+                format!("skill-{index}"),
+                "acme",
+                "private-skills",
+                CommitSha::parse("1".repeat(40)).unwrap(),
+                CommitSha::parse("2".repeat(40)).unwrap(),
+                RemoteComparisonAccess::Hosted,
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let results = remote.compare_updates(&comparisons).unwrap();
+
+    assert_eq!(results.len(), 51);
+    assert!(results.iter().all(|result| matches!(
+        result.outcome,
+        RemoteComparisonOutcome::Ready {
+            relation: RemoteComparisonRelation::Identical,
+            ..
+        }
+    )));
+    let requests = http.requests.lock().unwrap();
+    assert_eq!(requests.len(), 2);
+    let mut sizes = requests
+        .iter()
+        .map(|request| {
+            assert_eq!(request.url, "http://127.0.0.1:8787/api/v1/update-plans");
+            assert!(request.headers.iter().any(|header| {
+                header.name == "authorization" && header.value.expose() == "Bearer account-token"
+            }));
+            serde_json::from_slice::<serde_json::Value>(&request.body).unwrap()["comparisons"]
+                .as_array()
+                .unwrap()
+                .len()
+        })
+        .collect::<Vec<_>>();
+    sizes.sort_unstable();
+    assert_eq!(sizes, [1, 50]);
+    assert!(http.maximum_concurrency.load(Ordering::SeqCst) <= 4);
+}
+
+#[test]
+fn hosted_comparison_keeps_per_item_failures_and_retry_after() {
+    let inputs = ["ready", "limited"]
+        .into_iter()
+        .map(|id| {
+            RemoteUpdateComparison::new(
+                id,
+                "acme",
+                "private-skills",
+                CommitSha::parse("1".repeat(40)).unwrap(),
+                CommitSha::parse("2".repeat(40)).unwrap(),
+                RemoteComparisonAccess::Hosted,
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let identity = |id: &str| {
+        json!({
+            "id": id,
+            "owner": "acme",
+            "repository": "private-skills",
+            "baseSha": "1".repeat(40),
+            "headSha": "2".repeat(40),
+        })
+    };
+    let http = Arc::new(FakeHttp::with([response(
+        200,
+        serde_json::to_vec(&json!({
+            "results": [
+                {
+                    "_tag": "ready",
+                    "id": identity("ready")["id"],
+                    "owner": identity("ready")["owner"],
+                    "repository": identity("ready")["repository"],
+                    "baseSha": identity("ready")["baseSha"],
+                    "headSha": identity("ready")["headSha"],
+                    "relation": "identical",
+                    "commits": [],
+                    "total": 0,
+                    "truncated": false,
+                    "compareUrl": format!(
+                        "https://github.com/acme/private-skills/compare/{}...{}",
+                        "1".repeat(40),
+                        "2".repeat(40)
+                    )
+                },
+                {
+                    "_tag": "rate_limited",
+                    "id": identity("limited")["id"],
+                    "owner": identity("limited")["owner"],
+                    "repository": identity("limited")["repository"],
+                    "baseSha": identity("limited")["baseSha"],
+                    "headSha": identity("limited")["headSha"],
+                    "retryAfterSeconds": 12,
+                    "resetAt": "2026-08-21T00:10:00.000Z"
+                }
+            ]
+        }))
+        .unwrap(),
+    )]));
+    let remote = SkilldRemote::new(http, Arc::new(FixedToken), NativeRemoteConfig::Unconfigured)
+        .with_endpoint("http://127.0.0.1:8787")
+        .unwrap()
+        .with_sleeper(Arc::new(NoSleep));
+
+    let results = remote.compare_updates(&inputs).unwrap();
+
+    assert!(matches!(
+        results[0].outcome,
+        RemoteComparisonOutcome::Ready {
+            relation: RemoteComparisonRelation::Identical,
+            ..
+        }
+    ));
+    assert!(matches!(
+        &results[1].outcome,
+        RemoteComparisonOutcome::RateLimited {
+            retry_after_seconds: Some(12),
+            reset_at: Some(reset_at),
+        } if reset_at == "2026-08-21T00:10:00.000Z"
+    ));
 }
 
 #[test]
@@ -771,6 +1100,23 @@ impl RemoteProvider for FakeProvider {
         }
     }
 
+    fn prepare_exact(
+        &self,
+        selector: &RemoteSelector,
+        expected_commit: &CommitSha,
+        _direct: bool,
+    ) -> Result<PreparedRemoteSkill, RemoteError> {
+        if *self.fail_prepare.lock().unwrap() {
+            return Err(RemoteError::new("CHECK_BLOCKED", "a required check failed"));
+        }
+        let mut prepared = self.prepared(selector);
+        let LockedSource::Remote { commit_sha, .. } = &mut prepared.locked_source else {
+            unreachable!("the fixture uses a remote source")
+        };
+        *commit_sha = expected_commit.as_str().to_owned();
+        Ok(prepared)
+    }
+
     fn source_state(
         &self,
         _selector: &RemoteSelector,
@@ -785,6 +1131,69 @@ impl RemoteProvider for FakeProvider {
         } else {
             Ok(RemoteSourceState::Current)
         }
+    }
+
+    fn compare_updates(
+        &self,
+        comparisons: &[RemoteUpdateComparison],
+    ) -> Result<Vec<skilld_command::RemoteUpdateResult>, RemoteError> {
+        Ok(comparisons
+            .iter()
+            .map(|comparison| skilld_command::RemoteUpdateResult {
+                id: comparison.id.clone(),
+                outcome: RemoteComparisonOutcome::Ready {
+                    relation: if *self.stale.lock().unwrap() {
+                        RemoteComparisonRelation::Ahead
+                    } else {
+                        RemoteComparisonRelation::Identical
+                    },
+                    commits: if *self.stale.lock().unwrap() {
+                        vec![CommitSummary {
+                            sha: comparison.head_sha.clone(),
+                            subject: "Update example".to_owned(),
+                            author: CommitAuthor {
+                                name: "Ada Lovelace".to_owned(),
+                                login: Some("ada".to_owned()),
+                            },
+                            timestamp: "2026-08-21T00:00:00Z".to_owned(),
+                            url: format!(
+                                "https://github.com/{}/{}/commit/{}",
+                                comparison.owner,
+                                comparison.repository,
+                                comparison.head_sha.as_str(),
+                            ),
+                        }]
+                    } else {
+                        vec![]
+                    },
+                    total: u64::from(*self.stale.lock().unwrap()),
+                    truncated: false,
+                    compare_url: format!(
+                        "https://github.com/{}/{}/compare/{}...{}",
+                        comparison.owner,
+                        comparison.repository,
+                        comparison.base_sha.as_str(),
+                        comparison.head_sha.as_str(),
+                    ),
+                },
+            })
+            .collect())
+    }
+
+    fn latest_commit(
+        &self,
+        _selector: &RemoteSelector,
+        _direct: bool,
+    ) -> Result<skilld_command::RemoteLatestCommit, RemoteError> {
+        Ok(skilld_command::RemoteLatestCommit {
+            commit_sha: CommitSha::parse(if *self.stale.lock().unwrap() {
+                "ffffffffffffffffffffffffffffffffffffffff"
+            } else {
+                "0123456789abcdef0123456789abcdef01234567"
+            })
+            .unwrap(),
+            access: RemoteComparisonAccess::PublicGithub,
+        })
     }
 }
 
@@ -809,6 +1218,138 @@ fn provider(content: &str) -> Arc<FakeProvider> {
         stale: Mutex::new(false),
         fail_prepare: Mutex::new(false),
     })
+}
+
+#[derive(Default)]
+struct BatchProvider {
+    version: Mutex<&'static str>,
+    prepared_names: Mutex<Vec<String>>,
+}
+
+impl BatchProvider {
+    fn prepared(&self, selector: &RemoteSelector) -> PreparedRemoteSkill {
+        let skilld_core::SourceSelector::NamedSkill { name } = &selector.source().selector else {
+            panic!("expected a named Skill selector")
+        };
+        self.prepared_names.lock().unwrap().push(name.clone());
+        let bytes = format!(
+            "---\nname: {name}\ndescription: {}\n---\n",
+            *self.version.lock().unwrap()
+        )
+        .into_bytes();
+        let file = PreparedFile {
+            path: "SKILL.md".to_owned(),
+            mode: 0o644,
+            bytes,
+        };
+        let digest = installed_digest(std::slice::from_ref(&file));
+        PreparedRemoteSkill {
+            files: vec![file],
+            locked_source: LockedSource::Remote {
+                source: selector.canonical(),
+                commit_sha: "0123456789abcdef0123456789abcdef01234567".to_owned(),
+                skill_path: name.clone(),
+            },
+            source_status: SourceStatus::Verified {
+                artifact_id: format!("sha256:{digest}"),
+                content_sha256: digest.clone(),
+                installed_sha256: digest,
+                attestation_key_id: "test-key".to_owned(),
+            },
+        }
+    }
+}
+
+impl RemoteProvider for BatchProvider {
+    fn search(&self, _query: &str, _limit: u8) -> Result<SearchResponse, RemoteError> {
+        unreachable!("search is outside this test")
+    }
+
+    fn prepare(
+        &self,
+        selector: &RemoteSelector,
+        _direct: bool,
+    ) -> Result<PreparedRemoteSkill, RemoteError> {
+        Ok(self.prepared(selector))
+    }
+
+    fn prepare_exact(
+        &self,
+        selector: &RemoteSelector,
+        expected_commit: &CommitSha,
+        _direct: bool,
+    ) -> Result<PreparedRemoteSkill, RemoteError> {
+        let mut prepared = self.prepared(selector);
+        let LockedSource::Remote { commit_sha, .. } = &mut prepared.locked_source else {
+            unreachable!("the fixture uses a remote source")
+        };
+        *commit_sha = expected_commit.as_str().to_owned();
+        Ok(prepared)
+    }
+
+    fn source_state(
+        &self,
+        _selector: &RemoteSelector,
+        _artifact_id: &str,
+        _commit_sha: &str,
+    ) -> Result<RemoteSourceState, RemoteError> {
+        Ok(RemoteSourceState::Current)
+    }
+
+    fn latest_commit(
+        &self,
+        _selector: &RemoteSelector,
+        _direct: bool,
+    ) -> Result<skilld_command::RemoteLatestCommit, RemoteError> {
+        Ok(skilld_command::RemoteLatestCommit {
+            commit_sha: CommitSha::parse("f".repeat(40)).unwrap(),
+            access: RemoteComparisonAccess::PublicGithub,
+        })
+    }
+
+    fn compare_updates(
+        &self,
+        _comparisons: &[RemoteUpdateComparison],
+    ) -> Result<Vec<skilld_command::RemoteUpdateResult>, RemoteError> {
+        unreachable!("comparison is outside this test")
+    }
+}
+
+#[test]
+fn multi_skill_update_prepares_every_artifact_before_refusing_partial_mutation() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = Arc::new(BatchProvider {
+        version: Mutex::new("first"),
+        prepared_names: Mutex::new(vec![]),
+    });
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    for name in ["alpha", "beta"] {
+        host.install_request(InstallRequest {
+            source: Some(InstallSource::Remote(format!(
+                "skilld:skilld-dev/skills/{name}"
+            ))),
+            scope: InstallScope::Project,
+            targets: vec![AgentTargetId::Codex],
+            mode: Some(InstallMode::Copy),
+        })
+        .unwrap();
+    }
+    provider.prepared_names.lock().unwrap().clear();
+    *provider.version.lock().unwrap() = "second";
+
+    let error = host.update(None).unwrap_err();
+
+    assert_eq!(error.code, "ATOMIC_UPDATE_UNAVAILABLE");
+    assert_eq!(*provider.prepared_names.lock().unwrap(), ["alpha", "beta"]);
+    for name in ["alpha", "beta"] {
+        assert_eq!(
+            fs::read_to_string(project.join(format!(".skills/{name}/SKILL.md"))).unwrap(),
+            format!("---\nname: {name}\ndescription: first\n---\n")
+        );
+    }
 }
 
 #[test]
@@ -879,7 +1420,7 @@ fn remote_install_verify_and_failed_update_use_the_normal_transaction() {
 }
 
 #[test]
-fn update_check_keeps_an_uncompared_commit_unavailable() {
+fn update_check_carries_the_exact_comparison_and_commit_history() {
     let temporary = tempfile::tempdir().unwrap();
     let project = temporary.path().join("project");
     fs::create_dir_all(&project).unwrap();
@@ -914,11 +1455,11 @@ fn update_check_keeps_an_uncompared_commit_unavailable() {
         &mut global_stderr,
     );
     let outcome: serde_json::Value = serde_json::from_slice(&stdout).unwrap();
-    let check: UpdateCheckV1 = serde_json::from_value(outcome["data"].clone()).unwrap();
+    let check: UpdatePlanV1 = serde_json::from_value(outcome["data"].clone()).unwrap();
 
-    assert_eq!(result.exit_code, 0);
+    assert_eq!(result.exit_code, 1);
     assert!(stderr.is_empty());
-    assert_eq!(global_result.exit_code, 0);
+    assert_eq!(global_result.exit_code, 1);
     assert!(global_stderr.is_empty());
     assert_eq!(global_stdout, stdout);
     assert_eq!(outcome["schemaVersion"], 1);
@@ -927,13 +1468,37 @@ fn update_check_keeps_an_uncompared_commit_unavailable() {
     assert_eq!(outcome["notices"], serde_json::json!([]));
     assert!(matches!(
         check.items()[0].relation(),
-        UpdateRelation::Unavailable {
-            latest_commit: UpdateLatestCommit::Known { commit_sha },
-            failure,
+        UpdateRelation::Available {
+            latest_commit_sha: commit_sha,
             ..
         } if commit_sha.as_str() == "ffffffffffffffffffffffffffffffffffffffff"
-            && failure.code == "COMPARISON_UNAVAILABLE"
     ));
+    assert_eq!(
+        check.items()[0].history(),
+        &skilld_core::CommitHistory::compared(
+            vec![CommitSummary {
+                sha: CommitSha::parse("f".repeat(40)).unwrap(),
+                subject: "Update example".to_owned(),
+                author: CommitAuthor {
+                    name: "Ada Lovelace".to_owned(),
+                    login: Some("ada".to_owned()),
+                },
+                timestamp: "2026-08-21T00:00:00Z".to_owned(),
+                url: format!(
+                    "https://github.com/skilld-dev/skills/commit/{}",
+                    "f".repeat(40)
+                ),
+            }],
+            1,
+            false,
+            format!(
+                "https://github.com/skilld-dev/skills/compare/{}...{}",
+                "0123456789abcdef0123456789abcdef01234567",
+                "f".repeat(40)
+            ),
+        )
+        .unwrap()
+    );
 }
 
 #[test]

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fs;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use ed25519_dalek::{Signer as _, SigningKey};
@@ -95,9 +95,16 @@ impl HttpAdapter for UpdatePlansHttp {
                     "repository": comparison["repository"],
                     "baseSha": comparison["baseSha"],
                     "headSha": comparison["headSha"],
-                    "relation": "identical",
-                    "commits": [],
-                    "total": 0,
+                    "relation": "ahead",
+                    "aheadBy": 1,
+                    "behindBy": 0,
+                    "commits": [{
+                        "sha": comparison["headSha"],
+                        "subject": "Update Skill",
+                        "timestamp": "2026-08-21T00:00:00Z",
+                        "author": { "name": "Ada Lovelace", "login": "ada" }
+                    }],
+                    "total": 1,
                     "truncated": false,
                     "compareUrl": format!(
                         "https://github.com/{}/{}/compare/{}...{}",
@@ -406,6 +413,8 @@ fn public_comparison_uses_anonymous_github_and_keeps_full_commit_details() {
         200,
         serde_json::to_vec(&json!({
             "status": "ahead",
+            "ahead_by": 1,
+            "behind_by": 0,
             "total_commits": 1,
             "commits": [{
                 "sha": commit,
@@ -441,11 +450,14 @@ fn public_comparison_uses_anonymous_github_and_keeps_full_commit_details() {
         total,
         truncated,
         compare_url,
+        ahead_by,
+        behind_by,
     } = &results[0].outcome
     else {
         panic!("expected a ready comparison")
     };
     assert_eq!(*relation, RemoteComparisonRelation::Ahead);
+    assert_eq!((*ahead_by, *behind_by), (1, 0));
     assert_eq!((*total, *truncated), (1, false));
     assert_eq!(
         commits[0].sha.as_str(),
@@ -488,6 +500,8 @@ fn public_comparison_keeps_the_newest_five_hundred_commits() {
             200,
             serde_json::to_vec(&json!({
                 "status": "ahead",
+                "ahead_by": 550,
+                "behind_by": 0,
                 "total_commits": 550,
                 "commits": (start..start + count).map(|number| json!({
                     "sha": format!("{number:040x}"),
@@ -535,6 +549,97 @@ fn public_comparison_keeps_the_newest_five_hundred_commits() {
 }
 
 #[test]
+fn public_comparison_rejects_an_incomplete_success_page() {
+    let responses = (0..6).map(|page| {
+        let start = page * 100 + 1;
+        let count = if page == 2 {
+            0
+        } else if page == 5 {
+            50
+        } else {
+            100
+        };
+        response(
+            200,
+            serde_json::to_vec(&json!({
+                "status": "ahead",
+                "ahead_by": 550,
+                "behind_by": 0,
+                "total_commits": 550,
+                "commits": (start..start + count).map(|number| json!({
+                    "sha": format!("{number:040x}"),
+                    "commit": {
+                        "message": format!("Commit {number}"),
+                        "author": {
+                            "name": "Ada Lovelace",
+                            "date": "2026-08-21T00:00:00Z"
+                        }
+                    },
+                    "author": { "login": "ada" }
+                })).collect::<Vec<_>>()
+            }))
+            .unwrap(),
+        )
+    });
+    let remote = search_remote(Arc::new(FakeHttp::with(responses)));
+    let comparison = RemoteUpdateComparison::new(
+        "grill",
+        "acme",
+        "skills",
+        CommitSha::parse("1".repeat(40)).unwrap(),
+        CommitSha::parse("2".repeat(40)).unwrap(),
+        RemoteComparisonAccess::PublicGithub,
+    )
+    .unwrap();
+
+    let results = remote.compare_updates(&[comparison]).unwrap();
+
+    assert!(matches!(
+        results[0].outcome,
+        RemoteComparisonOutcome::RequestFailure {
+            code: "INVALID_RESPONSE",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn public_rate_limit_exposes_the_github_reset_wait() {
+    let reset = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        + 300;
+    let mut limited = response(403, vec![]);
+    limited
+        .headers
+        .insert("x-ratelimit-remaining".to_owned(), "0".to_owned());
+    limited
+        .headers
+        .insert("x-ratelimit-reset".to_owned(), reset.to_string());
+    let remote = search_remote(Arc::new(FakeHttp::with([limited])));
+    let comparison = RemoteUpdateComparison::new(
+        "grill",
+        "acme",
+        "skills",
+        CommitSha::parse("1".repeat(40)).unwrap(),
+        CommitSha::parse("2".repeat(40)).unwrap(),
+        RemoteComparisonAccess::PublicGithub,
+    )
+    .unwrap();
+
+    let results = remote.compare_updates(&[comparison]).unwrap();
+
+    assert!(matches!(
+        results[0].outcome,
+        RemoteComparisonOutcome::RateLimited {
+            retry_after_seconds: Some(1..=300),
+            reset_at: None,
+        }
+    ));
+}
+
+#[test]
 fn hosted_comparisons_are_authenticated_and_chunked_at_fifty() {
     let http = Arc::new(UpdatePlansHttp::default());
     let remote = SkilldRemote::new(
@@ -565,7 +670,7 @@ fn hosted_comparisons_are_authenticated_and_chunked_at_fifty() {
     assert!(results.iter().all(|result| matches!(
         result.outcome,
         RemoteComparisonOutcome::Ready {
-            relation: RemoteComparisonRelation::Identical,
+            relation: RemoteComparisonRelation::Ahead,
             ..
         }
     )));
@@ -587,6 +692,80 @@ fn hosted_comparisons_are_authenticated_and_chunked_at_fifty() {
     sizes.sort_unstable();
     assert_eq!(sizes, [1, 50]);
     assert!(http.maximum_concurrency.load(Ordering::SeqCst) <= 4);
+}
+
+#[test]
+fn hosted_comparison_accepts_the_largest_valid_commit_batch() {
+    let comparisons = (0..25)
+        .map(|index| {
+            RemoteUpdateComparison::new(
+                format!("skill-{index}"),
+                "acme",
+                "private-skills",
+                CommitSha::parse("1".repeat(40)).unwrap(),
+                CommitSha::parse("2".repeat(40)).unwrap(),
+                RemoteComparisonAccess::Hosted,
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let commits = (0..500)
+        .map(|index| {
+            json!({
+                "sha": format!("{index:040x}"),
+                "subject": "s".repeat(500),
+                "timestamp": "2026-08-21T00:00:00Z",
+                "author": {
+                    "name": "a".repeat(200),
+                    "login": "l".repeat(100),
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    let results = comparisons
+        .iter()
+        .map(|comparison| {
+            json!({
+                "_tag": "ready",
+                "id": comparison.id,
+                "owner": comparison.owner,
+                "repository": comparison.repository,
+                "baseSha": comparison.base_sha.as_str(),
+                "headSha": comparison.head_sha.as_str(),
+                "relation": "ahead",
+                "aheadBy": 500,
+                "behindBy": 0,
+                "commits": commits,
+                "total": 500,
+                "truncated": false,
+                "compareUrl": format!(
+                    "https://github.com/acme/private-skills/compare/{}...{}",
+                    comparison.base_sha.as_str(),
+                    comparison.head_sha.as_str(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    let body = serde_json::to_vec(&json!({ "results": results })).unwrap();
+    assert!(body.len() > 8 * 1024 * 1024);
+    let remote = SkilldRemote::new(
+        Arc::new(FakeHttp::with([response(200, body)])),
+        Arc::new(FixedToken),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap();
+
+    let results = remote.compare_updates(&comparisons).unwrap();
+
+    assert!(results.iter().all(|result| matches!(
+        result.outcome,
+        RemoteComparisonOutcome::Ready {
+            total: 500,
+            truncated: false,
+            ..
+        }
+    )));
 }
 
 #[test]
@@ -625,9 +804,16 @@ fn hosted_comparison_keeps_per_item_failures_and_retry_after() {
                     "repository": identity("ready")["repository"],
                     "baseSha": identity("ready")["baseSha"],
                     "headSha": identity("ready")["headSha"],
-                    "relation": "identical",
-                    "commits": [],
-                    "total": 0,
+                    "relation": "ahead",
+                    "aheadBy": 1,
+                    "behindBy": 0,
+                    "commits": [{
+                        "sha": identity("ready")["headSha"],
+                        "subject": "Update Skill",
+                        "timestamp": "2026-08-21T00:00:00Z",
+                        "author": { "name": "Ada Lovelace", "login": "ada" }
+                    }],
+                    "total": 1,
                     "truncated": false,
                     "compareUrl": format!(
                         "https://github.com/acme/private-skills/compare/{}...{}",
@@ -659,7 +845,7 @@ fn hosted_comparison_keeps_per_item_failures_and_retry_after() {
     assert!(matches!(
         results[0].outcome,
         RemoteComparisonOutcome::Ready {
-            relation: RemoteComparisonRelation::Identical,
+            relation: RemoteComparisonRelation::Ahead,
             ..
         }
     ));
@@ -669,6 +855,110 @@ fn hosted_comparison_keeps_per_item_failures_and_retry_after() {
             retry_after_seconds: Some(12),
             reset_at: Some(reset_at),
         } if reset_at == "2026-08-21T00:10:00.000Z"
+    ));
+}
+
+#[test]
+fn invalid_hosted_item_does_not_hide_a_ready_sibling() {
+    let inputs = ["ready", "invalid"]
+        .into_iter()
+        .map(|id| {
+            RemoteUpdateComparison::new(
+                id,
+                "acme",
+                "private-skills",
+                CommitSha::parse("1".repeat(40)).unwrap(),
+                CommitSha::parse("2".repeat(40)).unwrap(),
+                RemoteComparisonAccess::Hosted,
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+    let ready = |id: &str, subject: &str| {
+        json!({
+            "_tag": "ready",
+            "id": id,
+            "owner": "acme",
+            "repository": "private-skills",
+            "baseSha": "1".repeat(40),
+            "headSha": "2".repeat(40),
+            "relation": "ahead",
+            "aheadBy": 1,
+            "behindBy": 0,
+            "commits": [{
+                "sha": "2".repeat(40),
+                "subject": subject,
+                "timestamp": "2026-08-21T00:00:00Z",
+                "author": { "name": "Ada Lovelace", "login": "ada" }
+            }],
+            "total": 1,
+            "truncated": false,
+            "compareUrl": format!(
+                "https://github.com/acme/private-skills/compare/{}...{}",
+                "1".repeat(40),
+                "2".repeat(40),
+            )
+        })
+    };
+    let body = serde_json::to_vec(&json!({
+        "results": [ready("ready", "Valid commit"), ready("invalid", "")]
+    }))
+    .unwrap();
+    let remote = SkilldRemote::new(
+        Arc::new(FakeHttp::with([response(200, body)])),
+        Arc::new(FixedToken),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap();
+
+    let results = remote.compare_updates(&inputs).unwrap();
+
+    assert!(matches!(
+        results[0].outcome,
+        RemoteComparisonOutcome::Ready { .. }
+    ));
+    assert!(matches!(
+        results[1].outcome,
+        RemoteComparisonOutcome::RequestFailure {
+            code: "INVALID_RESPONSE",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn hosted_batch_rate_limit_stays_visible_for_each_item() {
+    let input = RemoteUpdateComparison::new(
+        "private",
+        "acme",
+        "private-skills",
+        CommitSha::parse("1".repeat(40)).unwrap(),
+        CommitSha::parse("2".repeat(40)).unwrap(),
+        RemoteComparisonAccess::Hosted,
+    )
+    .unwrap();
+    let mut limited = response(429, vec![]);
+    limited
+        .headers
+        .insert("retry-after".to_owned(), "120".to_owned());
+    let remote = SkilldRemote::new(
+        Arc::new(FakeHttp::with([limited])),
+        Arc::new(FixedToken),
+        NativeRemoteConfig::Unconfigured,
+    )
+    .with_endpoint("http://127.0.0.1:8787")
+    .unwrap()
+    .with_sleeper(Arc::new(NoSleep));
+
+    let results = remote.compare_updates(&[input]).unwrap();
+
+    assert!(matches!(
+        results[0].outcome,
+        RemoteComparisonOutcome::RateLimited {
+            retry_after_seconds: Some(120),
+            reset_at: None,
+        }
     ));
 }
 
@@ -1137,17 +1427,20 @@ impl RemoteProvider for FakeProvider {
         &self,
         comparisons: &[RemoteUpdateComparison],
     ) -> Result<Vec<skilld_command::RemoteUpdateResult>, RemoteError> {
+        let stale = *self.stale.lock().unwrap();
         Ok(comparisons
             .iter()
             .map(|comparison| skilld_command::RemoteUpdateResult {
                 id: comparison.id.clone(),
                 outcome: RemoteComparisonOutcome::Ready {
-                    relation: if *self.stale.lock().unwrap() {
+                    relation: if stale {
                         RemoteComparisonRelation::Ahead
                     } else {
                         RemoteComparisonRelation::Identical
                     },
-                    commits: if *self.stale.lock().unwrap() {
+                    ahead_by: u64::from(stale),
+                    behind_by: 0,
+                    commits: if stale {
                         vec![CommitSummary {
                             sha: comparison.head_sha.clone(),
                             subject: "Update example".to_owned(),
@@ -1166,7 +1459,7 @@ impl RemoteProvider for FakeProvider {
                     } else {
                         vec![]
                     },
-                    total: u64::from(*self.stale.lock().unwrap()),
+                    total: u64::from(stale),
                     truncated: false,
                     compare_url: format!(
                         "https://github.com/{}/{}/compare/{}...{}",
@@ -1220,11 +1513,11 @@ fn provider(content: &str) -> Arc<FakeProvider> {
     })
 }
 
-#[derive(Default)]
 struct BatchProvider {
     version: Mutex<&'static str>,
     prepared_names: Mutex<Vec<String>>,
     fail_name: Mutex<Option<&'static str>>,
+    relation: Mutex<RemoteComparisonRelation>,
 }
 
 impl BatchProvider {
@@ -1316,9 +1609,52 @@ impl RemoteProvider for BatchProvider {
 
     fn compare_updates(
         &self,
-        _comparisons: &[RemoteUpdateComparison],
+        comparisons: &[RemoteUpdateComparison],
     ) -> Result<Vec<skilld_command::RemoteUpdateResult>, RemoteError> {
-        unreachable!("comparison is outside this test")
+        Ok(comparisons
+            .iter()
+            .map(|comparison| {
+                let relation = *self.relation.lock().unwrap();
+                let (ahead_by, behind_by) = match relation {
+                    RemoteComparisonRelation::Ahead => (1, 0),
+                    RemoteComparisonRelation::Behind => (0, 1),
+                    RemoteComparisonRelation::Diverged => (1, 1),
+                    RemoteComparisonRelation::Identical => (0, 0),
+                };
+                skilld_command::RemoteUpdateResult {
+                    id: comparison.id.clone(),
+                    outcome: RemoteComparisonOutcome::Ready {
+                        relation,
+                        ahead_by,
+                        behind_by,
+                        commits: vec![CommitSummary {
+                            sha: comparison.head_sha.clone(),
+                            subject: "Update Skill".to_owned(),
+                            author: CommitAuthor {
+                                name: "Ada Lovelace".to_owned(),
+                                login: Some("ada".to_owned()),
+                            },
+                            timestamp: "2026-08-21T00:00:00Z".to_owned(),
+                            url: format!(
+                                "https://github.com/{}/{}/commit/{}",
+                                comparison.owner,
+                                comparison.repository,
+                                comparison.head_sha.as_str(),
+                            ),
+                        }],
+                        total: 1,
+                        truncated: false,
+                        compare_url: format!(
+                            "https://github.com/{}/{}/compare/{}...{}",
+                            comparison.owner,
+                            comparison.repository,
+                            comparison.base_sha.as_str(),
+                            comparison.head_sha.as_str(),
+                        ),
+                    },
+                }
+            })
+            .collect())
     }
 }
 
@@ -1331,6 +1667,7 @@ fn multi_skill_update_prepares_then_commits_every_artifact() {
         version: Mutex::new("first"),
         prepared_names: Mutex::new(vec![]),
         fail_name: Mutex::new(None),
+        relation: Mutex::new(RemoteComparisonRelation::Ahead),
     });
     let host = LocalHost::new(project.clone(), temporary.path().join("data"))
         .with_remote_provider(provider.clone());
@@ -1373,6 +1710,7 @@ fn multi_skill_update_changes_nothing_when_one_artifact_cannot_prepare() {
         version: Mutex::new("first"),
         prepared_names: Mutex::new(vec![]),
         fail_name: Mutex::new(None),
+        relation: Mutex::new(RemoteComparisonRelation::Ahead),
     });
     let host = LocalHost::new(project.clone(), temporary.path().join("data"))
         .with_remote_provider(provider.clone());
@@ -1406,6 +1744,42 @@ fn multi_skill_update_changes_nothing_when_one_artifact_cannot_prepare() {
             expected
         );
     }
+}
+
+#[test]
+fn plain_update_rejects_a_source_that_moved_behind() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = Arc::new(BatchProvider {
+        version: Mutex::new("first"),
+        prepared_names: Mutex::new(vec![]),
+        fail_name: Mutex::new(None),
+        relation: Mutex::new(RemoteComparisonRelation::Ahead),
+    });
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    host.install_request(InstallRequest {
+        source: Some(InstallSource::Remote(
+            "skilld:skilld-dev/skills/alpha".to_owned(),
+        )),
+        scope: InstallScope::Project,
+        targets: vec![AgentTargetId::Codex],
+        mode: Some(InstallMode::Copy),
+    })
+    .unwrap();
+    provider.prepared_names.lock().unwrap().clear();
+    *provider.version.lock().unwrap() = "second";
+    *provider.relation.lock().unwrap() = RemoteComparisonRelation::Behind;
+
+    let error = host.update(None).unwrap_err();
+
+    assert_eq!(error.code, "UPDATE_CONFIRMATION_REQUIRED");
+    assert!(provider.prepared_names.lock().unwrap().is_empty());
+    assert_eq!(
+        fs::read_to_string(project.join(".skills/alpha/SKILL.md")).unwrap(),
+        "---\nname: alpha\ndescription: first\n---\n"
+    );
 }
 
 #[test]
@@ -1464,6 +1838,7 @@ fn remote_install_verify_and_failed_update_use_the_normal_transaction() {
     );
     let before = fs::read(project.join(".skills/example/SKILL.md")).unwrap();
     *provider.content.lock().unwrap() = b"---\nname: example\ndescription: second\n---\n".to_vec();
+    *provider.stale.lock().unwrap() = true;
     *provider.fail_prepare.lock().unwrap() = true;
 
     let error = host.update(Some("example")).unwrap_err();
@@ -1522,6 +1897,7 @@ fn update_check_carries_the_exact_comparison_and_commit_history() {
     assert_eq!(outcome["_tag"], "Success");
     assert_eq!(outcome["command"], "update");
     assert_eq!(outcome["notices"], serde_json::json!([]));
+    assert_eq!(outcome["data"]["items"][0]["relation"]["aheadBy"], 1);
     assert!(matches!(
         check.items()[0].relation(),
         UpdateRelation::Available {

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1224,6 +1224,7 @@ fn provider(content: &str) -> Arc<FakeProvider> {
 struct BatchProvider {
     version: Mutex<&'static str>,
     prepared_names: Mutex<Vec<String>>,
+    fail_name: Mutex<Option<&'static str>>,
 }
 
 impl BatchProvider {
@@ -1280,6 +1281,12 @@ impl RemoteProvider for BatchProvider {
         _direct: bool,
     ) -> Result<PreparedRemoteSkill, RemoteError> {
         let mut prepared = self.prepared(selector);
+        let skilld_core::SourceSelector::NamedSkill { name } = &selector.source().selector else {
+            panic!("expected a named Skill selector")
+        };
+        if self.fail_name.lock().unwrap().as_ref() == Some(&name.as_str()) {
+            return Err(RemoteError::new("CHECK_BLOCKED", "a required check failed"));
+        }
         let LockedSource::Remote { commit_sha, .. } = &mut prepared.locked_source else {
             unreachable!("the fixture uses a remote source")
         };
@@ -1316,13 +1323,14 @@ impl RemoteProvider for BatchProvider {
 }
 
 #[test]
-fn multi_skill_update_prepares_every_artifact_before_refusing_partial_mutation() {
+fn multi_skill_update_prepares_then_commits_every_artifact() {
     let temporary = tempfile::tempdir().unwrap();
     let project = temporary.path().join("project");
     fs::create_dir_all(&project).unwrap();
     let provider = Arc::new(BatchProvider {
         version: Mutex::new("first"),
         prepared_names: Mutex::new(vec![]),
+        fail_name: Mutex::new(None),
     });
     let host = LocalHost::new(project.clone(), temporary.path().join("data"))
         .with_remote_provider(provider.clone());
@@ -1340,14 +1348,62 @@ fn multi_skill_update_prepares_every_artifact_before_refusing_partial_mutation()
     provider.prepared_names.lock().unwrap().clear();
     *provider.version.lock().unwrap() = "second";
 
-    let error = host.update(None).unwrap_err();
+    let lines = host.update(None).unwrap();
 
-    assert_eq!(error.code, "ATOMIC_UPDATE_UNAVAILABLE");
+    assert_eq!(lines, ["Updated Skill alpha.", "Updated Skill beta."]);
     assert_eq!(*provider.prepared_names.lock().unwrap(), ["alpha", "beta"]);
     for name in ["alpha", "beta"] {
         assert_eq!(
             fs::read_to_string(project.join(format!(".skills/{name}/SKILL.md"))).unwrap(),
-            format!("---\nname: {name}\ndescription: first\n---\n")
+            format!("---\nname: {name}\ndescription: second\n---\n")
+        );
+        assert_eq!(
+            fs::read_to_string(project.join(format!(".agents/skills/{name}/SKILL.md"))).unwrap(),
+            format!("---\nname: {name}\ndescription: second\n---\n")
+        );
+    }
+}
+
+#[test]
+fn multi_skill_update_changes_nothing_when_one_artifact_cannot_prepare() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = Arc::new(BatchProvider {
+        version: Mutex::new("first"),
+        prepared_names: Mutex::new(vec![]),
+        fail_name: Mutex::new(None),
+    });
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    for name in ["alpha", "beta"] {
+        host.install_request(InstallRequest {
+            source: Some(InstallSource::Remote(format!(
+                "skilld:skilld-dev/skills/{name}"
+            ))),
+            scope: InstallScope::Project,
+            targets: vec![AgentTargetId::Codex],
+            mode: Some(InstallMode::Copy),
+        })
+        .unwrap();
+    }
+    provider.prepared_names.lock().unwrap().clear();
+    *provider.version.lock().unwrap() = "second";
+    *provider.fail_name.lock().unwrap() = Some("beta");
+
+    let error = host.update(None).unwrap_err();
+
+    assert_eq!(error.code, "CHECK_BLOCKED");
+    assert_eq!(*provider.prepared_names.lock().unwrap(), ["alpha", "beta"]);
+    for name in ["alpha", "beta"] {
+        let expected = format!("---\nname: {name}\ndescription: first\n---\n");
+        assert_eq!(
+            fs::read_to_string(project.join(format!(".skills/{name}/SKILL.md"))).unwrap(),
+            expected
+        );
+        assert_eq!(
+            fs::read_to_string(project.join(format!(".agents/skills/{name}/SKILL.md"))).unwrap(),
+            expected
         );
     }
 }

--- a/crates/skilld-core/src/lib.rs
+++ b/crates/skilld-core/src/lib.rs
@@ -22,8 +22,9 @@ pub use target::{
     AGENT_TARGETS, AgentTarget, AgentTargetId, GlobalTargetPath, TargetSelection, select_target_ids,
 };
 pub use update::{
-    CommitSha, NotTrackedReason, UpdateCheckV1, UpdateFailure, UpdateLatestCommit,
-    UpdateModelError, UpdatePlan, UpdatePlanItem, UpdateRelation, classify_update_comparison,
+    CommitAuthor, CommitHistory, CommitSha, CommitSummary, NotTrackedReason, UpdateFailure,
+    UpdateLatestCommit, UpdateModelError, UpdatePlan, UpdatePlanItem, UpdatePlanV1, UpdateRelation,
+    UpdateRetryAfter, classify_update_comparison,
 };
 
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/crates/skilld-core/src/update.rs
+++ b/crates/skilld-core/src/update.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::num::NonZeroU64;
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -177,14 +178,18 @@ pub enum UpdateRelation {
     Available {
         locked_commit_sha: CommitSha,
         latest_commit_sha: CommitSha,
+        ahead_by: NonZeroU64,
     },
     Behind {
         locked_commit_sha: CommitSha,
         latest_commit_sha: CommitSha,
+        behind_by: NonZeroU64,
     },
     Diverged {
         locked_commit_sha: CommitSha,
         latest_commit_sha: CommitSha,
+        ahead_by: NonZeroU64,
+        behind_by: NonZeroU64,
     },
     Pinned {
         commit_sha: CommitSha,
@@ -212,15 +217,19 @@ pub fn classify_update_comparison(
         (false, ahead_by, 0) if ahead_by > 0 => Ok(UpdateRelation::Available {
             locked_commit_sha,
             latest_commit_sha,
+            ahead_by: NonZeroU64::new(ahead_by).expect("ahead count is non-zero"),
         }),
         (false, 0, behind_by) if behind_by > 0 => Ok(UpdateRelation::Behind {
             locked_commit_sha,
             latest_commit_sha,
+            behind_by: NonZeroU64::new(behind_by).expect("behind count is non-zero"),
         }),
         (false, ahead_by, behind_by) if ahead_by > 0 && behind_by > 0 => {
             Ok(UpdateRelation::Diverged {
                 locked_commit_sha,
                 latest_commit_sha,
+                ahead_by: NonZeroU64::new(ahead_by).expect("ahead count is non-zero"),
+                behind_by: NonZeroU64::new(behind_by).expect("behind count is non-zero"),
             })
         }
         _ => Err(UpdateModelError::InvalidComparison),

--- a/crates/skilld-core/src/update.rs
+++ b/crates/skilld-core/src/update.rs
@@ -1,9 +1,10 @@
 use std::fmt;
-use std::num::NonZeroU64;
 
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::SkillName;
+
+const MAX_COMMIT_HISTORY: usize = 500;
 
 #[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(try_from = "String", into = "String")]
@@ -42,9 +43,73 @@ impl From<CommitSha> for String {
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct CommitAuthor {
+    pub name: String,
+    pub login: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct CommitSummary {
+    pub sha: CommitSha,
+    pub subject: String,
+    pub author: CommitAuthor,
+    pub timestamp: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    deny_unknown_fields,
+    tag = "_tag",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum CommitHistory {
+    Compared {
+        items: Vec<CommitSummary>,
+        total: u64,
+        truncated: bool,
+        compare_url: String,
+    },
+    #[default]
+    NotNeeded,
+}
+
+impl CommitHistory {
+    pub fn compared(
+        items: Vec<CommitSummary>,
+        total: u64,
+        truncated: bool,
+        compare_url: impl Into<String>,
+    ) -> Result<Self, UpdateModelError> {
+        let item_count = u64::try_from(items.len()).unwrap_or(u64::MAX);
+        if items.len() > MAX_COMMIT_HISTORY
+            || item_count > total
+            || truncated != (item_count < total)
+        {
+            return Err(UpdateModelError::InvalidCommitHistory);
+        }
+        Ok(Self::Compared {
+            items,
+            total,
+            truncated,
+            compare_url: compare_url.into(),
+        })
+    }
+
+    pub const fn is_not_needed(&self) -> bool {
+        matches!(self, Self::NotNeeded)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct UpdateFailure {
     pub code: String,
     pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub retry_after: Option<UpdateRetryAfter>,
 }
 
 impl UpdateFailure {
@@ -52,8 +117,31 @@ impl UpdateFailure {
         Self {
             code: code.into(),
             message: message.into(),
+            retry_after: None,
         }
     }
+
+    pub fn rate_limited(message: impl Into<String>, retry_after: UpdateRetryAfter) -> Self {
+        Self {
+            code: "RATE_LIMITED".to_owned(),
+            message: message.into(),
+            retry_after: Some(retry_after),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(
+    deny_unknown_fields,
+    tag = "_tag",
+    rename_all = "camelCase",
+    rename_all_fields = "camelCase"
+)]
+pub enum UpdateRetryAfter {
+    Seconds { seconds: u64 },
+    Reset { reset_at: String },
+    SecondsAndReset { seconds: u64, reset_at: String },
+    Unknown,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
@@ -89,18 +177,14 @@ pub enum UpdateRelation {
     Available {
         locked_commit_sha: CommitSha,
         latest_commit_sha: CommitSha,
-        ahead_by: NonZeroU64,
     },
     Behind {
         locked_commit_sha: CommitSha,
         latest_commit_sha: CommitSha,
-        behind_by: NonZeroU64,
     },
     Diverged {
         locked_commit_sha: CommitSha,
         latest_commit_sha: CommitSha,
-        ahead_by: NonZeroU64,
-        behind_by: NonZeroU64,
     },
     Pinned {
         commit_sha: CommitSha,
@@ -128,19 +212,15 @@ pub fn classify_update_comparison(
         (false, ahead_by, 0) if ahead_by > 0 => Ok(UpdateRelation::Available {
             locked_commit_sha,
             latest_commit_sha,
-            ahead_by: NonZeroU64::new(ahead_by).expect("ahead count is non-zero"),
         }),
         (false, 0, behind_by) if behind_by > 0 => Ok(UpdateRelation::Behind {
             locked_commit_sha,
             latest_commit_sha,
-            behind_by: NonZeroU64::new(behind_by).expect("behind count is non-zero"),
         }),
         (false, ahead_by, behind_by) if ahead_by > 0 && behind_by > 0 => {
             Ok(UpdateRelation::Diverged {
                 locked_commit_sha,
                 latest_commit_sha,
-                ahead_by: NonZeroU64::new(ahead_by).expect("ahead count is non-zero"),
-                behind_by: NonZeroU64::new(behind_by).expect("behind count is non-zero"),
             })
         }
         _ => Err(UpdateModelError::InvalidComparison),
@@ -152,11 +232,25 @@ pub fn classify_update_comparison(
 pub struct UpdatePlanItem {
     name: SkillName,
     relation: UpdateRelation,
+    #[serde(default, skip_serializing_if = "CommitHistory::is_not_needed")]
+    history: CommitHistory,
 }
 
 impl UpdatePlanItem {
     pub fn new(name: SkillName, relation: UpdateRelation) -> Self {
-        Self { name, relation }
+        Self {
+            name,
+            relation,
+            history: CommitHistory::NotNeeded,
+        }
+    }
+
+    pub fn with_history(name: SkillName, relation: UpdateRelation, history: CommitHistory) -> Self {
+        Self {
+            name,
+            relation,
+            history,
+        }
     }
 
     pub const fn name(&self) -> &SkillName {
@@ -165,6 +259,10 @@ impl UpdatePlanItem {
 
     pub const fn relation(&self) -> &UpdateRelation {
         &self.relation
+    }
+
+    pub const fn history(&self) -> &CommitHistory {
+        &self.history
     }
 }
 
@@ -193,11 +291,11 @@ impl UpdatePlan {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct UpdateCheckV1 {
+pub struct UpdatePlanV1 {
     items: Vec<UpdatePlanItem>,
 }
 
-impl UpdateCheckV1 {
+impl UpdatePlanV1 {
     pub fn new(plan: UpdatePlan) -> Self {
         Self { items: plan.items }
     }
@@ -205,20 +303,37 @@ impl UpdateCheckV1 {
     pub fn items(&self) -> &[UpdatePlanItem] {
         &self.items
     }
+
+    pub fn has_changes(&self) -> bool {
+        self.items.iter().any(|item| {
+            matches!(
+                item.relation,
+                UpdateRelation::Available { .. }
+                    | UpdateRelation::Behind { .. }
+                    | UpdateRelation::Diverged { .. }
+            )
+        })
+    }
+
+    pub fn is_incomplete(&self) -> bool {
+        self.items
+            .iter()
+            .any(|item| matches!(item.relation, UpdateRelation::Unavailable { .. }))
+    }
 }
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-struct UpdateCheckV1Wire {
+struct UpdatePlanV1Wire {
     items: Vec<UpdatePlanItem>,
 }
 
-impl<'de> Deserialize<'de> for UpdateCheckV1 {
+impl<'de> Deserialize<'de> for UpdatePlanV1 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let wire = UpdateCheckV1Wire::deserialize(deserializer)?;
+        let wire = UpdatePlanV1Wire::deserialize(deserializer)?;
         UpdatePlan::new(wire.items)
             .map(Self::new)
             .map_err(serde::de::Error::custom)
@@ -229,6 +344,7 @@ impl<'de> Deserialize<'de> for UpdateCheckV1 {
 pub enum UpdateModelError {
     DuplicateSkill(String),
     InvalidCommitSha(String),
+    InvalidCommitHistory,
     InvalidComparison,
 }
 
@@ -239,6 +355,9 @@ impl fmt::Display for UpdateModelError {
                 write!(formatter, "duplicate Skill in update plan: {name}")
             }
             Self::InvalidCommitSha(_) => formatter.write_str("invalid Git commit in update plan"),
+            Self::InvalidCommitHistory => {
+                formatter.write_str("invalid Git commit history in update plan")
+            }
             Self::InvalidComparison => formatter.write_str("invalid Git update comparison"),
         }
     }

--- a/crates/skilld-core/tests/update.rs
+++ b/crates/skilld-core/tests/update.rs
@@ -1,8 +1,7 @@
-use std::num::NonZeroU64;
-
 use skilld_core::{
-    CommitSha, SkillName, UpdateCheckV1, UpdateLatestCommit, UpdateModelError, UpdatePlan,
-    UpdatePlanItem, UpdateRelation, classify_update_comparison,
+    CommitAuthor, CommitHistory, CommitSha, CommitSummary, SkillName, UpdateLatestCommit,
+    UpdateModelError, UpdatePlan, UpdatePlanItem, UpdatePlanV1, UpdateRelation,
+    classify_update_comparison,
 };
 
 fn sha(value: char) -> CommitSha {
@@ -25,7 +24,6 @@ fn comparison_counts_classify_every_git_relation() {
         UpdateRelation::Available {
             locked_commit_sha: locked.clone(),
             latest_commit_sha: latest.clone(),
-            ahead_by: NonZeroU64::new(3).unwrap(),
         }
     );
     assert_eq!(
@@ -33,7 +31,6 @@ fn comparison_counts_classify_every_git_relation() {
         UpdateRelation::Behind {
             locked_commit_sha: locked.clone(),
             latest_commit_sha: latest.clone(),
-            behind_by: NonZeroU64::new(2).unwrap(),
         }
     );
     assert_eq!(
@@ -41,8 +38,6 @@ fn comparison_counts_classify_every_git_relation() {
         UpdateRelation::Diverged {
             locked_commit_sha: locked,
             latest_commit_sha: latest,
-            ahead_by: NonZeroU64::new(4).unwrap(),
-            behind_by: NonZeroU64::new(2).unwrap(),
         }
     );
 }
@@ -102,15 +97,68 @@ fn update_plan_sorts_skills_and_rejects_duplicates() {
 }
 
 #[test]
+fn update_plan_carries_full_bounded_commit_history() {
+    let item = UpdatePlanItem::with_history(
+        SkillName::parse("grill").unwrap(),
+        UpdateRelation::Available {
+            locked_commit_sha: sha('1'),
+            latest_commit_sha: sha('2'),
+        },
+        CommitHistory::compared(
+            vec![CommitSummary {
+                sha: sha('2'),
+                subject: "Add charcoal timing".to_owned(),
+                author: CommitAuthor {
+                    name: "Ada Lovelace".to_owned(),
+                    login: Some("ada".to_owned()),
+                },
+                timestamp: "2026-08-21T00:00:00Z".to_owned(),
+                url: format!(
+                    "https://github.com/acme/skills/commit/{}",
+                    sha('2').as_str()
+                ),
+            }],
+            501,
+            true,
+            format!(
+                "https://github.com/acme/skills/compare/{}...{}",
+                sha('1').as_str(),
+                sha('2').as_str()
+            ),
+        )
+        .unwrap(),
+    );
+    let plan = UpdatePlanV1::new(UpdatePlan::new(vec![item]).unwrap());
+    let value = serde_json::to_value(plan).unwrap();
+
+    assert_eq!(value["items"][0]["history"]["total"], 501);
+    assert_eq!(value["items"][0]["history"]["truncated"], true);
+    assert_eq!(
+        value["items"][0]["history"]["items"][0]["sha"],
+        sha('2').as_str()
+    );
+    assert_eq!(
+        value["items"][0]["history"]["compareUrl"],
+        format!(
+            "https://github.com/acme/skills/compare/{}...{}",
+            sha('1').as_str(),
+            sha('2').as_str()
+        )
+    );
+}
+
+#[test]
 fn v1_check_fixture_covers_the_published_relations() {
     let bytes = include_bytes!("../../../tests/fixtures/v3-rust/v1/update-check.json");
     let fixture: serde_json::Value = serde_json::from_slice(bytes).unwrap();
-    let check: UpdateCheckV1 = serde_json::from_value(fixture["data"].clone()).unwrap();
+    let check: UpdatePlanV1 = serde_json::from_value(fixture["data"].clone()).unwrap();
 
     assert_eq!(fixture["schemaVersion"], 1);
     assert_eq!(fixture["_tag"], "Success");
     assert_eq!(fixture["command"], "update");
     assert_eq!(check.items().len(), 7);
+    assert!(check.has_changes());
+    assert!(check.is_incomplete());
     assert!(matches!(
         check.items()[6].relation(),
         UpdateRelation::Unavailable {

--- a/crates/skilld-core/tests/update.rs
+++ b/crates/skilld-core/tests/update.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU64;
+
 use skilld_core::{
     CommitAuthor, CommitHistory, CommitSha, CommitSummary, SkillName, UpdateLatestCommit,
     UpdateModelError, UpdatePlan, UpdatePlanItem, UpdatePlanV1, UpdateRelation,
@@ -24,6 +26,7 @@ fn comparison_counts_classify_every_git_relation() {
         UpdateRelation::Available {
             locked_commit_sha: locked.clone(),
             latest_commit_sha: latest.clone(),
+            ahead_by: NonZeroU64::new(3).unwrap(),
         }
     );
     assert_eq!(
@@ -31,6 +34,7 @@ fn comparison_counts_classify_every_git_relation() {
         UpdateRelation::Behind {
             locked_commit_sha: locked.clone(),
             latest_commit_sha: latest.clone(),
+            behind_by: NonZeroU64::new(2).unwrap(),
         }
     );
     assert_eq!(
@@ -38,6 +42,8 @@ fn comparison_counts_classify_every_git_relation() {
         UpdateRelation::Diverged {
             locked_commit_sha: locked,
             latest_commit_sha: latest,
+            ahead_by: NonZeroU64::new(4).unwrap(),
+            behind_by: NonZeroU64::new(2).unwrap(),
         }
     );
 }
@@ -103,6 +109,7 @@ fn update_plan_carries_full_bounded_commit_history() {
         UpdateRelation::Available {
             locked_commit_sha: sha('1'),
             latest_commit_sha: sha('2'),
+            ahead_by: NonZeroU64::new(501).unwrap(),
         },
         CommitHistory::compared(
             vec![CommitSummary {

--- a/tests/fixtures/v3-rust/v1/update-check.json
+++ b/tests/fixtures/v3-rust/v1/update-check.json
@@ -9,7 +9,8 @@
       "relation": {
         "_tag": "available",
         "lockedCommitSha": "1111111111111111111111111111111111111111",
-        "latestCommitSha": "2222222222222222222222222222222222222222"
+        "latestCommitSha": "2222222222222222222222222222222222222222",
+        "aheadBy": 3
       },
       "history": {
         "_tag": "compared",
@@ -35,7 +36,8 @@
       "relation": {
         "_tag": "behind",
         "lockedCommitSha": "2222222222222222222222222222222222222222",
-        "latestCommitSha": "1111111111111111111111111111111111111111"
+        "latestCommitSha": "1111111111111111111111111111111111111111",
+        "behindBy": 2
       }
     },
     {
@@ -50,7 +52,9 @@
       "relation": {
         "_tag": "diverged",
         "lockedCommitSha": "1111111111111111111111111111111111111111",
-        "latestCommitSha": "2222222222222222222222222222222222222222"
+        "latestCommitSha": "2222222222222222222222222222222222222222",
+        "aheadBy": 4,
+        "behindBy": 2
       }
     },
     {

--- a/tests/fixtures/v3-rust/v1/update-check.json
+++ b/tests/fixtures/v3-rust/v1/update-check.json
@@ -9,8 +9,25 @@
       "relation": {
         "_tag": "available",
         "lockedCommitSha": "1111111111111111111111111111111111111111",
-        "latestCommitSha": "2222222222222222222222222222222222222222",
-        "aheadBy": 3
+        "latestCommitSha": "2222222222222222222222222222222222222222"
+      },
+      "history": {
+        "_tag": "compared",
+        "items": [
+          {
+            "sha": "2222222222222222222222222222222222222222",
+            "subject": "Add update review",
+            "author": {
+              "name": "Ada Lovelace",
+              "login": "ada"
+            },
+            "timestamp": "2026-08-21T00:00:00Z",
+            "url": "https://github.com/acme/skills/commit/2222222222222222222222222222222222222222"
+          }
+        ],
+        "total": 3,
+        "truncated": true,
+        "compareUrl": "https://github.com/acme/skills/compare/1111111111111111111111111111111111111111...2222222222222222222222222222222222222222"
       }
     },
     {
@@ -18,8 +35,7 @@
       "relation": {
         "_tag": "behind",
         "lockedCommitSha": "2222222222222222222222222222222222222222",
-        "latestCommitSha": "1111111111111111111111111111111111111111",
-        "behindBy": 2
+        "latestCommitSha": "1111111111111111111111111111111111111111"
       }
     },
     {
@@ -34,9 +50,7 @@
       "relation": {
         "_tag": "diverged",
         "lockedCommitSha": "1111111111111111111111111111111111111111",
-        "latestCommitSha": "2222222222222222222222222222222222222222",
-        "aheadBy": 4,
-        "behindBy": 2
+        "latestCommitSha": "2222222222222222222222222222222222222222"
       }
     },
     {


### PR DESCRIPTION
`skilld update --check --json` now gives Agents the exact Git relation, both ancestry counts, and up to 500 newest commit summaries.

Public Repositories use anonymous GitHub compare requests. Private Repositories use skilld.dev. The skilld token never goes to GitHub. Checks run in batches with four requests at most. A failed Skill keeps the other results visible, including rate limit timing.

Plain updates now accept fast-forward commits only. Rewinds and diverged refs stop for confirmation. skilld prepares every exact commit before any write. It then commits the full selection through one recoverable transaction. If preparation or commit fails, the store restores every prior version.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).