### PR TITLE
ci: run the full suite only on main and releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,8 @@ jobs:
             tar -xf "$archive" -C packages
           done < <(find native-artifacts -type f -name '*.tar' | sort)
       - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - run: pnpm test:run
       - id: npm_tag
         name: Resolve shared npm tag
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - '**/README.md'
       - 'docs/**'
@@ -31,18 +33,28 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build
-      - run: pnpm test:run
-      - run: pnpm --filter skilld-protocol check:v1
-      - run: pnpm --filter skilld-protocol publint
-      - run: pnpm --filter skilld-protocol attw
-      - run: pnpm --filter skilld-harness publint
-      - run: pnpm --filter skilld-harness attw
+      - run: pnpm test:js
+      - name: Rust tests
+        if: github.event_name == 'push'
+        run: cargo test --workspace
+      - name: Protocol v1 drift check
+        if: github.event_name == 'push'
+        run: pnpm --filter skilld-protocol check:v1
+      - name: Package health checks
+        if: github.event_name == 'push'
+        run: |
+          pnpm --filter skilld-protocol publint
+          pnpm --filter skilld-protocol attw
+          pnpm --filter skilld-harness publint
+          pnpm --filter skilld-harness attw
       - name: Pack root CLI
+        if: github.event_name == 'push'
         run: |
           mkdir -p artifacts
           pnpm pack --pack-destination artifacts
 
   native-host:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "lint:fix": "eslint . --fix && cargo fmt --all",
     "typecheck": "pnpm --filter skilld-protocol typecheck && pnpm --filter skilld-harness typecheck",
     "test": "vitest",
-    "test:run": "vitest run tests/loader && pnpm --filter skilld-protocol test:run && pnpm --filter skilld-harness test:run && cargo test --workspace",
+    "test:js": "vitest run tests/loader && pnpm --filter skilld-protocol test:run && pnpm --filter skilld-harness test:run",
+    "test:run": "pnpm test:js && cargo test --workspace",
     "prepack": "pnpm test:loader",
     "test:loader": "vitest run --config vitest.config.mjs"
   },


### PR DESCRIPTION
## Why
PR checks were slow. Every PR ran the full matrix even for small changes.

## What
- PRs run lint, typecheck, build, and JS tests only
- cargo test, protocol v1 drift check, publint, attw, pack, and the native matrix run on push to `main` only
- Feature branch pushes no longer trigger CI, so each PR runs once
- Releases run `pnpm build` and the full `pnpm test:run` before publishing

## Tradeoff
Rust breakage on Windows or macOS now surfaces on `main` or at release time, in the PR.