### PR TITLE
feat(cli): add interactive Skill update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,7 +112,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -137,7 +143,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -163,7 +169,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -269,6 +275,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +377,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +462,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +528,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.119",
 ]
@@ -579,6 +674,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "endi"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +762,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,7 +809,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -808,11 +921,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -964,6 +1088,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -991,9 +1121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1007,10 +1146,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1070,6 +1231,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1081,10 +1248,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "macro-string"
@@ -1110,6 +1295,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1281,6 +1478,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,7 +1555,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1437,6 +1663,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1717,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1468,7 +1737,7 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1506,6 +1775,24 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secret-service"
@@ -1662,6 +1949,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,7 +2016,7 @@ dependencies = [
  "sha2 0.11.0",
  "skilld-core",
  "tempfile",
- "unicode-width",
+ "unicode-width 0.2.0",
  "url",
 ]
 
@@ -1728,12 +2036,15 @@ dependencies = [
 name = "skilld-native"
 version = "3.0.0-beta.1"
 dependencies = [
+ "crossterm",
  "nix",
+ "ratatui",
  "skilld-auth",
  "skilld-command",
  "skilld-core",
  "tempfile",
  "terminal_size",
+ "unicode-width 0.2.0",
  "ureq",
  "url",
 ]
@@ -1788,6 +2099,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,7 +2168,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.3",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1845,7 +2178,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -1974,10 +2307,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-segmentation"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "untrusted"
@@ -2099,7 +2455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -2112,6 +2468,28 @@ checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2378,7 +2756,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
 dependencies = [
  "anyhow",
- "hashbrown",
+ "hashbrown 0.17.1",
  "id-arena",
  "indexmap",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ skilld-core = { path = "crates/skilld-core" }
 subtle = "2.6.1"
 tempfile = "3.27.0"
 terminal_size = "0.4.4"
-unicode-width = "0.2.2"
+unicode-width = "=0.2.0"
 url = "2.5.8"
 wit-bindgen = "0.60.0"
 zeroize = "1.9.0"

--- a/crates/skilld-command/src/lib.rs
+++ b/crates/skilld-command/src/lib.rs
@@ -95,6 +95,12 @@ enum Command {
         /// Check update relations without changing files.
         #[arg(long)]
         check: bool,
+        /// Select Skill updates in a terminal.
+        #[arg(
+            long,
+            conflicts_with_all = ["skill", "check", "json", "plain"]
+        )]
+        interactive: bool,
     },
     /// Verify a Skill source.
     Verify { skill: Option<String> },
@@ -168,6 +174,16 @@ pub trait Host {
     fn update(&self, _name: Option<&str>) -> Result<Vec<String>, CommandError> {
         Err(CommandError::unsupported_host(
             "Skill update is unavailable on this host",
+        ))
+    }
+
+    fn update_selected(&self, names: &[String]) -> Result<Vec<String>, CommandError> {
+        let names = parse_update_selection(names)?;
+        if let [name] = names.as_slice() {
+            return self.update(Some(name));
+        }
+        Err(CommandError::unsupported_host(
+            "Selected Skill updates are unavailable on this host",
         ))
     }
 
@@ -311,6 +327,22 @@ impl std::error::Error for CommandError {}
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CommandResult {
     pub exit_code: u8,
+}
+
+pub fn interactive_update_requested<I, T>(args: I) -> Result<bool, clap::Error>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    Cli::try_parse_from(args).map(|cli| {
+        matches!(
+            cli.command,
+            Command::Update {
+                interactive: true,
+                ..
+            }
+        )
+    })
 }
 
 enum CommandOutput {
@@ -678,8 +710,16 @@ fn dispatch<H: Host>(command: Command, host: &H) -> Result<CommandOutput, Comman
                 total: response.total,
             }))
         }
-        Command::Update { skill, check } => {
-            if check {
+        Command::Update {
+            skill,
+            check,
+            interactive,
+        } => {
+            if interactive {
+                Err(CommandError::unsupported_host(
+                    "Interactive Skill update needs a native terminal host",
+                ))
+            } else if check {
                 host.update_check(skill.as_deref())
                     .map(CommandOutput::UpdateCheck)
             } else {
@@ -1421,6 +1461,14 @@ impl Host for LocalHost {
             .collect())
     }
 
+    fn update_selected(&self, names: &[String]) -> Result<Vec<String>, CommandError> {
+        let names = parse_update_selection(names)?;
+        let scope = InstallScope::Project;
+        let known = self.known_targets(scope)?;
+        let store = self.store(scope);
+        apply_update_selection(self, names, store, known)
+    }
+
     fn update_check(&self, requested: Option<&str>) -> Result<UpdatePlanV1, CommandError> {
         let scope = InstallScope::Project;
         let known = self.known_targets(scope)?;
@@ -1602,6 +1650,184 @@ struct PreparedUpdateSelection {
     targets: Vec<TargetInstall>,
     expected_transaction_id: String,
     expected_skill: skilld_core::LockedSkill,
+}
+
+fn apply_update_selection(
+    host: &LocalHost,
+    names: Vec<String>,
+    store: LocalStore,
+    known: Vec<ResolvedTarget>,
+) -> Result<Vec<String>, CommandError> {
+    let provider = host.remote_provider()?;
+    let mut pending = Vec::new();
+    for name in names {
+        let skill_name =
+            skilld_core::SkillName::parse(name.clone()).map_err(CommandError::domain)?;
+        let view = store
+            .verify_content(&skill_name, &known)
+            .map_err(CommandError::store)?;
+        let LockedSource::Remote { source, .. } = &view.skill.source else {
+            continue;
+        };
+        if !matches!(
+            view.skill.source_status,
+            skilld_core::SourceStatus::Verified { .. }
+        ) {
+            return Err(CommandError::operation(
+                "UNVERIFIED_SOURCE",
+                format!("Skill {name} needs another explicit --direct install"),
+            ));
+        }
+        let selector = skilld_core::RemoteSelector::parse(source).map_err(CommandError::remote)?;
+        if matches!(selector.source().r#ref, Some(SourceRef::Commit { .. })) {
+            continue;
+        }
+        let latest_commit = provider
+            .latest_commit(&selector, false)
+            .map_err(CommandError::remote)?;
+        let LockedSource::Remote { commit_sha, .. } = &view.skill.source else {
+            unreachable!("the update candidate has a remote source")
+        };
+        let locked_commit_sha = CommitSha::parse(commit_sha.clone()).map_err(update_model_error)?;
+        if latest_commit.commit_sha == locked_commit_sha {
+            continue;
+        }
+        let comparison = RemoteUpdateComparison::new(
+            skill_name.as_str(),
+            &selector.source().owner,
+            &selector.source().repository,
+            locked_commit_sha,
+            latest_commit.commit_sha.clone(),
+            latest_commit.access,
+        )
+        .map_err(CommandError::remote)?;
+        pending.push(PendingUpdateApply {
+            name,
+            skill_name,
+            view,
+            selector,
+            expected_commit: latest_commit.commit_sha,
+            comparison,
+        });
+    }
+    if pending.is_empty() {
+        return Ok(vec![]);
+    }
+    let comparisons = pending
+        .iter()
+        .map(|pending| pending.comparison.clone())
+        .collect::<Vec<_>>();
+    let results = provider
+        .compare_updates(&comparisons)
+        .map_err(CommandError::remote)?;
+    if results.len() != pending.len() {
+        return Err(CommandError::service(
+            "Update comparison results were incomplete",
+        ));
+    }
+    let mut selected = Vec::new();
+    for (pending, result) in pending.into_iter().zip(results) {
+        if pending.comparison.id != result.id {
+            return Err(CommandError::service(
+                "Update comparison results changed order",
+            ));
+        }
+        match result.outcome {
+            RemoteComparisonOutcome::Ready {
+                relation: RemoteComparisonRelation::Ahead,
+                total,
+                ..
+            } if total > 0 => {}
+            RemoteComparisonOutcome::Ready {
+                relation: RemoteComparisonRelation::Behind,
+                ..
+            } => {
+                return Err(CommandError::operation(
+                    "UPDATE_CONFIRMATION_REQUIRED",
+                    format!(
+                        "Skill {} needs interactive confirmation because its source moved behind",
+                        pending.name
+                    ),
+                ));
+            }
+            RemoteComparisonOutcome::Ready {
+                relation: RemoteComparisonRelation::Diverged,
+                ..
+            } => {
+                return Err(CommandError::operation(
+                    "UPDATE_CONFIRMATION_REQUIRED",
+                    format!(
+                        "Skill {} needs interactive confirmation because its source diverged",
+                        pending.name
+                    ),
+                ));
+            }
+            RemoteComparisonOutcome::Ready { .. } => {
+                return Err(CommandError::operation(
+                    "INVALID_RESPONSE",
+                    "GitHub returned an impossible update relation",
+                ));
+            }
+            outcome => return Err(update_apply_failure(&pending.name, outcome)),
+        }
+        let prepared = provider
+            .prepare_exact(&pending.selector, &pending.expected_commit, false)
+            .map_err(CommandError::remote)?;
+        let staged = materialize_remote(&prepared.files)?;
+        let staged_name =
+            skilld_core::SkillName::from_source(staged.path()).map_err(CommandError::domain)?;
+        if staged_name != pending.skill_name {
+            return Err(CommandError::operation(
+                "SOURCE_MISMATCH",
+                format!("the updated Skill name changed from {}", pending.name),
+            ));
+        }
+        let targets = pending
+            .view
+            .skill
+            .targets
+            .iter()
+            .map(|locked| {
+                known
+                    .iter()
+                    .find(|target| target.agent == locked.agent)
+                    .cloned()
+                    .map(|target| TargetInstall {
+                        target,
+                        mode: locked.mode,
+                    })
+                    .ok_or_else(|| {
+                        CommandError::domain(DomainError::InvalidTarget(locked.agent.to_string()))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        selected.push(PreparedUpdateSelection {
+            name: pending.name,
+            staged,
+            prepared,
+            targets,
+            expected_transaction_id: pending.view.transaction_id,
+            expected_skill: pending.view.skill,
+        });
+    }
+    let updates = selected
+        .iter()
+        .map(|selection| PreparedStoreUpdate {
+            source: selection.staged.path().to_owned(),
+            locked_source: selection.prepared.locked_source.clone(),
+            source_status: Some(selection.prepared.source_status.clone()),
+            targets: selection.targets.clone(),
+            expected_transaction_id: selection.expected_transaction_id.clone(),
+            expected_skill: selection.expected_skill.clone(),
+        })
+        .collect();
+    store
+        .apply_update_batch(updates, &known)
+        .map_err(CommandError::store)?;
+    Ok(selected
+        .into_iter()
+        .map(|selection| format!("Updated Skill {}.", selection.name))
+        .collect())
 }
 
 fn update_plan_item(
@@ -1816,6 +2042,28 @@ fn selected_names(
     } else {
         store.list(known).map_err(CommandError::store)
     }
+}
+
+fn parse_update_selection(names: &[String]) -> Result<Vec<String>, CommandError> {
+    if names.is_empty() {
+        return Err(CommandError::usage(
+            "INVALID_SELECTION",
+            "Select at least one Skill",
+        ));
+    }
+    let mut unique = BTreeSet::new();
+    let mut parsed = Vec::with_capacity(names.len());
+    for name in names {
+        let name = skilld_core::SkillName::parse(name.clone()).map_err(CommandError::domain)?;
+        if !unique.insert(name.clone()) {
+            return Err(CommandError::usage(
+                "INVALID_SELECTION",
+                "Select each Skill once",
+            ));
+        }
+        parsed.push(name.to_string());
+    }
+    Ok(parsed)
 }
 
 fn unavailable_update(

--- a/crates/skilld-command/tests/remote.rs
+++ b/crates/skilld-command/tests/remote.rs
@@ -1783,6 +1783,110 @@ fn plain_update_rejects_a_source_that_moved_behind() {
 }
 
 #[test]
+fn selected_skill_update_commits_only_the_exact_subset() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = Arc::new(BatchProvider {
+        version: Mutex::new("first"),
+        prepared_names: Mutex::new(vec![]),
+        fail_name: Mutex::new(None),
+        relation: Mutex::new(RemoteComparisonRelation::Ahead),
+    });
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    for name in ["alpha", "beta", "gamma"] {
+        host.install_request(InstallRequest {
+            source: Some(InstallSource::Remote(format!(
+                "skilld:skilld-dev/skills/{name}"
+            ))),
+            scope: InstallScope::Project,
+            targets: vec![AgentTargetId::Codex],
+            mode: Some(InstallMode::Copy),
+        })
+        .unwrap();
+    }
+    provider.prepared_names.lock().unwrap().clear();
+    *provider.version.lock().unwrap() = "second";
+
+    let lines = host
+        .update_selected(&["gamma".to_owned(), "alpha".to_owned()])
+        .unwrap();
+
+    assert_eq!(lines, ["Updated Skill gamma.", "Updated Skill alpha."]);
+    assert_eq!(*provider.prepared_names.lock().unwrap(), ["gamma", "alpha"]);
+    for (name, version) in [("alpha", "second"), ("beta", "first"), ("gamma", "second")] {
+        assert_eq!(
+            fs::read_to_string(project.join(format!(".skills/{name}/SKILL.md"))).unwrap(),
+            format!("---\nname: {name}\ndescription: {version}\n---\n")
+        );
+    }
+}
+
+#[test]
+fn selected_skill_update_rejects_empty_duplicate_and_invalid_names() {
+    let temporary = tempfile::tempdir().unwrap();
+    let host = LocalHost::new(
+        temporary.path().join("project"),
+        temporary.path().join("data"),
+    );
+
+    let empty = host.update_selected(&[]).unwrap_err();
+    let duplicate = host
+        .update_selected(&["alpha".to_owned(), "alpha".to_owned()])
+        .unwrap_err();
+    let invalid = host.update_selected(&["../alpha".to_owned()]).unwrap_err();
+
+    assert_eq!(empty.code, "INVALID_SELECTION");
+    assert_eq!(empty.message, "Select at least one Skill");
+    assert_eq!(duplicate.code, "INVALID_SELECTION");
+    assert_eq!(duplicate.message, "Select each Skill once");
+    assert_eq!(invalid.code, "INVALID_SOURCE");
+}
+
+#[test]
+fn selected_skill_update_changes_nothing_when_one_selected_artifact_fails() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    fs::create_dir_all(&project).unwrap();
+    let provider = Arc::new(BatchProvider {
+        version: Mutex::new("first"),
+        prepared_names: Mutex::new(vec![]),
+        fail_name: Mutex::new(None),
+        relation: Mutex::new(RemoteComparisonRelation::Ahead),
+    });
+    let host = LocalHost::new(project.clone(), temporary.path().join("data"))
+        .with_remote_provider(provider.clone());
+    for name in ["alpha", "beta", "gamma"] {
+        host.install_request(InstallRequest {
+            source: Some(InstallSource::Remote(format!(
+                "skilld:skilld-dev/skills/{name}"
+            ))),
+            scope: InstallScope::Project,
+            targets: vec![AgentTargetId::Codex],
+            mode: Some(InstallMode::Copy),
+        })
+        .unwrap();
+    }
+    provider.prepared_names.lock().unwrap().clear();
+    *provider.version.lock().unwrap() = "second";
+    *provider.fail_name.lock().unwrap() = Some("gamma");
+
+    let error = host
+        .update_selected(&["alpha".to_owned(), "gamma".to_owned()])
+        .unwrap_err();
+
+    assert_eq!(error.code, "CHECK_BLOCKED");
+    assert_eq!(*provider.prepared_names.lock().unwrap(), ["alpha", "gamma"]);
+    for name in ["alpha", "beta", "gamma"] {
+        assert_eq!(
+            fs::read_to_string(project.join(format!(".skills/{name}/SKILL.md"))).unwrap(),
+            format!("---\nname: {name}\ndescription: first\n---\n")
+        );
+    }
+}
+
+#[test]
 fn verify_reports_changed_bytes_and_stale_sources() {
     let temporary = tempfile::tempdir().unwrap();
     let project = temporary.path().join("project");

--- a/crates/skilld-native/Cargo.toml
+++ b/crates/skilld-native/Cargo.toml
@@ -30,5 +30,14 @@ ureq = { version = "=3.1.4", default-features = false, features = [ "rustls" ] }
 
 url.workspace = true
 
+[target.'cfg(not(target_os = "wasi"))'.dependencies]
+crossterm = { version = "=0.28.1", default-features = false, features = [
+  "events",
+  "windows",
+] }
+ratatui = { version = "=0.29.0", default-features = false, features = [ "crossterm" ] }
+
+unicode-width.workspace = true
+
 [target.'cfg(unix)'.dev-dependencies]
 nix = { version = "0.29.0", features = [ "term" ] }

--- a/crates/skilld-native/src/lib.rs
+++ b/crates/skilld-native/src/lib.rs
@@ -6,6 +6,9 @@ use skilld_command::{Cancellation, HttpAdapter, HttpMethod, HttpRequest, HttpRes
 use skilld_core::RemoteError;
 use url::Url;
 
+#[cfg(not(target_os = "wasi"))]
+pub mod update_ui;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BrowserCommand {
     pub program: &'static str,

--- a/crates/skilld-native/src/main.rs
+++ b/crates/skilld-native/src/main.rs
@@ -2,7 +2,7 @@ mod embedded_skill;
 mod native_auth;
 
 use std::env;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 use std::sync::Arc;
@@ -11,13 +11,17 @@ use embedded_skill::EmbeddedSkilld;
 use native_auth::NativeAccount;
 use skilld_command::{
     CommandError, DetectionEnvironment, Host, LocalHost, NativeRemoteConfig, OutputContext,
-    SkilldRemote, TargetRoots, run_stdio_probe, run_with_output,
+    SkilldRemote, TargetRoots, interactive_update_requested, run_stdio_probe, run_with_output,
 };
 use skilld_core::{
     InstallScope, InstallSource, SearchResponse, SearchResult, SourceProvider, SourceRequest,
     SourceSelector, TrustedRootPin,
 };
 use skilld_native::NativeHttpAdapter;
+use skilld_native::update_ui::{
+    CommandInteractiveUpdateHost, require_interactive_tty, run_interactive_update,
+    write_static_summary,
+};
 use terminal_size::Width;
 
 fn main() -> ExitCode {
@@ -32,6 +36,18 @@ fn main() -> ExitCode {
         return run_search_output_probe();
     }
 
+    let args = env::args_os().collect::<Vec<_>>();
+    let interactive = interactive_update_requested(args.clone()).is_ok_and(|requested| requested);
+    if interactive {
+        if let Err(error) = require_interactive_tty(
+            std::io::stdin().is_terminal(),
+            std::io::stdout().is_terminal(),
+        ) {
+            eprintln!("{error}");
+            return ExitCode::from(2);
+        }
+    }
+
     let project_root = match env::current_dir() {
         Ok(path) => path,
         Err(error) => {
@@ -42,16 +58,43 @@ fn main() -> ExitCode {
     let global_root = global_root();
     let detection = detection_environment();
     let account = Arc::new(NativeAccount::new());
-    let host = LocalHost::new(project_root, global_root)
-        .with_target_roots(target_roots())
-        .with_detection_environment(detection.clone())
-        .with_bundled_provider(Arc::new(EmbeddedSkilld::new()))
-        .with_account_provider(account.clone())
-        .with_remote_provider(Arc::new(SkilldRemote::new(
-            Arc::new(NativeHttpAdapter::new()),
-            account,
-            native_remote_config(),
-        )));
+    let host = Arc::new(
+        LocalHost::new(project_root, global_root)
+            .with_target_roots(target_roots())
+            .with_detection_environment(detection.clone())
+            .with_bundled_provider(Arc::new(EmbeddedSkilld::new()))
+            .with_account_provider(account.clone())
+            .with_remote_provider(Arc::new(SkilldRemote::new(
+                Arc::new(NativeHttpAdapter::new()),
+                account,
+                native_remote_config(),
+            ))),
+    );
+
+    if interactive {
+        let interactive_host = Arc::new(CommandInteractiveUpdateHost::new(host));
+        return match run_interactive_update(interactive_host, !environment_present("NO_COLOR")) {
+            Ok(summary) => {
+                let exit_code = summary.exit_code();
+                let mut stdout = std::io::stdout().lock();
+                if let Err(error) = write_static_summary(&summary, &mut stdout) {
+                    eprintln!("{error}");
+                    ExitCode::from(2)
+                } else if stdout.flush().is_err() {
+                    eprintln!(
+                        "TERMINAL_UNAVAILABLE: The Skill update summary could not be written."
+                    );
+                    ExitCode::from(2)
+                } else {
+                    ExitCode::from(exit_code)
+                }
+            }
+            Err(error) => {
+                eprintln!("{error}");
+                ExitCode::from(2)
+            }
+        };
+    }
 
     let mut stdout = std::io::stdout().lock();
     let mut stderr = std::io::stderr().lock();
@@ -63,7 +106,7 @@ fn main() -> ExitCode {
         env::var("TERM").is_ok_and(|term| term.eq_ignore_ascii_case("dumb")),
         terminal_width(),
     );
-    let result = run_with_output(env::args_os(), &host, output, &mut stdout, &mut stderr);
+    let result = run_with_output(args, host.as_ref(), output, &mut stdout, &mut stderr);
     ExitCode::from(result.exit_code)
 }
 

--- a/crates/skilld-native/src/update_ui.rs
+++ b/crates/skilld-native/src/update_ui.rs
@@ -1,0 +1,1723 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fmt;
+use std::io::{self, Write};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::mpsc::{self, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use crossterm::cursor::{Hide, Show};
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::Terminal;
+use ratatui::backend::{CrosstermBackend, TestBackend};
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Text};
+use ratatui::widgets::{Block, List, ListItem, ListState, Paragraph, Tabs};
+use skilld_command::{CommandError, Host};
+use skilld_core::{CommitHistory, UpdatePlanV1, UpdateRelation, UpdateRetryAfter};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+use url::Url;
+
+const SPINNER: [&str; 4] = ["⠋", "⠙", "⠹", "⠸"];
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct ComparisonId(String);
+
+impl ComparisonId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(clean_text(&value.into()))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UpdateCandidate {
+    Available {
+        name: String,
+        repository: String,
+        locked_commit_sha: String,
+        latest_commit_sha: String,
+        commit_count: u64,
+        comparison_id: ComparisonId,
+    },
+    Unavailable {
+        name: String,
+        error: InteractiveUpdateError,
+    },
+}
+
+impl UpdateCandidate {
+    pub fn new(
+        name: impl Into<String>,
+        repository: impl Into<String>,
+        locked_commit_sha: impl Into<String>,
+        latest_commit_sha: impl Into<String>,
+        commit_count: u64,
+        comparison_id: ComparisonId,
+    ) -> Self {
+        Self::Available {
+            name: clean_text(&name.into()),
+            repository: clean_text(&repository.into()),
+            locked_commit_sha: clean_text(&locked_commit_sha.into()),
+            latest_commit_sha: clean_text(&latest_commit_sha.into()),
+            commit_count,
+            comparison_id,
+        }
+    }
+
+    pub fn unavailable(name: impl Into<String>, error: InteractiveUpdateError) -> Self {
+        Self::Unavailable {
+            name: clean_text(&name.into()),
+            error,
+        }
+    }
+
+    fn name(&self) -> &str {
+        match self {
+            Self::Available { name, .. } | Self::Unavailable { name, .. } => name,
+        }
+    }
+
+    fn comparison_id(&self) -> Option<&ComparisonId> {
+        match self {
+            Self::Available { comparison_id, .. } => Some(comparison_id),
+            Self::Unavailable { .. } => None,
+        }
+    }
+
+    const fn is_available(&self) -> bool {
+        matches!(self, Self::Available { .. })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitSummary {
+    commit_sha: String,
+    subject: String,
+    timestamp: String,
+    author: String,
+}
+
+impl CommitSummary {
+    pub fn new(
+        commit_sha: impl Into<String>,
+        subject: impl Into<String>,
+        timestamp: impl Into<String>,
+        author: impl Into<String>,
+    ) -> Self {
+        let subject = subject.into();
+        Self {
+            commit_sha: clean_text(&commit_sha.into()),
+            subject: clean_text(subject.lines().next().unwrap_or_default()),
+            timestamp: clean_text(&timestamp.into()),
+            author: clean_text(&author.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitPage {
+    comparison_id: ComparisonId,
+    commits: Vec<CommitSummary>,
+    total: u64,
+    truncated: bool,
+    compare_url: String,
+}
+
+impl CommitPage {
+    pub fn new(
+        comparison_id: ComparisonId,
+        mut commits: Vec<CommitSummary>,
+        total: u64,
+        truncated: bool,
+        compare_url: impl Into<String>,
+    ) -> Self {
+        commits.sort_by(|left, right| right.timestamp.cmp(&left.timestamp));
+        Self {
+            comparison_id,
+            commits,
+            total,
+            truncated,
+            compare_url: clean_text(&compare_url.into()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InteractiveUpdateError {
+    pub code: String,
+    pub message: String,
+}
+
+impl InteractiveUpdateError {
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: clean_text(&code.into()),
+            message: clean_text(&message.into()),
+        }
+    }
+
+    fn terminal(code: &'static str, message: &'static str) -> Self {
+        Self::new(code, message)
+    }
+}
+
+impl fmt::Display for InteractiveUpdateError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for InteractiveUpdateError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitLoadResult {
+    comparison_id: ComparisonId,
+    result: Result<CommitPage, InteractiveUpdateError>,
+}
+
+impl CommitLoadResult {
+    pub fn ready(comparison_id: ComparisonId, page: CommitPage) -> Self {
+        Self {
+            comparison_id,
+            result: Ok(page),
+        }
+    }
+
+    pub fn failed(comparison_id: ComparisonId, error: InteractiveUpdateError) -> Self {
+        Self {
+            comparison_id,
+            result: Err(error),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ApplyResult {
+    name: String,
+    result: Result<(), InteractiveUpdateError>,
+}
+
+impl ApplyResult {
+    pub fn updated(name: impl Into<String>) -> Self {
+        Self {
+            name: clean_text(&name.into()),
+            result: Ok(()),
+        }
+    }
+
+    pub fn failed(name: impl Into<String>, error: InteractiveUpdateError) -> Self {
+        Self {
+            name: clean_text(&name.into()),
+            result: Err(error),
+        }
+    }
+}
+
+pub trait InteractiveUpdateHost: Send + Sync + 'static {
+    fn load_candidates(&self) -> Result<Vec<UpdateCandidate>, InteractiveUpdateError>;
+
+    fn load_commits(&self, comparisons: &[ComparisonId]) -> Vec<CommitLoadResult>;
+
+    fn apply(&self, names: &[String]) -> Vec<ApplyResult>;
+}
+
+pub struct CommandInteractiveUpdateHost<H: Host> {
+    host: Arc<H>,
+    commits: Mutex<BTreeMap<ComparisonId, CommitPage>>,
+}
+
+impl<H: Host> CommandInteractiveUpdateHost<H> {
+    pub fn new(host: Arc<H>) -> Self {
+        Self {
+            host,
+            commits: Mutex::new(BTreeMap::new()),
+        }
+    }
+}
+
+impl<H: Host + Send + Sync + 'static> InteractiveUpdateHost for CommandInteractiveUpdateHost<H> {
+    fn load_candidates(&self) -> Result<Vec<UpdateCandidate>, InteractiveUpdateError> {
+        let plan = self.host.update_check(None).map_err(command_error)?;
+        let (candidates, commits) = prepare_interactive_plan(&plan);
+        *self.commits.lock().map_err(|_| {
+            InteractiveUpdateError::new(
+                "SERVICE_UNAVAILABLE",
+                "The repository commit cache could not be updated.",
+            )
+        })? = commits;
+        Ok(candidates)
+    }
+
+    fn load_commits(&self, comparisons: &[ComparisonId]) -> Vec<CommitLoadResult> {
+        let commits = match self.commits.lock() {
+            Ok(commits) => commits,
+            Err(_) => {
+                return comparisons
+                    .iter()
+                    .cloned()
+                    .map(|comparison| {
+                        CommitLoadResult::failed(
+                            comparison,
+                            InteractiveUpdateError::new(
+                                "SERVICE_UNAVAILABLE",
+                                "Repository commits could not be read.",
+                            ),
+                        )
+                    })
+                    .collect();
+            }
+        };
+        comparisons
+            .iter()
+            .cloned()
+            .map(|comparison| match commits.get(&comparison) {
+                Some(page) => CommitLoadResult::ready(comparison, page.clone()),
+                None => CommitLoadResult::failed(
+                    comparison,
+                    InteractiveUpdateError::new(
+                        "COMPARISON_UNAVAILABLE",
+                        "The repository commit range is unavailable.",
+                    ),
+                ),
+            })
+            .collect()
+    }
+
+    fn apply(&self, names: &[String]) -> Vec<ApplyResult> {
+        match self.host.update_selected(names) {
+            Ok(_) => names.iter().map(ApplyResult::updated).collect(),
+            Err(error) => {
+                let error = command_error(error);
+                names
+                    .iter()
+                    .map(|name| ApplyResult::failed(name, error.clone()))
+                    .collect()
+            }
+        }
+    }
+}
+
+fn prepare_interactive_plan(
+    plan: &UpdatePlanV1,
+) -> (Vec<UpdateCandidate>, BTreeMap<ComparisonId, CommitPage>) {
+    let mut candidates = Vec::new();
+    let mut pages = BTreeMap::new();
+    for item in plan.items() {
+        let name = item.name().as_str();
+        match item.relation() {
+            UpdateRelation::Available {
+                locked_commit_sha,
+                latest_commit_sha,
+                ahead_by,
+            } => {
+                let CommitHistory::Compared {
+                    items,
+                    total,
+                    truncated,
+                    compare_url,
+                } = item.history()
+                else {
+                    candidates.push(UpdateCandidate::unavailable(
+                        name,
+                        InteractiveUpdateError::new(
+                            "INVALID_UPDATE_PLAN",
+                            "The Skill has no repository commit range.",
+                        ),
+                    ));
+                    continue;
+                };
+                let Some(repository) = repository_from_compare_url(compare_url) else {
+                    candidates.push(UpdateCandidate::unavailable(
+                        name,
+                        InteractiveUpdateError::new(
+                            "INVALID_UPDATE_PLAN",
+                            "The repository compare URL is invalid.",
+                        ),
+                    ));
+                    continue;
+                };
+                let comparison = ComparisonId::new(format!(
+                    "{repository}:{}..{}",
+                    locked_commit_sha.as_str(),
+                    latest_commit_sha.as_str()
+                ));
+                let commits = items
+                    .iter()
+                    .map(|commit| {
+                        CommitSummary::new(
+                            commit.sha.as_str(),
+                            &commit.subject,
+                            &commit.timestamp,
+                            &commit.author.name,
+                        )
+                    })
+                    .collect();
+                pages.insert(
+                    comparison.clone(),
+                    CommitPage::new(comparison.clone(), commits, *total, *truncated, compare_url),
+                );
+                candidates.push(UpdateCandidate::new(
+                    name,
+                    repository,
+                    locked_commit_sha.as_str(),
+                    latest_commit_sha.as_str(),
+                    ahead_by.get(),
+                    comparison,
+                ));
+            }
+            UpdateRelation::Unavailable { failure, .. } => {
+                candidates.push(UpdateCandidate::unavailable(
+                    name,
+                    InteractiveUpdateError::new(&failure.code, update_failure_message(failure)),
+                ));
+            }
+            UpdateRelation::Behind { .. } => {
+                candidates.push(UpdateCandidate::unavailable(
+                    name,
+                    InteractiveUpdateError::new(
+                        "SOURCE_BEHIND",
+                        "The installed Skill is ahead of its source.",
+                    ),
+                ));
+            }
+            UpdateRelation::Diverged { .. } => {
+                candidates.push(UpdateCandidate::unavailable(
+                    name,
+                    InteractiveUpdateError::new(
+                        "SOURCE_DIVERGED",
+                        "The installed Skill and its source have diverged.",
+                    ),
+                ));
+            }
+            UpdateRelation::Current { .. }
+            | UpdateRelation::Pinned { .. }
+            | UpdateRelation::NotTracked { .. } => {}
+        }
+    }
+    (candidates, pages)
+}
+
+fn repository_from_compare_url(value: &str) -> Option<String> {
+    let url = Url::parse(value).ok()?;
+    if url.scheme() != "https"
+        || url.host_str() != Some("github.com")
+        || url.port_or_known_default() != Some(443)
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return None;
+    }
+    let mut segments = url.path_segments()?;
+    let owner = segments.next()?;
+    let repository = segments.next()?;
+    let kind = segments.next()?;
+    let range = segments.next()?;
+    (kind == "compare"
+        && !owner.is_empty()
+        && !repository.is_empty()
+        && !range.is_empty()
+        && segments.next().is_none())
+    .then(|| format!("{owner}/{repository}"))
+}
+
+fn update_failure_message(failure: &skilld_core::UpdateFailure) -> String {
+    let retry = match failure.retry_after.as_ref() {
+        Some(UpdateRetryAfter::Seconds { seconds }) => {
+            format!(" Try again in {seconds} seconds.")
+        }
+        Some(UpdateRetryAfter::Reset { reset_at }) => {
+            format!(" Try again after {reset_at}.")
+        }
+        Some(UpdateRetryAfter::SecondsAndReset { seconds, reset_at }) => {
+            format!(" Try again in {seconds} seconds, after {reset_at}.")
+        }
+        Some(UpdateRetryAfter::Unknown) | None => String::new(),
+    };
+    format!("{}{retry}", failure.message)
+}
+
+fn command_error(error: CommandError) -> InteractiveUpdateError {
+    InteractiveUpdateError::new(error.code, error.message)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Tab {
+    Outdated,
+    Commits,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum KeyInput {
+    Up,
+    Down,
+    PageUp,
+    PageDown,
+    NextTab,
+    PreviousTab,
+    Select,
+    SelectAll,
+    Apply,
+    Retry,
+    Help,
+    Cancel,
+    Interrupt,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Message {
+    Key(KeyInput),
+    Resized { width: u16, height: u16 },
+    CandidatesLoaded(Result<Vec<UpdateCandidate>, InteractiveUpdateError>),
+    CommitsLoaded(Vec<CommitLoadResult>),
+    Applied(Vec<ApplyResult>),
+    Tick,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Effect {
+    LoadCandidates,
+    LoadCommits(Vec<ComparisonId>),
+    Apply(Vec<String>),
+    Exit(InteractiveUpdateSummary),
+}
+
+impl Effect {
+    pub fn exit_summary(&self) -> Option<&InteractiveUpdateSummary> {
+        match self {
+            Self::Exit(summary) => Some(summary),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InteractiveUpdateSummary {
+    pub updated: usize,
+    pub failed: usize,
+    pub cancelled: bool,
+    failures: Vec<(String, InteractiveUpdateError)>,
+    interrupted: bool,
+    all_current: bool,
+}
+
+impl InteractiveUpdateSummary {
+    fn current() -> Self {
+        Self {
+            updated: 0,
+            failed: 0,
+            cancelled: false,
+            failures: Vec::new(),
+            interrupted: false,
+            all_current: true,
+        }
+    }
+
+    fn cancelled(interrupted: bool) -> Self {
+        Self {
+            updated: 0,
+            failed: 0,
+            cancelled: true,
+            failures: Vec::new(),
+            interrupted,
+            all_current: false,
+        }
+    }
+
+    fn applied(results: &[ApplyResult]) -> Self {
+        Self {
+            updated: results
+                .iter()
+                .filter(|result| result.result.is_ok())
+                .count(),
+            failed: results
+                .iter()
+                .filter(|result| result.result.is_err())
+                .count(),
+            cancelled: false,
+            failures: results
+                .iter()
+                .filter_map(|result| {
+                    result
+                        .result
+                        .as_ref()
+                        .err()
+                        .map(|error| (result.name.clone(), error.clone()))
+                })
+                .collect(),
+            interrupted: false,
+            all_current: false,
+        }
+    }
+
+    pub fn render(&self) -> String {
+        if self.all_current {
+            return "All installed Skills are current.\n".to_owned();
+        }
+        if self.cancelled {
+            return "Skill update cancelled.\n".to_owned();
+        }
+        let updated = skill_count(self.updated);
+        if self.failed == 0 {
+            return format!("Updated {updated}.\n");
+        }
+        let mut summary = format!("Updated {updated}.\n");
+        for (name, error) in &self.failures {
+            summary.push_str(&format!(
+                "Failed Skill {name}: {}: {}\n",
+                error.code, error.message
+            ));
+        }
+        summary
+    }
+
+    pub fn exit_code(&self) -> u8 {
+        if self.interrupted {
+            130
+        } else if self.failed > 0 {
+            2
+        } else {
+            0
+        }
+    }
+}
+
+fn skill_count(count: usize) -> String {
+    if count == 1 {
+        "1 Skill".to_owned()
+    } else {
+        format!("{count} Skills")
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Phase {
+    LoadingCandidates,
+    Browsing,
+    Applying,
+    FailedLoad(InteractiveUpdateError),
+    Finished(InteractiveUpdateSummary),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum CommitState {
+    NotRequested,
+    Loading,
+    Ready(CommitPage),
+    Failed(InteractiveUpdateError),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct UpdateRow {
+    candidate: UpdateCandidate,
+    selected: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Model {
+    tab: Tab,
+    phase: Phase,
+    rows: Vec<UpdateRow>,
+    commits: BTreeMap<ComparisonId, CommitState>,
+    cursor: usize,
+    viewport: usize,
+    width: u16,
+    height: u16,
+    expanded_help: bool,
+    spinner: usize,
+}
+
+impl Model {
+    pub fn new(width: u16, height: u16) -> Self {
+        Self {
+            tab: Tab::Outdated,
+            phase: Phase::LoadingCandidates,
+            rows: Vec::new(),
+            commits: BTreeMap::new(),
+            cursor: 0,
+            viewport: 0,
+            width: width.max(1),
+            height: height.max(1),
+            expanded_help: false,
+            spinner: 0,
+        }
+    }
+
+    pub const fn tab(&self) -> Tab {
+        self.tab
+    }
+
+    pub fn comparison_ids(&self) -> Vec<ComparisonId> {
+        self.rows
+            .iter()
+            .filter_map(|row| row.candidate.comparison_id().cloned())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+
+    fn selected_names(&self) -> Vec<String> {
+        self.rows
+            .iter()
+            .filter(|row| row.selected)
+            .map(|row| row.candidate.name().to_owned())
+            .collect()
+    }
+
+    fn visible_outdated_rows(&self) -> usize {
+        let body_height = usize::from(self.height.saturating_sub(7).max(1));
+        if self.width >= 60 {
+            (body_height / 2).max(1)
+        } else {
+            body_height
+        }
+    }
+
+    fn keep_cursor_visible(&mut self) {
+        let visible = self.visible_outdated_rows();
+        if self.cursor < self.viewport {
+            self.viewport = self.cursor;
+        } else if self.cursor >= self.viewport.saturating_add(visible) {
+            self.viewport = self.cursor.saturating_add(1).saturating_sub(visible);
+        }
+    }
+
+    fn keep_commit_viewport_valid(&mut self) {
+        let visible = usize::from(self.height.saturating_sub(9).max(1));
+        let maximum = self.commit_line_count().saturating_sub(visible);
+        self.viewport = self.viewport.min(maximum);
+    }
+
+    fn commit_line_count(&self) -> usize {
+        let mut rendered = BTreeSet::new();
+        self.rows
+            .iter()
+            .filter_map(|row| {
+                row.candidate
+                    .comparison_id()
+                    .filter(|id| rendered.insert((*id).clone()))
+                    .map(|id| (row, id))
+            })
+            .map(|(_row, id)| {
+                let state_lines = match self.commits.get(id) {
+                    Some(CommitState::Ready(page)) => {
+                        page.commits.len() + usize::from(page.truncated)
+                    }
+                    _ => 1,
+                };
+                2 + state_lines
+            })
+            .sum()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Transition {
+    pub model: Model,
+    pub effects: Vec<Effect>,
+}
+
+pub const fn initial_effect() -> Effect {
+    Effect::LoadCandidates
+}
+
+pub fn update(mut model: Model, message: Message) -> Transition {
+    let mut effects = Vec::new();
+    match message {
+        Message::CandidatesLoaded(Ok(mut candidates)) => {
+            candidates.sort_by(|left, right| left.name().cmp(right.name()));
+            model.rows = candidates
+                .into_iter()
+                .map(|candidate| UpdateRow {
+                    selected: candidate.is_available(),
+                    candidate,
+                })
+                .collect();
+            model.commits = model
+                .comparison_ids()
+                .into_iter()
+                .map(|id| (id, CommitState::NotRequested))
+                .collect();
+            model.cursor = 0;
+            model.viewport = 0;
+            if model.rows.is_empty() {
+                let summary = InteractiveUpdateSummary::current();
+                model.phase = Phase::Finished(summary.clone());
+                effects.push(Effect::Exit(summary));
+            } else {
+                model.phase = Phase::Browsing;
+            }
+        }
+        Message::CandidatesLoaded(Err(error)) => {
+            model.phase = Phase::FailedLoad(error);
+        }
+        Message::CommitsLoaded(results) => {
+            for result in results {
+                let CommitLoadResult {
+                    comparison_id,
+                    result,
+                } = result;
+                if let std::collections::btree_map::Entry::Occupied(mut entry) =
+                    model.commits.entry(comparison_id)
+                {
+                    let state = match result {
+                        Ok(page) if page.comparison_id == *entry.key() => CommitState::Ready(page),
+                        Ok(_) => CommitState::Failed(InteractiveUpdateError::new(
+                            "INVALID_UPDATE_PLAN",
+                            "The commit range did not match its request.",
+                        )),
+                        Err(error) => CommitState::Failed(error),
+                    };
+                    entry.insert(state);
+                }
+            }
+            model.keep_commit_viewport_valid();
+        }
+        Message::Applied(results) => {
+            let summary = InteractiveUpdateSummary::applied(&results);
+            model.phase = Phase::Finished(summary.clone());
+            effects.push(Effect::Exit(summary));
+        }
+        Message::Resized { width, height } => {
+            model.width = width.max(1);
+            model.height = height.max(1);
+            match model.tab {
+                Tab::Outdated => model.keep_cursor_visible(),
+                Tab::Commits => model.keep_commit_viewport_valid(),
+            }
+        }
+        Message::Tick => {
+            model.spinner = (model.spinner + 1) % SPINNER.len();
+        }
+        Message::Key(key) => update_key(&mut model, key, &mut effects),
+    }
+    Transition { model, effects }
+}
+
+fn update_key(model: &mut Model, key: KeyInput, effects: &mut Vec<Effect>) {
+    if matches!(key, KeyInput::Cancel | KeyInput::Interrupt)
+        && !matches!(model.phase, Phase::Finished(_))
+    {
+        let summary = InteractiveUpdateSummary::cancelled(key == KeyInput::Interrupt);
+        if !matches!(model.phase, Phase::Applying) {
+            model.phase = Phase::Finished(summary.clone());
+        }
+        effects.push(Effect::Exit(summary));
+        return;
+    }
+    if key == KeyInput::Help {
+        model.expanded_help = !model.expanded_help;
+        return;
+    }
+    if let Phase::FailedLoad(_) = &model.phase {
+        if key == KeyInput::Retry {
+            model.phase = Phase::LoadingCandidates;
+            effects.push(Effect::LoadCandidates);
+        }
+        return;
+    }
+    if !matches!(model.phase, Phase::Browsing) {
+        return;
+    }
+
+    match key {
+        KeyInput::NextTab | KeyInput::PreviousTab => {
+            model.tab = match model.tab {
+                Tab::Outdated => Tab::Commits,
+                Tab::Commits => Tab::Outdated,
+            };
+            model.viewport = 0;
+            if model.tab == Tab::Commits {
+                let pending = model
+                    .commits
+                    .iter()
+                    .filter_map(|(id, state)| {
+                        matches!(state, CommitState::NotRequested).then_some(id.clone())
+                    })
+                    .collect::<Vec<_>>();
+                for id in &pending {
+                    model.commits.insert(id.clone(), CommitState::Loading);
+                }
+                if !pending.is_empty() {
+                    effects.push(Effect::LoadCommits(pending));
+                }
+            }
+        }
+        KeyInput::Up if model.tab == Tab::Outdated => {
+            model.cursor = model.cursor.saturating_sub(1);
+            model.keep_cursor_visible();
+        }
+        KeyInput::Down if model.tab == Tab::Outdated => {
+            model.cursor = model
+                .cursor
+                .saturating_add(1)
+                .min(model.rows.len().saturating_sub(1));
+            model.keep_cursor_visible();
+        }
+        KeyInput::Up if model.tab == Tab::Commits => {
+            model.viewport = model.viewport.saturating_sub(1);
+        }
+        KeyInput::Down if model.tab == Tab::Commits => {
+            model.viewport = model.viewport.saturating_add(1);
+            model.keep_commit_viewport_valid();
+        }
+        KeyInput::PageUp if model.tab == Tab::Commits => {
+            model.viewport = model
+                .viewport
+                .saturating_sub(usize::from(model.height.max(1)));
+        }
+        KeyInput::PageDown if model.tab == Tab::Commits => {
+            model.viewport = model
+                .viewport
+                .saturating_add(usize::from(model.height.max(1)));
+            model.keep_commit_viewport_valid();
+        }
+        KeyInput::Select if model.tab == Tab::Outdated => {
+            if let Some(row) = model
+                .rows
+                .get_mut(model.cursor)
+                .filter(|row| row.candidate.is_available())
+            {
+                row.selected = !row.selected;
+            }
+        }
+        KeyInput::SelectAll if model.tab == Tab::Outdated => {
+            for row in &mut model.rows {
+                row.selected = row.candidate.is_available();
+            }
+        }
+        KeyInput::Apply if model.tab == Tab::Outdated => {
+            let names = model.selected_names();
+            if !names.is_empty() {
+                model.phase = Phase::Applying;
+                effects.push(Effect::Apply(names));
+            }
+        }
+        KeyInput::Retry
+            if model.tab == Tab::Outdated
+                && model.rows.iter().any(|row| !row.candidate.is_available()) =>
+        {
+            model.phase = Phase::LoadingCandidates;
+            effects.push(Effect::LoadCandidates);
+        }
+        KeyInput::Retry if model.tab == Tab::Commits => {
+            let failed = model
+                .commits
+                .iter()
+                .filter_map(|(id, state)| {
+                    matches!(state, CommitState::Failed(_)).then_some(id.clone())
+                })
+                .collect::<Vec<_>>();
+            for id in &failed {
+                model.commits.insert(id.clone(), CommitState::Loading);
+            }
+            if !failed.is_empty() {
+                effects.push(Effect::LoadCommits(failed));
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn view(frame: &mut ratatui::Frame<'_>, model: &Model, color: bool) {
+    let help_height = if model.expanded_help { 3 } else { 1 };
+    let areas = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(2),
+        Constraint::Min(1),
+        Constraint::Length(1),
+        Constraint::Length(help_height),
+    ])
+    .split(frame.area());
+
+    frame.render_widget(
+        Paragraph::new("skilld update").style(
+            Style::default()
+                .fg(theme(color, Color::Cyan))
+                .add_modifier(Modifier::BOLD),
+        ),
+        areas[0],
+    );
+    render_tabs(frame, model, color, areas[1]);
+    render_body(frame, model, color, areas[2]);
+    frame.render_widget(Paragraph::new(status_text(model)), areas[3]);
+    frame.render_widget(
+        Paragraph::new(help_text(model)).style(Style::default().fg(theme(color, Color::DarkGray))),
+        areas[4],
+    );
+}
+
+fn render_tabs(frame: &mut ratatui::Frame<'_>, model: &Model, color: bool, area: Rect) {
+    let outdated = format!(
+        "Outdated {}",
+        model
+            .rows
+            .iter()
+            .filter(|row| row.candidate.is_available())
+            .count()
+    );
+    let titles = match model.tab {
+        Tab::Outdated => vec![format!("[ {outdated} ]"), "Commits".to_owned()],
+        Tab::Commits => vec![outdated, "[ Commits ]".to_owned()],
+    };
+    let tabs = Tabs::new(titles)
+        .divider("   ")
+        .select(match model.tab {
+            Tab::Outdated => 0,
+            Tab::Commits => 1,
+        })
+        .highlight_style(
+            Style::default()
+                .fg(theme(color, Color::Cyan))
+                .add_modifier(Modifier::BOLD),
+        );
+    frame.render_widget(tabs, area);
+}
+
+fn render_body(frame: &mut ratatui::Frame<'_>, model: &Model, color: bool, area: Rect) {
+    match &model.phase {
+        Phase::LoadingCandidates => {
+            frame.render_widget(
+                Paragraph::new(format!(
+                    "{} Loading outdated Skills...",
+                    SPINNER[model.spinner]
+                )),
+                area,
+            );
+        }
+        Phase::FailedLoad(error) => {
+            frame.render_widget(
+                Paragraph::new(Text::from(vec![
+                    Line::from("The update plan could not load."),
+                    Line::from(format!("{}: {}", error.code, error.message)),
+                ]))
+                .style(Style::default().fg(theme(color, Color::Red))),
+                area,
+            );
+        }
+        Phase::Finished(summary) => {
+            frame.render_widget(Paragraph::new(summary.render()), area);
+        }
+        Phase::Browsing | Phase::Applying => match model.tab {
+            Tab::Outdated => render_outdated(frame, model, color, area),
+            Tab::Commits => render_commits(frame, model, color, area),
+        },
+    }
+}
+
+fn render_outdated(frame: &mut ratatui::Frame<'_>, model: &Model, color: bool, area: Rect) {
+    let visible = model.visible_outdated_rows();
+    let compact = model.width < 60;
+    let width = usize::from(area.width.saturating_sub(4));
+    let items = model
+        .rows
+        .iter()
+        .skip(model.viewport)
+        .take(visible)
+        .map(|row| match &row.candidate {
+            UpdateCandidate::Available {
+                name,
+                repository,
+                locked_commit_sha,
+                latest_commit_sha,
+                commit_count,
+                ..
+            } => {
+                let checked = if row.selected { 'x' } else { ' ' };
+                if compact {
+                    ListItem::new(truncate(&format!("[{checked}] {name}"), width))
+                } else {
+                    let first = format!("[{checked}] {name:<28} {repository}");
+                    let commits = if *commit_count == 1 {
+                        "1 commit".to_owned()
+                    } else {
+                        format!("{commit_count} commits")
+                    };
+                    let second = format!(
+                        "    {} -> {}  {commits}",
+                        short_sha(locked_commit_sha),
+                        short_sha(latest_commit_sha)
+                    );
+                    ListItem::new(Text::from(vec![
+                        Line::from(truncate(&first, width)),
+                        Line::from(truncate(&second, width)),
+                    ]))
+                }
+            }
+            UpdateCandidate::Unavailable { name, error } => {
+                if compact {
+                    ListItem::new(truncate(&format!("[!] {name}: {}", error.code), width))
+                } else {
+                    ListItem::new(Text::from(vec![
+                        Line::from(truncate(&format!("[!] {name}: {}", error.code), width)),
+                        Line::from(truncate(&format!("    {}", error.message), width)),
+                    ]))
+                    .style(Style::default().fg(theme(color, Color::Red)))
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+    let list = List::new(items)
+        .block(Block::bordered().title("Select Skills to update"))
+        .highlight_symbol("> ")
+        .highlight_style(
+            Style::default()
+                .fg(theme(color, Color::Cyan))
+                .add_modifier(Modifier::BOLD),
+        );
+    let mut state = ListState::default().with_selected(
+        (!model.rows.is_empty()).then_some(model.cursor.saturating_sub(model.viewport)),
+    );
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn render_commits(frame: &mut ratatui::Frame<'_>, model: &Model, color: bool, area: Rect) {
+    let width = usize::from(area.width.saturating_sub(4));
+    let mut lines = Vec::new();
+    let mut rendered = BTreeSet::new();
+    for row in &model.rows {
+        let UpdateCandidate::Available {
+            repository,
+            locked_commit_sha,
+            latest_commit_sha,
+            comparison_id: id,
+            ..
+        } = &row.candidate
+        else {
+            continue;
+        };
+        if !rendered.insert(id.clone()) {
+            continue;
+        }
+        lines.push(Line::styled(
+            truncate(
+                &format!(
+                    "{}  {}..{}",
+                    repository,
+                    short_sha(locked_commit_sha),
+                    short_sha(latest_commit_sha)
+                ),
+                width,
+            ),
+            Style::default()
+                .fg(theme(color, Color::Cyan))
+                .add_modifier(Modifier::BOLD),
+        ));
+        match model.commits.get(id) {
+            Some(CommitState::NotRequested) => {
+                lines.push(Line::from("  Open this tab to load commits."));
+            }
+            Some(CommitState::Loading) => {
+                lines.push(Line::from(format!(
+                    "  {} Loading commits...",
+                    SPINNER[model.spinner]
+                )));
+            }
+            Some(CommitState::Failed(error)) => {
+                lines.push(Line::styled(
+                    truncate(&format!("  {}: {}", error.code, error.message), width),
+                    Style::default().fg(theme(color, Color::Red)),
+                ));
+            }
+            Some(CommitState::Ready(page)) => {
+                for commit in &page.commits {
+                    let date = commit.timestamp.get(..10).unwrap_or(&commit.timestamp);
+                    let details = if model.width >= 100 {
+                        format!("{}  {date}", commit.author)
+                    } else {
+                        date.to_owned()
+                    };
+                    lines.push(Line::from(truncate(
+                        &format!(
+                            "  {}  {}  {}",
+                            short_sha(&commit.commit_sha),
+                            commit.subject,
+                            details
+                        ),
+                        width,
+                    )));
+                }
+                if page.truncated {
+                    lines.push(Line::styled(
+                        truncate(
+                            &format!(
+                                "  Showing newest {} of {} commits. {}",
+                                page.commits.len(),
+                                page.total,
+                                page.compare_url
+                            ),
+                            width,
+                        ),
+                        Style::default().fg(theme(color, Color::Yellow)),
+                    ));
+                }
+            }
+            None => {}
+        }
+        lines.push(Line::from(""));
+    }
+    let lines = lines.into_iter().skip(model.viewport).collect::<Vec<_>>();
+    frame.render_widget(
+        Paragraph::new(lines).block(Block::bordered().title("Repository commits")),
+        area,
+    );
+}
+
+fn status_text(model: &Model) -> String {
+    match model.phase {
+        Phase::LoadingCandidates => "Loading update plan".to_owned(),
+        Phase::Applying => format!(
+            "{} Updating {}...",
+            SPINNER[model.spinner],
+            skill_count(model.selected_names().len())
+        ),
+        Phase::FailedLoad(_) => "Update plan failed".to_owned(),
+        Phase::Finished(_) => String::new(),
+        Phase::Browsing if model.tab == Tab::Outdated => {
+            let unavailable = model
+                .rows
+                .iter()
+                .filter(|row| !row.candidate.is_available())
+                .count();
+            if unavailable == 0 {
+                format!("{} selected", model.selected_names().len())
+            } else {
+                format!(
+                    "{} selected. {} unavailable",
+                    model.selected_names().len(),
+                    unavailable
+                )
+            }
+        }
+        Phase::Browsing => {
+            let loading = model
+                .commits
+                .values()
+                .filter(|state| matches!(state, CommitState::Loading))
+                .count();
+            let failed = model
+                .commits
+                .values()
+                .filter(|state| matches!(state, CommitState::Failed(_)))
+                .count();
+            match (loading, failed) {
+                (0, 0) => "Repository commits loaded".to_owned(),
+                (_, 0) => format!("Loading {loading} commit ranges"),
+                (0, _) => format!("{failed} commit ranges failed"),
+                _ => format!("Loading {loading}. {failed} failed"),
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Binding {
+    keys: &'static str,
+    action: &'static str,
+}
+
+fn bindings(model: &Model) -> Vec<Binding> {
+    let mut bindings = match (&model.phase, model.tab) {
+        (Phase::FailedLoad(_), _) => vec![Binding {
+            keys: "r",
+            action: "retry",
+        }],
+        (Phase::Browsing, Tab::Outdated) => vec![
+            Binding {
+                keys: "↑/↓",
+                action: "move",
+            },
+            Binding {
+                keys: "space",
+                action: "select",
+            },
+            Binding {
+                keys: "a",
+                action: "select all",
+            },
+            Binding {
+                keys: "tab",
+                action: "commits",
+            },
+            Binding {
+                keys: "enter",
+                action: "update",
+            },
+        ]
+        .into_iter()
+        .chain(
+            model
+                .rows
+                .iter()
+                .any(|row| !row.candidate.is_available())
+                .then_some(Binding {
+                    keys: "r",
+                    action: "retry",
+                }),
+        )
+        .collect(),
+        (Phase::Browsing, Tab::Commits) => {
+            let mut values = vec![
+                Binding {
+                    keys: "↑/↓",
+                    action: "scroll",
+                },
+                Binding {
+                    keys: "tab",
+                    action: "outdated",
+                },
+            ];
+            if model
+                .commits
+                .values()
+                .any(|state| matches!(state, CommitState::Failed(_)))
+            {
+                values.push(Binding {
+                    keys: "r",
+                    action: "retry",
+                });
+            }
+            values
+        }
+        _ => Vec::new(),
+    };
+    bindings.extend([
+        Binding {
+            keys: "?",
+            action: "help",
+        },
+        Binding {
+            keys: "q",
+            action: "cancel",
+        },
+    ]);
+    bindings
+}
+
+fn help_text(model: &Model) -> String {
+    let concise = bindings(model)
+        .into_iter()
+        .map(|binding| format!("{} {}", binding.keys, binding.action))
+        .collect::<Vec<_>>()
+        .join("  ");
+    if model.expanded_help {
+        format!("{concise}\nVim keys: j/k move. Arrow keys change tabs.\nEsc and Ctrl+C cancel.")
+    } else {
+        concise
+    }
+}
+
+fn theme(color: bool, value: Color) -> Color {
+    if color { value } else { Color::Reset }
+}
+
+fn short_sha(value: &str) -> &str {
+    value.get(..7).unwrap_or(value)
+}
+
+fn clean_text(value: &str) -> String {
+    value
+        .chars()
+        .map(|character| {
+            if character.is_control() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn truncate(value: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let mut used: usize = 0;
+    let mut output = String::new();
+    for character in value.chars() {
+        let character_width = character.width().unwrap_or(0);
+        if used.saturating_add(character_width) > width {
+            break;
+        }
+        output.push(character);
+        used = used.saturating_add(character_width);
+    }
+    output
+}
+
+pub fn render_snapshot(model: &Model, color: bool) -> String {
+    let backend = TestBackend::new(model.width, model.height);
+    let mut terminal = Terminal::new(backend).expect("the in-memory terminal is valid");
+    terminal
+        .draw(|frame| view(frame, model, color))
+        .expect("the in-memory terminal can draw");
+    let buffer = terminal.backend().buffer();
+    let mut lines = Vec::with_capacity(usize::from(model.height));
+    for y in 0..model.height {
+        let mut line = String::new();
+        let mut x = 0;
+        while x < model.width {
+            if let Some(cell) = buffer.cell((x, y)) {
+                line.push_str(cell.symbol());
+                x = x.saturating_add(UnicodeWidthStr::width(cell.symbol()).max(1) as u16);
+            } else {
+                x = x.saturating_add(1);
+            }
+        }
+        lines.push(line.trim_end().to_owned());
+    }
+    lines.join("\n")
+}
+
+pub trait TerminalLifecycle {
+    fn enter(&mut self) -> Result<(), InteractiveUpdateError>;
+
+    fn restore(&mut self) -> Result<(), InteractiveUpdateError>;
+}
+
+struct RestoreGuard<L: TerminalLifecycle> {
+    lifecycle: Option<L>,
+}
+
+impl<L: TerminalLifecycle> RestoreGuard<L> {
+    fn enter(mut lifecycle: L) -> Result<Self, InteractiveUpdateError> {
+        lifecycle.enter()?;
+        Ok(Self {
+            lifecycle: Some(lifecycle),
+        })
+    }
+
+    fn restore(mut self) -> Result<(), InteractiveUpdateError> {
+        let result = self
+            .lifecycle
+            .as_mut()
+            .expect("the active terminal has a lifecycle")
+            .restore();
+        self.lifecycle = None;
+        result
+    }
+}
+
+impl<L: TerminalLifecycle> Drop for RestoreGuard<L> {
+    fn drop(&mut self) {
+        if let Some(lifecycle) = self.lifecycle.as_mut() {
+            let _ = lifecycle.restore();
+        }
+    }
+}
+
+pub fn with_restored_terminal<L, Operation, Outcome>(
+    lifecycle: L,
+    operation: Operation,
+) -> Result<Outcome, InteractiveUpdateError>
+where
+    L: TerminalLifecycle,
+    Operation: FnOnce() -> Result<Outcome, InteractiveUpdateError>,
+{
+    let guard = RestoreGuard::enter(lifecycle)?;
+    let outcome = operation();
+    guard.restore()?;
+    outcome
+}
+
+struct NativeTerminalLifecycle;
+
+impl TerminalLifecycle for NativeTerminalLifecycle {
+    fn enter(&mut self) -> Result<(), InteractiveUpdateError> {
+        enable_raw_mode().map_err(|_| {
+            InteractiveUpdateError::terminal(
+                "TERMINAL_UNAVAILABLE",
+                "The terminal could not enter interactive mode.",
+            )
+        })?;
+        let mut stdout = io::stdout();
+        if execute!(stdout, EnterAlternateScreen, Hide).is_err() {
+            let _ = disable_raw_mode();
+            return Err(InteractiveUpdateError::terminal(
+                "TERMINAL_UNAVAILABLE",
+                "The terminal could not enter interactive mode.",
+            ));
+        }
+        Ok(())
+    }
+
+    fn restore(&mut self) -> Result<(), InteractiveUpdateError> {
+        let mut stdout = io::stdout();
+        let screen = execute!(stdout, Show, LeaveAlternateScreen);
+        let raw = disable_raw_mode();
+        if screen.is_err() || raw.is_err() {
+            return Err(InteractiveUpdateError::terminal(
+                "TERMINAL_RESTORE_FAILED",
+                "Run reset if the terminal still looks incorrect.",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub fn run_interactive_update<H: InteractiveUpdateHost>(
+    host: Arc<H>,
+    color: bool,
+) -> Result<InteractiveUpdateSummary, InteractiveUpdateError> {
+    with_restored_terminal(NativeTerminalLifecycle, || {
+        let backend = CrosstermBackend::new(io::stdout());
+        let mut terminal = Terminal::new(backend).map_err(terminal_lost)?;
+        terminal.clear().map_err(terminal_lost)?;
+        run_event_loop(&mut terminal, host, color)
+    })
+}
+
+pub fn require_interactive_tty(
+    stdin_is_terminal: bool,
+    stdout_is_terminal: bool,
+) -> Result<(), InteractiveUpdateError> {
+    if stdin_is_terminal && stdout_is_terminal {
+        return Ok(());
+    }
+    Err(InteractiveUpdateError::new(
+        "INTERACTIVE_TTY_REQUIRED",
+        "Interactive Skill update needs terminal input and output.",
+    ))
+}
+
+fn run_event_loop<H: InteractiveUpdateHost>(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    host: Arc<H>,
+    color: bool,
+) -> Result<InteractiveUpdateSummary, InteractiveUpdateError> {
+    let size = terminal.size().map_err(terminal_lost)?;
+    let mut model = Model::new(size.width, size.height);
+    let mut effects = VecDeque::from([initial_effect()]);
+    let (sender, receiver) = mpsc::channel();
+    let mut running = None;
+    let mut interrupt_after_apply = false;
+    loop {
+        terminal
+            .draw(|frame| view(frame, &model, color))
+            .map_err(terminal_lost)?;
+
+        if matches!(effects.front(), Some(Effect::Exit(_))) {
+            let Some(Effect::Exit(summary)) = effects.pop_front() else {
+                unreachable!("the front effect is an exit")
+            };
+            if running == Some(RunningEffect::Apply) {
+                interrupt_after_apply |= summary.interrupted;
+                continue;
+            }
+            return Ok(summary);
+        }
+
+        match receiver.try_recv() {
+            Ok(message) => {
+                running = None;
+                let mut transition = update(model, message);
+                if interrupt_after_apply {
+                    mark_interrupted(&mut transition);
+                    interrupt_after_apply = false;
+                }
+                model = transition.model;
+                enqueue_effects(&mut effects, transition.effects);
+                continue;
+            }
+            Err(TryRecvError::Disconnected) if running.is_some() => {
+                return Err(InteractiveUpdateError::new(
+                    "INTERACTIVE_WORKER_FAILED",
+                    "The interactive update worker stopped.",
+                ));
+            }
+            Err(TryRecvError::Empty | TryRecvError::Disconnected) => {}
+        }
+
+        if running.is_none()
+            && let Some(effect) = effects.pop_front()
+        {
+            let kind = match effect {
+                Effect::Apply(_) => RunningEffect::Apply,
+                Effect::LoadCandidates | Effect::LoadCommits(_) => RunningEffect::Load,
+                Effect::Exit(_) => unreachable!("exit effects are handled first"),
+            };
+            let fallback = failed_effect(&effect);
+            let host = host.clone();
+            let sender = sender.clone();
+            thread::spawn(move || {
+                let message =
+                    catch_unwind(AssertUnwindSafe(|| resolve_effect(host.as_ref(), effect)))
+                        .unwrap_or(fallback);
+                let _ = sender.send(message);
+            });
+            running = Some(kind);
+            continue;
+        }
+
+        let message = if event::poll(Duration::from_millis(120)).map_err(terminal_lost)? {
+            match event::read().map_err(terminal_lost)? {
+                Event::Key(key) => key_input(key).map(Message::Key),
+                Event::Resize(width, height) => Some(Message::Resized { width, height }),
+                _ => None,
+            }
+        } else {
+            Some(Message::Tick)
+        };
+        if let Some(message) = message {
+            let transition = update(model, message);
+            model = transition.model;
+            enqueue_effects(&mut effects, transition.effects);
+        }
+    }
+}
+
+fn mark_interrupted(transition: &mut Transition) {
+    if let Phase::Finished(summary) = &mut transition.model.phase {
+        summary.interrupted = true;
+    }
+    for effect in &mut transition.effects {
+        if let Effect::Exit(summary) = effect {
+            summary.interrupted = true;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RunningEffect {
+    Load,
+    Apply,
+}
+
+fn enqueue_effects(queue: &mut VecDeque<Effect>, effects: Vec<Effect>) {
+    if effects
+        .iter()
+        .any(|effect| matches!(effect, Effect::Exit(_)))
+    {
+        queue.clear();
+    }
+    queue.extend(effects);
+}
+
+fn failed_effect(effect: &Effect) -> Message {
+    let error = InteractiveUpdateError::new(
+        "INTERACTIVE_WORKER_FAILED",
+        "The interactive update worker stopped.",
+    );
+    match effect {
+        Effect::LoadCandidates => Message::CandidatesLoaded(Err(error)),
+        Effect::LoadCommits(comparisons) => Message::CommitsLoaded(
+            comparisons
+                .iter()
+                .cloned()
+                .map(|comparison| CommitLoadResult::failed(comparison, error.clone()))
+                .collect(),
+        ),
+        Effect::Apply(names) => Message::Applied(
+            names
+                .iter()
+                .map(|name| ApplyResult::failed(name, error.clone()))
+                .collect(),
+        ),
+        Effect::Exit(_) => unreachable!("exit effects do not run in a worker"),
+    }
+}
+
+pub fn resolve_effect<H: InteractiveUpdateHost>(host: &H, effect: Effect) -> Message {
+    match effect {
+        Effect::LoadCandidates => Message::CandidatesLoaded(host.load_candidates()),
+        Effect::LoadCommits(ids) => {
+            let mut results = host
+                .load_commits(&ids)
+                .into_iter()
+                .map(|result| (result.comparison_id.clone(), result))
+                .collect::<BTreeMap<_, _>>();
+            Message::CommitsLoaded(
+                ids.into_iter()
+                    .map(|id| {
+                        results.remove(&id).unwrap_or_else(|| {
+                            CommitLoadResult::failed(
+                                id.clone(),
+                                InteractiveUpdateError::new(
+                                    "COMPARISON_UNAVAILABLE",
+                                    "The commit range returned no result.",
+                                ),
+                            )
+                        })
+                    })
+                    .collect(),
+            )
+        }
+        Effect::Apply(names) => {
+            let mut results = host
+                .apply(&names)
+                .into_iter()
+                .map(|result| (result.name.clone(), result))
+                .collect::<BTreeMap<_, _>>();
+            Message::Applied(
+                names
+                    .into_iter()
+                    .map(|name| {
+                        results.remove(&name).unwrap_or_else(|| {
+                            ApplyResult::failed(
+                                name.clone(),
+                                InteractiveUpdateError::new(
+                                    "UPDATE_FAILED",
+                                    "The Skill update returned no result.",
+                                ),
+                            )
+                        })
+                    })
+                    .collect(),
+            )
+        }
+        Effect::Exit(_) => unreachable!("exit effects end the event loop"),
+    }
+}
+
+fn key_input(event: KeyEvent) -> Option<KeyInput> {
+    if !matches!(event.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+        return None;
+    }
+    if event.modifiers.contains(KeyModifiers::CONTROL) && event.code == KeyCode::Char('c') {
+        return Some(KeyInput::Interrupt);
+    }
+    match event.code {
+        KeyCode::Up | KeyCode::Char('k') => Some(KeyInput::Up),
+        KeyCode::Down | KeyCode::Char('j') => Some(KeyInput::Down),
+        KeyCode::PageUp => Some(KeyInput::PageUp),
+        KeyCode::PageDown => Some(KeyInput::PageDown),
+        KeyCode::Tab | KeyCode::Right => Some(KeyInput::NextTab),
+        KeyCode::BackTab | KeyCode::Left => Some(KeyInput::PreviousTab),
+        KeyCode::Char(' ') => Some(KeyInput::Select),
+        KeyCode::Char('a') => Some(KeyInput::SelectAll),
+        KeyCode::Enter => Some(KeyInput::Apply),
+        KeyCode::Char('r') => Some(KeyInput::Retry),
+        KeyCode::Char('?') => Some(KeyInput::Help),
+        KeyCode::Char('q') | KeyCode::Esc => Some(KeyInput::Cancel),
+        _ => None,
+    }
+}
+
+fn terminal_lost(_error: io::Error) -> InteractiveUpdateError {
+    InteractiveUpdateError::terminal(
+        "INTERACTIVE_TTY_LOST",
+        "The interactive terminal stopped responding.",
+    )
+}
+
+pub fn write_static_summary(
+    summary: &InteractiveUpdateSummary,
+    output: &mut impl Write,
+) -> Result<(), InteractiveUpdateError> {
+    output.write_all(summary.render().as_bytes()).map_err(|_| {
+        InteractiveUpdateError::terminal(
+            "TERMINAL_UNAVAILABLE",
+            "The Skill update summary could not be written.",
+        )
+    })
+}

--- a/crates/skilld-native/tests/cli.rs
+++ b/crates/skilld-native/tests/cli.rs
@@ -96,6 +96,49 @@ fn run_output_probe_in_pty(signal: (&str, &str), width: u16) -> String {
 }
 
 #[cfg(unix)]
+fn run_empty_interactive_update_in_pty(project: &Path, data: &Path, home: &Path) -> String {
+    let pair = openpty(
+        Some(&Winsize {
+            ws_row: 18,
+            ws_col: 80,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        }),
+        None,
+    )
+    .unwrap();
+    let mut master = File::from(pair.master);
+    let slave = File::from(pair.slave);
+    let slave_stdout = slave.try_clone().unwrap();
+    let slave_stderr = slave.try_clone().unwrap();
+    let mut command = Command::new(binary());
+    for name in DETECTION_SIGNALS {
+        command.env_remove(name);
+    }
+    let mut child = command
+        .current_dir(project)
+        .env_remove("CI")
+        .env("SKILLD_DATA_DIR", data)
+        .env("HOME", home)
+        .env("XDG_CONFIG_HOME", home.join(".config"))
+        .env("NO_COLOR", "1")
+        .env("TERM", "xterm-256color")
+        .args(["update", "--interactive"])
+        .stdin(Stdio::from(slave))
+        .stdout(Stdio::from(slave_stdout))
+        .stderr(Stdio::from(slave_stderr))
+        .spawn()
+        .unwrap();
+    drop(command);
+
+    let status = child.wait().unwrap();
+    let mut output = String::new();
+    let _ = master.read_to_string(&mut output);
+    assert!(status.success(), "{output:?}");
+    output.replace("\r\n", "\n")
+}
+
+#[cfg(unix)]
 #[test]
 fn active_agent_signal_uses_plain_output_in_a_terminal() {
     let output = run_output_probe_in_pty(("AGENT_SESSION_ID", "test-session"), 40);
@@ -124,6 +167,73 @@ fn version_reports_the_rust_package_version() {
         format!("skilld {}\n", env!("CARGO_PKG_VERSION"))
     );
     assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn interactive_update_requires_terminal_input_and_output() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    let data = temporary.path().join("data");
+    let home = temporary.path().join("home");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&home).unwrap();
+
+    let output = run(&project, &data, &home, &["update", "--interactive"]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8(output.stderr).unwrap(),
+        concat!(
+            "INTERACTIVE_TTY_REQUIRED: Interactive Skill update needs terminal input ",
+            "and output.\n"
+        )
+    );
+}
+
+#[test]
+fn interactive_update_rejects_plain_json_check_and_skill_arguments() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    let data = temporary.path().join("data");
+    let home = temporary.path().join("home");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&home).unwrap();
+
+    for args in [
+        &["update", "--interactive", "--plain"][..],
+        &["update", "--interactive", "--json"][..],
+        &["update", "--interactive", "--check"][..],
+        &["update", "example", "--interactive"][..],
+    ] {
+        let output = run(&project, &data, &home, args);
+        assert_eq!(output.status.code(), Some(2), "{args:?}");
+        assert!(output.stdout.is_empty(), "{args:?}");
+        assert!(
+            String::from_utf8(output.stderr)
+                .unwrap()
+                .contains("cannot be used with"),
+            "{args:?}"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn empty_interactive_update_restores_the_terminal_before_its_summary() {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    let data = temporary.path().join("data");
+    let home = temporary.path().join("home");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&home).unwrap();
+
+    let output = run_empty_interactive_update_in_pty(&project, &data, &home);
+    let restored = output.rfind("\u{1b}[?1049l").unwrap();
+    let summary = output.rfind("All installed Skills are current.").unwrap();
+
+    assert!(output.contains("\u{1b}[?25h"));
+    assert!(restored < summary, "{output:?}");
 }
 
 #[test]

--- a/crates/skilld-native/tests/update_ui.rs
+++ b/crates/skilld-native/tests/update_ui.rs
@@ -1,0 +1,543 @@
+use std::cell::RefCell;
+use std::num::NonZeroU64;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+
+use skilld_command::{CommandError, Host};
+use skilld_core::{
+    CommitAuthor, CommitHistory, CommitSha, CommitSummary as CoreCommitSummary, InstallScope,
+    InstallSource, SkillName, UpdateFailure, UpdatePlan, UpdatePlanItem, UpdatePlanV1,
+    UpdateRelation, UpdateRetryAfter,
+};
+use skilld_native::update_ui::{
+    ApplyResult, CommandInteractiveUpdateHost, CommitLoadResult, CommitPage, CommitSummary,
+    ComparisonId, Effect, InteractiveUpdateError, InteractiveUpdateHost, KeyInput, Message, Model,
+    Tab, TerminalLifecycle, UpdateCandidate, initial_effect, render_snapshot,
+    require_interactive_tty, resolve_effect, update, with_restored_terminal,
+};
+use unicode_width::UnicodeWidthStr;
+
+fn comparison(value: &str) -> ComparisonId {
+    ComparisonId::new(value)
+}
+
+fn candidate(name: &str, repository: &str, commits: u64) -> UpdateCandidate {
+    UpdateCandidate::new(
+        name,
+        repository,
+        "1111111111111111111111111111111111111111",
+        "2222222222222222222222222222222222222222",
+        commits,
+        comparison(&format!("{repository}:111..222")),
+    )
+}
+
+fn browsing_model(width: u16, height: u16) -> Model {
+    let transition = update(
+        Model::new(width, height),
+        Message::CandidatesLoaded(Ok(vec![
+            candidate("grill-me", "mattpocock/skills", 4),
+            candidate("review-skill", "skilld-dev/skilld", 2),
+            candidate("web-perf", "cloudflare/skills", 9),
+        ])),
+    );
+    assert!(transition.effects.is_empty());
+    transition.model
+}
+
+#[test]
+fn model_selects_outdated_skills_and_generates_visible_key_help() {
+    assert_eq!(initial_effect(), Effect::LoadCandidates);
+    let transition = update(browsing_model(100, 20), Message::Key(KeyInput::Down));
+    let transition = update(transition.model, Message::Key(KeyInput::Select));
+    let snapshot = render_snapshot(&transition.model, false);
+
+    assert!(transition.effects.is_empty());
+    assert!(snapshot.contains("> [ ] review-skill"));
+    assert!(snapshot.contains("2 selected"));
+    assert!(snapshot.contains("↑/↓ move"));
+    assert!(snapshot.contains("space select"));
+    assert!(snapshot.contains("tab commits"));
+    assert!(snapshot.contains("enter update"));
+}
+
+#[test]
+fn commits_load_on_first_open_and_retry_only_failed_comparisons() {
+    let model = browsing_model(100, 22);
+    let expected = model.comparison_ids();
+    let transition = update(model, Message::Key(KeyInput::NextTab));
+
+    assert_eq!(transition.model.tab(), Tab::Commits);
+    assert_eq!(transition.effects, [Effect::LoadCommits(expected.clone())]);
+
+    let failed = expected[0].clone();
+    let ready = expected[1].clone();
+    let transition = update(
+        transition.model,
+        Message::CommitsLoaded(vec![
+            CommitLoadResult::failed(
+                failed.clone(),
+                InteractiveUpdateError::new("GITHUB_RATE_LIMIT", "Try again after 10:42 UTC."),
+            ),
+            CommitLoadResult::ready(
+                ready.clone(),
+                CommitPage::new(
+                    ready,
+                    vec![CommitSummary::new(
+                        "3333333333333333333333333333333333333333",
+                        "fix: preserve accepted decisions\nignored body",
+                        "2026-08-20T03:14:00Z",
+                        "Harlan",
+                    )],
+                    1,
+                    false,
+                    "https://github.com/skilld-dev/skilld/compare/111...222",
+                ),
+            ),
+        ]),
+    );
+    let snapshot = render_snapshot(&transition.model, false);
+
+    assert!(snapshot.contains("GITHUB_RATE_LIMIT"));
+    assert!(snapshot.contains("3333333"));
+    assert!(snapshot.contains("fix: preserve accepted decisions"));
+    assert!(!snapshot.contains("ignored body"));
+
+    let transition = update(transition.model, Message::Key(KeyInput::Retry));
+    assert_eq!(transition.effects, [Effect::LoadCommits(vec![failed])]);
+}
+
+#[test]
+fn view_reflows_at_narrow_width_and_keeps_the_cursor_in_the_viewport() {
+    let mut model = browsing_model(44, 11);
+    for _ in 0..2 {
+        model = update(model, Message::Key(KeyInput::Down)).model;
+    }
+    model = update(
+        model,
+        Message::Resized {
+            width: 36,
+            height: 10,
+        },
+    )
+    .model;
+    let snapshot = render_snapshot(&model, false);
+
+    assert!(snapshot.contains("> [x] web-perf"));
+    assert!(!snapshot.contains("cloudflare/skills"));
+    assert!(
+        snapshot
+            .lines()
+            .all(|line| UnicodeWidthStr::width(line) <= 36)
+    );
+}
+
+#[test]
+fn view_preserves_unicode_width_and_removes_terminal_controls() {
+    let model = update(
+        Model::new(40, 12),
+        Message::CandidatesLoaded(Ok(vec![candidate(
+            "技能🙂 cafe\u{301}\u{1b}[31m",
+            "skilld-dev/skills",
+            3,
+        )])),
+    )
+    .model;
+    let plain = render_snapshot(&model, false);
+    let colored = render_snapshot(&model, true);
+
+    assert!(plain.contains("技能🙂 cafe\u{301}"), "{plain:?}");
+    assert!(!plain.contains('\u{1b}'));
+    assert_eq!(plain, colored);
+    assert!(plain.lines().all(|line| UnicodeWidthStr::width(line) <= 40));
+}
+
+#[test]
+fn commits_render_newest_first_and_name_visible_truncation() {
+    let mut model = update(
+        Model::new(100, 18),
+        Message::CandidatesLoaded(Ok(vec![candidate(
+            "review-skill",
+            "skilld-dev/skilld",
+            550,
+        )])),
+    )
+    .model;
+    let id = model.comparison_ids()[0].clone();
+    model = update(model, Message::Key(KeyInput::NextTab)).model;
+    model = update(
+        model,
+        Message::CommitsLoaded(vec![CommitLoadResult::ready(
+            id.clone(),
+            CommitPage::new(
+                id,
+                vec![
+                    CommitSummary::new(
+                        "3333333333333333333333333333333333333333",
+                        "older commit",
+                        "2026-08-19T03:14:00Z",
+                        "Harlan",
+                    ),
+                    CommitSummary::new(
+                        "4444444444444444444444444444444444444444",
+                        "newest commit",
+                        "2026-08-21T03:14:00Z",
+                        "Harlan",
+                    ),
+                ],
+                550,
+                true,
+                "https://github.com/skilld-dev/skilld/compare/111...222",
+            ),
+        )]),
+    )
+    .model;
+    let snapshot = render_snapshot(&model, false);
+
+    assert!(snapshot.find("newest commit").unwrap() < snapshot.find("older commit").unwrap());
+    assert!(snapshot.contains("Showing newest 2 of 550 commits."));
+}
+
+#[test]
+fn loading_failure_can_retry_or_cancel() {
+    let transition = update(
+        Model::new(80, 20),
+        Message::CandidatesLoaded(Err(InteractiveUpdateError::new(
+            "SERVICE_UNAVAILABLE",
+            "The update plan could not load.",
+        ))),
+    );
+    let snapshot = render_snapshot(&transition.model, false);
+
+    assert!(snapshot.contains("SERVICE_UNAVAILABLE"));
+    assert!(snapshot.contains("r retry"));
+
+    let retried = update(transition.model.clone(), Message::Key(KeyInput::Retry));
+    assert_eq!(retried.effects, [Effect::LoadCandidates]);
+
+    let cancelled = update(transition.model, Message::Key(KeyInput::Cancel));
+    assert_eq!(cancelled.effects.len(), 1);
+    assert!(cancelled.effects[0].exit_summary().unwrap().cancelled);
+}
+
+#[test]
+fn one_unavailable_skill_keeps_other_updates_selectable() {
+    let model = update(
+        Model::new(120, 16),
+        Message::CandidatesLoaded(Ok(vec![
+            candidate("grill-me", "mattpocock/skills", 4),
+            UpdateCandidate::unavailable(
+                "review-skill",
+                InteractiveUpdateError::new("RATE_LIMITED", "Try again in 60 seconds."),
+            ),
+        ])),
+    )
+    .model;
+    let snapshot = render_snapshot(&model, false);
+
+    assert!(snapshot.contains("[!] review-skill: RATE_LIMITED"));
+    assert!(snapshot.contains("1 selected. 1 unavailable"));
+    assert!(snapshot.contains("r retry"));
+
+    let retry = update(model.clone(), Message::Key(KeyInput::Retry));
+    assert_eq!(retry.effects, [Effect::LoadCandidates]);
+
+    let model = update(model, Message::Key(KeyInput::Down)).model;
+    let model = update(model, Message::Key(KeyInput::Select)).model;
+    let transition = update(model, Message::Key(KeyInput::Apply));
+
+    assert_eq!(
+        transition.effects,
+        [Effect::Apply(vec!["grill-me".to_owned()])]
+    );
+}
+
+#[test]
+fn applying_selected_skills_produces_a_static_summary() {
+    let model = update(browsing_model(80, 20), Message::Key(KeyInput::SelectAll)).model;
+    let transition = update(model, Message::Key(KeyInput::Apply));
+
+    assert_eq!(
+        transition.effects,
+        [Effect::Apply(vec![
+            "grill-me".to_owned(),
+            "review-skill".to_owned(),
+            "web-perf".to_owned(),
+        ])]
+    );
+    let cancelling = update(transition.model.clone(), Message::Key(KeyInput::Interrupt));
+    assert!(cancelling.effects[0].exit_summary().unwrap().cancelled);
+    assert!(render_snapshot(&cancelling.model, false).contains("Updating 3 Skills"));
+
+    let transition = update(
+        transition.model,
+        Message::Applied(vec![
+            ApplyResult::updated("grill-me"),
+            ApplyResult::updated("review-skill"),
+            ApplyResult::failed(
+                "web-perf",
+                InteractiveUpdateError::new("CHECK_BLOCKED", "Review the failed check."),
+            ),
+        ]),
+    );
+    let summary = transition.effects[0].exit_summary().unwrap();
+
+    assert_eq!(summary.updated, 2);
+    assert_eq!(summary.failed, 1);
+    assert_eq!(
+        summary.render(),
+        concat!(
+            "Updated 2 Skills.\n",
+            "Failed Skill web-perf: CHECK_BLOCKED: Review the failed check.\n"
+        )
+    );
+}
+
+#[derive(Clone)]
+struct RecordingTerminal {
+    events: Rc<RefCell<Vec<&'static str>>>,
+}
+
+impl TerminalLifecycle for RecordingTerminal {
+    fn enter(&mut self) -> Result<(), InteractiveUpdateError> {
+        self.events.borrow_mut().push("enter");
+        Ok(())
+    }
+
+    fn restore(&mut self) -> Result<(), InteractiveUpdateError> {
+        self.events.borrow_mut().push("restore");
+        Ok(())
+    }
+}
+
+#[test]
+fn terminal_restores_after_success_error_and_panic() {
+    for outcome in ["success", "error", "panic"] {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let terminal = RecordingTerminal {
+            events: events.clone(),
+        };
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            with_restored_terminal(terminal, || match outcome {
+                "success" => Ok(()),
+                "error" => Err(InteractiveUpdateError::new("TEST", "failed")),
+                _ => panic!("test panic"),
+            })
+        }));
+
+        if outcome == "panic" {
+            assert!(result.is_err());
+        } else {
+            assert!(result.is_ok());
+        }
+        assert_eq!(*events.borrow(), ["enter", "restore"]);
+    }
+}
+
+#[test]
+fn interactive_mode_needs_both_terminal_streams() {
+    assert!(require_interactive_tty(true, true).is_ok());
+    for streams in [(false, false), (false, true), (true, false)] {
+        assert_eq!(
+            require_interactive_tty(streams.0, streams.1)
+                .unwrap_err()
+                .code,
+            "INTERACTIVE_TTY_REQUIRED"
+        );
+    }
+}
+
+#[derive(Clone)]
+struct FixtureHost {
+    candidates: Vec<UpdateCandidate>,
+}
+
+impl InteractiveUpdateHost for FixtureHost {
+    fn load_candidates(&self) -> Result<Vec<UpdateCandidate>, InteractiveUpdateError> {
+        Ok(self.candidates.clone())
+    }
+
+    fn load_commits(&self, comparisons: &[ComparisonId]) -> Vec<CommitLoadResult> {
+        comparisons
+            .iter()
+            .cloned()
+            .map(|id| {
+                CommitLoadResult::ready(
+                    id.clone(),
+                    CommitPage::new(id, Vec::new(), 0, false, "https://github.com"),
+                )
+            })
+            .collect()
+    }
+
+    fn apply(&self, names: &[String]) -> Vec<ApplyResult> {
+        names.iter().map(ApplyResult::updated).collect()
+    }
+}
+
+#[test]
+fn fixture_host_resolves_model_effects_without_terminal_access() {
+    let host = FixtureHost {
+        candidates: vec![candidate("grill-me", "mattpocock/skills", 4)],
+    };
+
+    let loaded = resolve_effect(&host, Effect::LoadCandidates);
+    let transition = update(Model::new(80, 20), loaded);
+    let applied = resolve_effect(
+        &host,
+        update(transition.model, Message::Key(KeyInput::Apply)).effects[0].clone(),
+    );
+
+    assert!(
+        matches!(applied, Message::Applied(results) if results == [ApplyResult::updated("grill-me")])
+    );
+}
+
+struct PlanHost {
+    plan: UpdatePlanV1,
+    selections: Mutex<Vec<Vec<String>>>,
+    apply_error: Option<CommandError>,
+}
+
+impl Host for PlanHost {
+    fn list(&self, _scope: InstallScope) -> Result<Vec<String>, CommandError> {
+        unreachable!("list is outside this test")
+    }
+
+    fn install(
+        &self,
+        _source: InstallSource,
+        _scope: InstallScope,
+    ) -> Result<String, CommandError> {
+        unreachable!("install is outside this test")
+    }
+
+    fn update_check(&self, _name: Option<&str>) -> Result<UpdatePlanV1, CommandError> {
+        Ok(self.plan.clone())
+    }
+
+    fn update_selected(&self, names: &[String]) -> Result<Vec<String>, CommandError> {
+        self.selections.lock().unwrap().push(names.to_vec());
+        if let Some(error) = self.apply_error.clone() {
+            return Err(error);
+        }
+        Ok(names
+            .iter()
+            .map(|name| format!("Updated Skill {name}."))
+            .collect())
+    }
+}
+
+fn command_plan_host(apply_error: Option<CommandError>) -> Arc<PlanHost> {
+    let locked = CommitSha::parse("1".repeat(40)).unwrap();
+    let latest = CommitSha::parse("2".repeat(40)).unwrap();
+    let available = UpdatePlanItem::with_history(
+        SkillName::parse("grill-me").unwrap(),
+        UpdateRelation::Available {
+            locked_commit_sha: locked.clone(),
+            latest_commit_sha: latest.clone(),
+            ahead_by: NonZeroU64::new(1).unwrap(),
+        },
+        CommitHistory::compared(
+            vec![CoreCommitSummary {
+                sha: latest.clone(),
+                subject: "feat: sharpen design questions".to_owned(),
+                author: CommitAuthor {
+                    name: "Ada".to_owned(),
+                    login: Some("ada".to_owned()),
+                },
+                timestamp: "2026-08-21T00:00:00Z".to_owned(),
+                url: format!(
+                    "https://github.com/mattpocock/skills/commit/{}",
+                    latest.as_str()
+                ),
+            }],
+            1,
+            false,
+            format!(
+                "https://github.com/mattpocock/skills/compare/{}...{}",
+                locked.as_str(),
+                latest.as_str()
+            ),
+        )
+        .unwrap(),
+    );
+    let unavailable = UpdatePlanItem::new(
+        SkillName::parse("review-skill").unwrap(),
+        UpdateRelation::Unavailable {
+            locked_commit_sha: locked.clone(),
+            latest_commit: skilld_core::UpdateLatestCommit::Known { commit_sha: latest },
+            failure: UpdateFailure::rate_limited(
+                "GitHub rate limited the update check.",
+                UpdateRetryAfter::Seconds { seconds: 60 },
+            ),
+        },
+    );
+    let current = UpdatePlanItem::new(
+        SkillName::parse("current-skill").unwrap(),
+        UpdateRelation::Current { commit_sha: locked },
+    );
+    Arc::new(PlanHost {
+        plan: UpdatePlanV1::new(UpdatePlan::new(vec![available, unavailable, current]).unwrap()),
+        selections: Mutex::new(Vec::new()),
+        apply_error,
+    })
+}
+
+#[test]
+fn command_host_maps_update_plans_commits_and_exact_selection() {
+    let host = command_plan_host(None);
+    let interactive = CommandInteractiveUpdateHost::new(host.clone());
+    let candidates = interactive.load_candidates().unwrap();
+    let mut model = update(
+        Model::new(100, 18),
+        Message::CandidatesLoaded(Ok(candidates)),
+    )
+    .model;
+    let outdated = render_snapshot(&model, false);
+
+    assert!(outdated.contains("grill-me"));
+    assert!(outdated.contains("review-skill: RATE_LIMITED"));
+    assert!(outdated.contains("Try again in 60 seconds."));
+    assert!(!outdated.contains("current-skill"));
+
+    let ids = model.comparison_ids();
+    model = update(model, Message::Key(KeyInput::NextTab)).model;
+    model = update(
+        model,
+        Message::CommitsLoaded(interactive.load_commits(&ids)),
+    )
+    .model;
+    assert!(render_snapshot(&model, false).contains("feat: sharpen design questions"));
+
+    assert_eq!(
+        interactive.apply(&["grill-me".to_owned()]),
+        [ApplyResult::updated("grill-me")]
+    );
+    assert_eq!(*host.selections.lock().unwrap(), [["grill-me".to_owned()]]);
+}
+
+#[test]
+fn command_host_reports_one_atomic_failure_for_every_selected_skill() {
+    let host = command_plan_host(Some(CommandError::operation(
+        "CHECK_BLOCKED",
+        "A required check failed.",
+    )));
+    let interactive = CommandInteractiveUpdateHost::new(host.clone());
+    let names = ["grill-me".to_owned(), "review-skill".to_owned()];
+
+    let results = interactive.apply(&names);
+
+    assert_eq!(host.selections.lock().unwrap().len(), 1);
+    assert_eq!(
+        results,
+        names
+            .iter()
+            .map(|name| ApplyResult::failed(
+                name,
+                InteractiveUpdateError::new("CHECK_BLOCKED", "A required check failed.")
+            ))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
`skilld update --interactive` now opens a terminal UI.

It lists outdated Skills, lets you inspect their repository commits, and updates the selected set atomically.

The command requires terminal input and output. It cannot be combined with JSON, plain, check, or named-Skill modes.

Stacked on #108.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).